### PR TITLE
Add middleware to define the user-agent for http requests

### DIFF
--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -14,6 +14,7 @@
     * [getErrorByCode](/docs/sdk/api/getErrorByCode.md)
     * [createQueueMiddleware](/docs/sdk/api/createQueueMiddleware.md)
     * [createLoggerMiddleware](/docs/sdk/api/createLoggerMiddleware.md)
+    * [createUserAgentMiddleware](/docs/sdk/api/createUserAgentMiddleware.md)
     * [createRequestBuilder](/docs/sdk/api/createRequestBuilder.md)
     * [createSyncCategories](/docs/sdk/api/createSyncCategories.md)
     * [createSyncCustomers](/docs/sdk/api/createSyncCustomers.md)

--- a/docs/sdk/api/README.md
+++ b/docs/sdk/api/README.md
@@ -26,6 +26,10 @@ This section documents the SDK packages APIs.
 
 * [createLoggerMiddleware(options)](createLoggerMiddleware.md)
 
+### `sdk-middleware-user-agent`
+
+* [createUserAgentMiddleware(options)](createUserAgentMiddleware.md)
+
 ### `api-request-builder`
 
 * [createRequestBuilder(customServices)](createRequestBuilder.md)

--- a/docs/sdk/api/createUserAgentMiddleware.md
+++ b/docs/sdk/api/createUserAgentMiddleware.md
@@ -1,0 +1,34 @@
+# `createUserAgentMiddleware(options)`
+
+> From package [@commercetools/sdk-middleware-user-agent](/docs/sdk/api/README.md#sdk-middleware-user-agent).
+
+Creates a [middleware](/docs/sdk/Glossary.md#middleware) to append the `User-Agent` HTTP header to the request.
+
+#### Named arguments (options)
+
+1. `name` *(String)*: the name of the library / package / application using the SDK (optional)
+2. `version` *(String)*: the version of the library / package / application using the SDK (optional)
+3. `url` *(String)*: the url of the library / package / application using the SDK (optional)
+
+
+#### Usage example
+
+```js
+import { createClient } from '@commercetools/sdk-client'
+import { createUserAgentMiddleware } from '@commercetools/sdk-middleware-user-agent'
+import { createAuthMiddleware } from '@commercetools/sdk-middleware-auth'
+import { createHttpMiddleware } from '@commercetools/sdk-middleware-http'
+
+const userAgentMiddleware = createUserAgentMiddleware(),
+const client = createClient({
+  middlewares: [
+    createAuthMiddleware({...}),
+    createUserAgentMiddleware({
+      name: 'my-awesome-library',
+      version: '1.0.0',
+      url: 'https://github.com/my-company/my-awesome-library'
+    }),
+    createHttpMiddleware({...}),
+  ],
+})
+```

--- a/integration-tests/package.json
+++ b/integration-tests/package.json
@@ -8,6 +8,7 @@
     "@commercetools/sdk-middleware-auth": "*",
     "@commercetools/sdk-middleware-http": "*",
     "@commercetools/sdk-middleware-queue": "*",
+    "@commercetools/sdk-middleware-user-agent": "*",
     "lodash.omit": "4.5.0"
   }
 }

