### PR TITLE
feat(sdk-client): implement process function to iterate through pages

### DIFF
--- a/docs/sdk/api/createClient.md
+++ b/docs/sdk/api/createClient.md
@@ -8,6 +8,13 @@ Creates a [client](/docs/sdk/Glossary.md#client) instance.
 
 1. `middlewares` *(Array)*: A list of [middlewares](/docs/sdk/Middlewares.md) to be used within this client. **The order of the middlewares is really important!** (e.g. it does not make sense to put the `http` middleware *before* the `auth` middleware).
 
+### Client API
+
+#### `execute(request)`
+Returns a `Promise` which gets resolved after all the provided middlewares have done their job with the given [request / response](/docs/sdk/Middlewares.md). _This is the primary method to use_.
+
+- `request` *(Object)*: A [request object](/docs/sdk/Glossary.md#clientrequest)
+
 #### Usage example
 
 ```js
@@ -28,6 +35,70 @@ const request = {
 }
 
 client.execute(request)
+.then(result => ...)
+.catch(error => ...)
+```
+
+
+#### `process(request, processFn, options)`
+This function should be used to _iterate_ through all the pages of a HTTP Rest API endpoint. Given the [request object](/docs/sdk/Glossary.md#clientrequest), the first page result of the request query will be passed to the `processFn`. This function does whatever it needs to do with the data and returns itself a promise which will trigger fetching a new page. This goes on and on until all available pages of the request query have being fetched and processed.
+Returns a `Promise` with the accumulated result of each `processFn` calls.
+
+- `request` *(Object)*: A [request object](/docs/sdk/Glossary.md#clientrequest)
+- `processFn` *(Function)*: A function that gets called on each API page iteration. The function gets as an argument the response of the API request and should return a `Promise` which will trigger the next iteration.
+- `options` *(Object)*
+  - `accumulate` *(Boolean)*: (default `true`) a flag to indicate whether all the results of the iterations should be accumulated. This is useful if you want to e.g. fetch all the entities of an API endpoint and do something with it at the end. _Be careful that this might lead to memory problems if the fetched data gets too big. If it's not necessary to have all the data when the process function resolves, it's recommended to disable this option_.
+
+#### Usage example
+
+```js
+import { createClient } from '@commercetools/sdk-client'
+import { createHttpMiddleware } from '@commercetools/sdk-middleware-http'
+import { createRequestBuilder } from '@commercetools/api-request-builder'
+
+const requestBuilder = createRequestBuilder()
+const productProjectionsService = requestBuilder.productProjections
+const productsService = requestBuilder.products
+
+const client = createClient({
+  middlewares: [
+    createHttpMiddleware(),
+  ],
+})
+const uri = productProjectionsService
+  .where('masterData(published = "false")')
+  .where('masterData(hasStagedChanges = "true")')
+  .build({ projectKey: 'foo' })
+
+const request = {
+  uri,
+  method: 'GET',
+  headers: {
+    Authorization: 'Bearer xxx',
+  },
+}
+
+// 1. We want to publish all products that are not published yet
+client.process(
+  request,
+  (payload) => {
+    const results = payload.body.results
+    return Promise.all(
+      results.map(product =>
+        client.execute({
+          uri: productsService.byId(product.id).build({ projectKey: 'foo' }),
+          method: 'POST',
+          body: JSON.stringify({
+            version: product.version,
+            actions: [{ action: 'publish' }]
+          }),
+          headers: request.headers,
+        })
+      ),
+    )
+  },
+  { accumulate: false },
+)
 .then(result => ...)
 .catch(error => ...)
 ```

--- a/integration-tests/sdk/channels.it.js
+++ b/integration-tests/sdk/channels.it.js
@@ -148,6 +148,29 @@ describe('Channels', () => {
       expect(response.statusCode).toBe(200)
     })
   })
+
+  it('process', () => {
+    const processRequest = {
+      uri: service.perPage(3).build({ projectKey }),
+      method: 'GET',
+      headers: {
+        Accept: 'application/json',
+        'Content-Type': 'application/json',
+      },
+    }
+
+    let resultCount = 0
+    return client.process(
+      processRequest,
+      (payload) => {
+        resultCount += payload.body.results.length
+        return Promise.resolve(payload.body.results.map(c => c.id))
+      },
+    )
+    .then((response) => {
+      expect(response).toHaveLength(resultCount)
+    })
+  })
 })
 
 let uniqueIdCounter = 0

--- a/packages/commercetools-sdk-client/src/client.js
+++ b/packages/commercetools-sdk-client/src/client.js
@@ -1,12 +1,15 @@
 /* @flow */
-
 import type {
   Client,
   ClientOptions,
   ClientRequest,
   ClientResponse,
   ClientResult,
+  ProcessFn,
+  ProcessOptions,
+  SuccessResult,
 } from 'types/sdk'
