### PR TITLE
refactor(sync-actions): upgrade jsondiffpatch and properly import it

### DIFF
--- a/packages/commercetools-sync-actions/package.json
+++ b/packages/commercetools-sync-actions/package.json
@@ -30,7 +30,7 @@
     "build:umd:min": "cross-env NODE_ENV=production webpack --config ../../webpack.config.js --output-library CommercetoolsSyncActions --output-library-target umd src/index.js dist/commercetools-sync-actions.min.js"
   },
   "dependencies": {
-    "jsondiffpatch": "emmenko/jsondiffpatch#patch-webpack",
+    "jsondiffpatch": "0.2.4",
     "lodash.flatten": "4.4.0",
     "lodash.foreach": "4.5.0",
     "lodash.uniqwith": "4.5.0"

--- a/packages/commercetools-sync-actions/src/utils/diffpatcher.js
+++ b/packages/commercetools-sync-actions/src/utils/diffpatcher.js
@@ -1,6 +1,10 @@
-import jsondiffpatch from 'jsondiffpatch'
+// Requiring directily from `jsondiffpatch` entry point will cause warnings
+// while bundling with webpack because of dynamic requires.
+// To get around this issue, simply require the `Diffpatcher` directly.
+// https://github.com/benjamine/jsondiffpatch/issues/76#issuecomment-270207970
+import { DiffPatcher } from 'jsondiffpatch/src/diffpatcher'
 
-const diffpatcher = jsondiffpatch.create({
+const diffpatcher = new DiffPatcher({
   objectHash,
   arrays: {
     // detect items moved inside the array
@@ -45,15 +49,18 @@ export function getDeltaValue (arr, originalObject) {
 
   if (arr.length === 3 && arr[2] === 2) { // text diff
     if (!originalObject)
-      throw new Error('Cannot apply patch to long text diff. ' +
-        'Missing original object.')
+      throw new Error(
+        'Cannot apply patch to long text diff. Missing original object.',
+      )
     // try to apply patch to given object based on delta value
-    return jsondiffpatch.patch(originalObject, arr)
+    return patch(originalObject, arr)
   }
 
   if (arr.length === 3 && arr[2] === 3) // array move
-    throw new Error('Detected an array move, it should not happen as ' +
-      '`includeValueOnMove` should be set to false')
+    throw new Error(
+      'Detected an array move, it should not happen as ' +
+      '`includeValueOnMove` should be set to false',
+    )
 
   throw new Error(`Got unsupported number ${arr[2]} in delta value`)
 }


### PR DESCRIPTION
#### Summary
Upgrade back to official version of `jsondiffpatch` and use import workaround to make it work in webpack