### PR TITLE
build(travis): fail fast and avoid running it tests for PRs coming from forks

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 sudo: false
+
 language: node_js
+
 node_js:
   - 4
   - 6
@@ -13,10 +15,7 @@ before_install:
   - .travis/before_install.sh
 
 script:
-  - npm run lint
-  - npm run coverage:ci
-  - npm run it
-  - npm run dist
+  - .travis/scripts.sh
 
 after_success:
   - .travis/after_success.sh

--- a/.travis/scripts.sh
+++ b/.travis/scripts.sh
@@ -13,6 +13,8 @@ npm run coverage:ci
 # thus tasks that rely on that should not run.
 if [ "$TRAVIS_SECURE_ENV_VARS" == "true" ]; then
   npm run it
+else
+  echo "Build does not have secure env variables, skipping integration tests!"
 fi
 
 # 4. run dist tasks where necessary

--- a/.travis/scripts.sh
+++ b/.travis/scripts.sh
@@ -1,0 +1,19 @@
+#!/bin/bash -e
+# This file runs all the main scripts to be run in the build.
+# Note: ensure to have `set -e` in order to fail the build fast.
+
+# 1. lint code
+npm run lint
+
+# 2. run tests + coverage
+npm run coverage:ci
+
+# 3. run integration tests
+# Note: PRs coming from forks do not have access to encrypted variables,
+# thus tasks that rely on that should not run.
+if [ "$TRAVIS_SECURE_ENV_VARS" == "true" ]; then
+  npm run it
+fi
+
+# 4. run dist tasks where necessary
+npm run dist

--- a/.travis/scripts.sh
+++ b/.travis/scripts.sh
@@ -1,6 +1,7 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 # This file runs all the main scripts to be run in the build.
-# Note: ensure to have `set -e` in order to fail the build fast.
+# Exit if one of the build steps errors
+set -e
 
 # 1. lint code
 npm run lint


### PR DESCRIPTION
#### Summary
- builds now will fail fast if an error occurs `set -e`
- don't run *it* tests if PR is coming from a fork (Closes #30)