+import qs from 'querystring'
 
 export default function createClient (options: ClientOptions = {}): Client {
   const {
@@ -20,25 +23,98 @@ export default function createClient (options: ClientOptions = {}): Client {
     throw new Error('You need to provide at least one middleware')
 
   return {
+    /*
+      Given a request object,
+    */
     execute (request: ClientRequest): Promise<ClientResult> {
       // TODO: validate request shape
       return new Promise((resolve, reject) => {
-        const response = {
-          resolve,
-          reject,
-        }
         const resolver = (rq: ClientRequest, rs: ClientResponse) => {
+          // Note: pick the promise `resolve` and `reject` function from
+          // the response object. This is not necessary the same function
+          // given from the `new Promise` constructor, as middlewares could
+          // override those functions for custom behaviours.
           if (rs.error)
-            reject(rs.error)
+            rs.reject(rs.error)
           else
-            resolve({
-              body: rs.body,
+            rs.resolve({
+              body: rs.body || {},
               statusCode: rs.statusCode,
             })
         }
 
         const dispatch = compose(...middlewares)(resolver)
-        dispatch(request, response)
+        dispatch(
+          request,
+          // Initial response shape
+          {
+            resolve,
+            reject,
+            body: undefined,
+            error: undefined,
+          },
+        )
+      })
+    },
+
+    process (
+      request: ClientRequest,
+      fn: ProcessFn,
+      opt: ProcessOptions = { accumulate: true },
+    ): Promise<Array<Object>> {
+      // Validate arguments
+      // - request must be a GET request
+      // - fn must be a function
+
+      return new Promise((resolve, reject) => {
+        const [path, queryString] = request.uri.split('?')
+        const query = {
+          // defaults
+          limit: 20,
+          // merge given query params
+          ...qs.parse(queryString),
+        }
+        const originalQueryString = qs.stringify(query)
+
+        const processPage = (lastId?: string, acc?: Array<any> = []) => {
+          const enhancedQuery = {
+            sort: 'id asc',
+            withTotal: false,
+            ...(lastId ? { where: `id > "${lastId}"` } : {}),
+          }
+          const enhancedQueryString = qs.stringify(enhancedQuery)
+          const enhancedRequest = {
+            ...request,
+            uri: `${path}?${enhancedQueryString}&${originalQueryString}`,
+          }
+
+          this.execute(enhancedRequest)
+          .then((payload: SuccessResult) => {
+            fn(payload)
+            .then((result: any) => {
+              const resultsLength = payload.body.results.length
+              let accumulated
+              if (opt.accumulate)
+                accumulated = acc.concat(result || [])
+
+              // If we get less results in a page then the limit set it means
+              // that there are no more pages and that we can finally resolve
+              // the promise.
+              if (resultsLength < query.limit) {
+                resolve(accumulated || [])
+                return
+              }
+
+              const last = payload.body.results[resultsLength - 1]
+              const newLastId = last && last.id
+              processPage(newLastId, accumulated)
+            })
+          })
+          .catch(reject)
+        }
+
+        // Start iterating through pages
+        processPage()
       })
     },
   }

--- a/packages/commercetools-sdk-client/test/client.spec.js
+++ b/packages/commercetools-sdk-client/test/client.spec.js
@@ -1,3 +1,4 @@
+import qs from 'querystring'
 import {
   createClient,
 } from '../src'
@@ -86,6 +87,205 @@ describe('execute', () => {
     })
 
     return client.execute(request)
+    .then(() =>
+      Promise.reject(
+        'This function should never be called, the response was rejected',
+      ),
+    )
+    .catch((error) => {
+      expect(error.message).toEqual('Invalid password')
+      return Promise.resolve()
+    })
+  })
+
+  describe('ensure correct functions are used to resolve the promise', () => {
+    it('resolve', () => {
+      const customResolveSpy = jest.fn()
+      const client = createClient({
+        middlewares: [
+          next => (req, res) => {
+            const responseWithCustomResolver = {
+              resolve () {
+                customResolveSpy()
+                res.resolve()
+              },
+            }
+            next(req, responseWithCustomResolver)
+          },
+        ],
+      })
+
+      return client.execute(request)
+      .then(() => {
+        expect(customResolveSpy).toHaveBeenCalled()
+      })
+    })
+
+    it('reject', () => {
+      const customRejectSpy = jest.fn()
+      const client = createClient({
+        middlewares: [
+          next => (req, res) => {
+            const responseWithCustomResolver = {
+              reject () {
+                customRejectSpy()
+                res.reject()
+              },
+              error: new Error('Oops'),
+            }
+            next(req, responseWithCustomResolver)
+          },
+        ],
+      })
+
+      return client.execute(request)
+      .catch(() => {
+        expect(customRejectSpy).toHaveBeenCalled()
+      })
+    })
+  })
+})
+
+describe('process', () => {
+  const request = {
+    uri: '/test/products',
+    method: 'GET',
+    body: null,
+    headers: {},
+  }
+
+  it('process and resolve paginating 3 times', () => {
+    const createPayloadResult = tot => ({
+      results: Array.from(
+        Array(tot),
+        (val, index) => ({ id: String(index + 1) }),
+      ),
+    })
+    let reqCount = 0
+    const reqStubs = {
+      0: {
+        body: createPayloadResult(20),
+        query: {
+          sort: 'id asc',
+          withTotal: 'false',
+          limit: '20',
+        },
+      },
+      1: {
+        body: createPayloadResult(20),
+        query: {
+          sort: 'id asc',
+          withTotal: 'false',
+          where: 'id > "20"',
+          limit: '20',
+        },
+      },
+      2: {
+        body: createPayloadResult(10),
+        query: {
+          sort: 'id asc',
+          withTotal: 'false',
+          where: 'id > "20"',
+          limit: '20',
+        },
+      },
+    }
+
+    const client = createClient({
+      middlewares: [
+        next => (req, res) => {
+          const body = reqStubs[reqCount].body
+          expect(qs.parse(req.uri.split('?')[1]))
+            .toEqual(reqStubs[reqCount].query)
+
+          reqCount += 1
+          next(req, { ...res, body, statusCode: 200 })
+        },
+      ],
+    })
+
+    return client.process(
+      request,
+      () => Promise.resolve('OK'),
+    )
+    .then((response) => {
+      expect(response).toEqual([
+        'OK',
+        'OK',
+        'OK',
+      ])
+    })
+  })
+
+  it('process and resolve pagination by preserving original query', () => {
+    const createPayloadResult = tot => ({
+      results: Array.from(
+        Array(tot),
+        (val, index) => ({ id: String(index + 1) }),
+      ),
+    })
+    let reqCount = 0
+    const reqStubs = {
+      0: {
+        body: createPayloadResult(5),
+        query: {
+          sort: ['id asc', 'createdAt desc'],
+          withTotal: 'false',
+          where: 'name (en = "Foo")',
+          limit: '5',
+        },
+      },
+      1: {
+        body: createPayloadResult(2),
+        query: {
+          sort: ['id asc', 'createdAt desc'],
+          withTotal: 'false',
+          where: ['id > "5"', 'name (en = "Foo")'],
+          limit: '5',
+        },
+      },
+    }
+
+    const client = createClient({
+      middlewares: [
+        next => (req, res) => {
+          const body = reqStubs[reqCount].body
+          expect(qs.parse(req.uri.split('?')[1]))
+            .toEqual(reqStubs[reqCount].query)
+
+          reqCount += 1
+          next(req, { ...res, body, statusCode: 200 })
+        },
+      ],
+    })
+
+    return client.process(
+      {
+        ...request,
+        uri: `${request.uri}?${qs.stringify({
+          sort: 'createdAt desc',
+          where: 'name (en = "Foo")',
+          limit: 5,
+        })}`,
+      },
+      () => Promise.resolve('OK'),
+    )
+  })
+
+  it('process and reject a request', () => {
+    const client = createClient({
+      middlewares: [
+        next => (req, res) => {
+          const error = new Error('Invalid password')
+          next(req, { ...res, error, statusCode: 400 })
+        },
+      ],
+    })
+
+    return client.process(
+      request,
+      () => Promise.resolve('OK'),
+    )
     .then(() =>
       Promise.reject(
         'This function should never be called, the response was rejected',

--- a/types/sdk.js
+++ b/types/sdk.js
@@ -36,14 +36,18 @@ export type Middleware = (next: Dispatch) => Dispatch;
 export type ClientOptions = {
   middlewares?: Array<Middleware>;
 }
-export type ClientResult = {
-  body: ?Object;
+export type SuccessResult = {
+  body: Object;
   statusCode: number;
-} | HttpErrorType
+}
+export type ClientResult = SuccessResult | HttpErrorType
 export type Client = {
   execute: (request: ClientRequest) => Promise<ClientResult>;
 }
-
+export type ProcessFn = (result: SuccessResult) => Promise<any>;
+export type ProcessOptions = {
+  accumulate?: boolean;
+}
 
 /* Middlewares */
 export type AuthMiddlewareOptions = {


### PR DESCRIPTION
#### Summary
Implements the `process` function to be able to iterate through all the pages of a HTTP endpoint.

```js
import { createClient } from '@commercetools/sdk-client'
import { createHttpMiddleware } from '@commercetools/sdk-middleware-http'
import { createRequestBuilder } from '@commercetools/api-request-builder'

const requestBuilder = createRequestBuilder()
const productProjectionsService = requestBuilder.productProjections
const productsService = requestBuilder.products

const client = createClient({
  middlewares: [
    createHttpMiddleware(),
  ],
})
const uri = productProjectionsService
  .where('masterData(published = "false")')
  .where('masterData(hasStagedChanges = "true")')
  .build({ projectKey: 'foo' })

const request = {
  uri,
  method: 'GET',
  headers: {
    Authorization: 'Bearer xxx',
  },
}

// 1. We want to publish all products that are not published yet
client.process(
  request,
  (payload) => {
    const results = payload.body.results
    return Promise.all(
      results.map(product =>
        client.execute({
          uri: productsService.byId(product.id).build({ projectKey: 'foo' }),
          method: 'POST',
          body: JSON.stringify({
            version: product.version,
            actions: [{ action: 'publish' }]
          }),
          headers: request.headers,
        })
      ),
    )
  },
  { accumulate: false },
)
.then(result => ...)
.catch(error => ...)
```