--- a/integration-tests/sdk/channels.it.js
+++ b/integration-tests/sdk/channels.it.js
@@ -9,7 +9,11 @@ import {
 import {
   createQueueMiddleware,
 } from '@commercetools/sdk-middleware-queue'
+import {
+  createUserAgentMiddleware,
+} from '@commercetools/sdk-middleware-user-agent'
 import omit from 'lodash.omit'
+import pkg from '../package.json'
 import loadCredentials from '../load-credentials'
 
 const {
@@ -36,11 +40,17 @@ const httpMiddleware = createHttpMiddleware({
 const queueMiddleware = createQueueMiddleware({
   concurrency: 5,
 })
+const userAgentMiddleware = createUserAgentMiddleware({
+  name: pkg.name,
+  version: pkg.version,
+  url: 'https://github.com/commercetools/nodejs',
+})
 const client = createClient({
   middlewares: [
     authMiddleware,
-    httpMiddleware,
     queueMiddleware,
+    userAgentMiddleware,
+    httpMiddleware,
   ],
 })
 

--- a/packages/commercetools-sdk-middleware-user-agent/README.md
+++ b/packages/commercetools-sdk-middleware-user-agent/README.md
@@ -1,0 +1,11 @@
+# commercetools-sdk-middlware-user-agent
+
+Middleware for setting the User-Agent on the HTTP request for usage with `@commercetools/sdk-client`
+
+https://commercetools.github.io/nodejs/docs/sdk/api/#sdk-middleware-user-agent
+
+## Install
+
+```bash
+npm install --save @commercetools/sdk-middleware-user-agent
+```

--- a/packages/commercetools-sdk-middleware-user-agent/package.json
+++ b/packages/commercetools-sdk-middleware-user-agent/package.json
@@ -1,0 +1,33 @@
+{
+  "private": false,
+  "publishConfig": {
+    "access": "public"
+  },
+  "name": "@commercetools/sdk-middleware-user-agent",
+  "version": "0.1.0",
+  "description": "Middleware for setting the User-Agent on the HTTP request, to use with @commercetools/sdk-client",
+  "keywords": [
+    "commercetools",
+    "sdk",
+    "middleware",
+    "user-agent"
+  ],
+  "homepage": "https://commercetools.github.io/nodejs/",
+  "bugs": "https://github.com/commercetools/nodejs/issues",
+  "license": "MIT",
+  "author": "Nicola Molinari <nicola.molinari@commercetools.com> (https://github.com/emmenko)",
+  "main": "lib/index.js",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/commercetools/nodejs.git"
+  },
+  "files": [
+    "dist",
+    "lib"
+  ],
+  "scripts": {
+    "dist": "npm run build:umd && npm run build:umd:min",
+    "build:umd": "cross-env cross-env NODE_ENV=development webpack --config ../../webpack.config.js --output-library CommercetoolsSdkMiddlewareUserAgent --output-library-target umd src/index.js dist/commercetools-sdk-middleware-user-agent.js",
+    "build:umd:min": "cross-env cross-env NODE_ENV=production webpack --config ../../webpack.config.js --output-library CommercetoolsSdkMiddlewareUserAgent --output-library-target umd src/index.js dist/commercetools-sdk-middleware-user-agent.min.js"
+  }
+}

--- a/packages/commercetools-sdk-middleware-user-agent/src/create-user-agent.js
+++ b/packages/commercetools-sdk-middleware-user-agent/src/create-user-agent.js
@@ -1,0 +1,40 @@
+/* @flow */
+import type {
+  UserAgentMiddlewareOptions,
+} from 'types/sdk'
+/* global window */
+
+const sdkInfo = 'commercetools-node-sdk' // version is not necessary
+// TODO: should this be configurable?
+const helpdesk = 'helpdesk@commercetools.com'
+
+export default function createUserAgent (
+  options: UserAgentMiddlewareOptions = {},
+  windowObject: Object = window,
+): string {
+  let libraryInfo
+  if (options.name && !options.version)
+    libraryInfo = options.name
+  else if (options.name && options.version)
+    libraryInfo = `${options.name}/${options.version}`
+  const libraryUrl = options.url
+
+  const solutionContactInfo = libraryUrl
+    ? `+${libraryUrl}; +${helpdesk}`
+    : `+${helpdesk}`
+  const solutionInfo = libraryInfo
+    ? `${libraryInfo} (${solutionContactInfo})`
+    : `(${solutionContactInfo})`
+  const systemInfo = getSystemInfo(windowObject)
+
+  return `${sdkInfo} ${systemInfo} ${solutionInfo}`
+}
+
+function getSystemInfo (windowObject: Object): string {
+  if (windowObject && windowObject.navigator)
+    return windowObject.navigator.userAgent
+
+  const nodeVersion = process.version.slice(1)
+  const platformInfo = `(${process.platform}; ${process.arch})`
+  return `Node.js/${nodeVersion} ${platformInfo}`
+}

--- a/packages/commercetools-sdk-middleware-user-agent/src/index.js
+++ b/packages/commercetools-sdk-middleware-user-agent/src/index.js
@@ -1,0 +1,2 @@
+// eslint-disable-next-line import/prefer-default-export
+export { default as createUserAgentMiddleware } from './user-agent'

--- a/packages/commercetools-sdk-middleware-user-agent/src/user-agent.js
+++ b/packages/commercetools-sdk-middleware-user-agent/src/user-agent.js
@@ -1,0 +1,25 @@
+/* @flow */
+import type {
+  Middleware,
+  ClientRequest,
+  ClientResponse,
+  UserAgentMiddlewareOptions,
+} from 'types/sdk'
+import createUserAgent from './create-user-agent'
+
+export default function createUserAgentMiddleware (
+  options: UserAgentMiddlewareOptions,
+): Middleware {
+  const userAgent = createUserAgent(options)
+
+  return next => (request: ClientRequest, response: ClientResponse) => {
+    const requestWithUserAgent = {
+      ...request,
+      headers: {
+        ...request.headers,
+        'User-Agent': userAgent,
+      },
+    }
+    next(requestWithUserAgent, response)
+  }
+}

--- a/packages/commercetools-sdk-middleware-user-agent/test/create-user-agent.spec.js
+++ b/packages/commercetools-sdk-middleware-user-agent/test/create-user-agent.spec.js
@@ -1,0 +1,99 @@
+import createUserAgent from '../src/create-user-agent'
+
+describe('for browser', () => {
+  const userAgent = createUserAgent({
+    name: 'foo',
+    version: '1.0.0',
+    url: 'http://foo.com',
+  })
+
+  it('has sdk info', () => {
+    expect(userAgent).toMatch('commercetools-node-sdk')
+  })
+  it('has browser info', () => {
+    // because we use jsdom
+    expect(userAgent).toMatch('Node.js')
+  })
+  it('has browser version', () => {
+    // because we use jsdom
+    expect(userAgent).toMatch(process.version.slice(1))
+  })
+  it('has library info', () => {
+    expect(userAgent).toMatch('foo/1.0.0')
+  })
+  it('has library url', () => {
+    expect(userAgent).toMatch('http://foo.com')
+  })
+  it('has contact info', () => {
+    expect(userAgent).toMatch('helpdesk@commercetools.com')
+  })
+})
+
+describe('for node', () => {
+  const userAgent = createUserAgent(
+    {
+      name: 'foo',
+      version: '1.0.0',
+      url: 'http://foo.com',
+    },
+    { /* to prevent using the window object */ },
+  )
+
+  it('has sdk info', () => {
+    expect(userAgent).toMatch('commercetools-node-sdk')
+  })
+  it('has node info', () => {
+    expect(userAgent).toMatch(`Node.js/${process.version.slice(1)}`)
+  })
+  it('has library info', () => {
+    expect(userAgent).toMatch('foo/1.0.0')
+  })
+  it('has library url', () => {
+    expect(userAgent).toMatch('http://foo.com')
+  })
+  it('has contact info', () => {
+    expect(userAgent).toMatch('helpdesk@commercetools.com')
+  })
+})
+
+describe('optional information', () => {
+  it('create user agent without any information', () => {
+    const userAgent = createUserAgent(
+      {},
+      { /* to prevent using the window object */ },
+    )
+    // eslint-disable-next-line max-len
+    expect(userAgent).toBe(`commercetools-node-sdk Node.js/${process.version.slice(1)} (${process.platform}; ${process.arch}) (+helpdesk@commercetools.com)`)
+  })
+  it('create user agent with only library name (missing version)', () => {
+    const userAgent = createUserAgent(
+      {
+        name: 'foo',
+      },
+      { /* to prevent using the window object */ },
+    )
+    // eslint-disable-next-line max-len
+    expect(userAgent).toBe(`commercetools-node-sdk Node.js/${process.version.slice(1)} (${process.platform}; ${process.arch}) foo (+helpdesk@commercetools.com)`)
+  })
+  it('create user agent with library name and version', () => {
+    const userAgent = createUserAgent(
+      {
+        name: 'foo',
+        version: '1.0.0',
+      },
+      { /* to prevent using the window object */ },
+    )
+    // eslint-disable-next-line max-len
+    expect(userAgent).toBe(`commercetools-node-sdk Node.js/${process.version.slice(1)} (${process.platform}; ${process.arch}) foo/1.0.0 (+helpdesk@commercetools.com)`)
+  })
+  it('create user agent with solution url', () => {
+    const userAgent = createUserAgent(
+      {
+        url: 'http://foo.com',
+      },
+      { /* to prevent using the window object */ },
+    )
+    // eslint-disable-next-line max-len
+    expect(userAgent).toBe(`commercetools-node-sdk Node.js/${process.version.slice(1)} (${process.platform}; ${process.arch}) (+http://foo.com; +helpdesk@commercetools.com)`)
+  })
+})

--- a/packages/commercetools-sdk-middleware-user-agent/test/user-agent.spec.js
+++ b/packages/commercetools-sdk-middleware-user-agent/test/user-agent.spec.js
@@ -1,0 +1,46 @@
+import {
+  createUserAgentMiddleware,
+} from '../src'
+
+describe('UserAgent', () => {
+  const userAgentMiddleware = createUserAgentMiddleware({
+    name: 'foo',
+    version: '1.0.0',
+    url: 'http://foo.com',
+  })
+  const request = {
+    headers: {
+      Authorization: '123',
+    },
+  }
+
+  const next = (req, res) => {
+    it('has the same given header', () => {
+      expect(req.headers['Authorization']).toBe('123')
+    })
+    it('has sdk info', () => {
+      expect(req.headers['User-Agent']).toMatch('commercetools-node-sdk')
+    })
+    it('has browser info', () => {
+      // because we use jsdom
+      expect(req.headers['User-Agent']).toMatch('Node.js')
+    })
+    it('has browser version', () => {
+      // because we use jsdom
+      expect(req.headers['User-Agent']).toMatch(process.version.slice(1))
+    })
+    it('has library info', () => {
+      expect(req.headers['User-Agent']).toMatch('foo/1.0.0')
+    })
+    it('has library url', () => {
+      expect(req.headers['User-Agent']).toMatch('http://foo.com')
+    })
+    it('has contact info', () => {
+      expect(req.headers['User-Agent']).toMatch('helpdesk@commercetools.com')
+    })
+    it('do not change response object', () => {
+      expect(res).toEqual({})
+    })
+  }
+  userAgentMiddleware(next)(request, {})
+})

--- a/types/sdk.js
+++ b/types/sdk.js
@@ -61,6 +61,11 @@ export type HttpMiddlewareOptions = {
 export type QueueMiddlewareOptions = {
   concurrency?: number;
 }
+export type UserAgentMiddlewareOptions = {
+  name?: string;
+  version?: string;
+  url?: string;
+}
 
 
 /* API Request Builder */


### PR DESCRIPTION
#### Summary
Add a middleware to properly provide `User-Agent` for HTTP requests, following spec.

```js
import { createClient } from '@commercetools/sdk-client'
import { createUserAgentMiddleware } from '@commercetools/sdk-middleware-user-agent'
import { createAuthMiddleware } from '@commercetools/sdk-middleware-auth'
import { createHttpMiddleware } from '@commercetools/sdk-middleware-http'

const userAgentMiddleware = createUserAgentMiddleware(),
const client = createClient({
  middlewares: [
    createAuthMiddleware({...}),
    createUserAgentMiddleware({
      name: 'my-awesome-library',
      version: '1.0.0',
      url: 'https://github.com/my-company/my-awesome-library'
    }),
    createHttpMiddleware({...}),
  ],
})

// The User-Agent will be for example:
// commercetools-node-sdk Node.js/6.9.0 (darwin; x64) my-awesome-library/1.0.0 (+https://github.com/my-company/my-awesome-library; +helpdesk@commercetools.com)
```
