### PR TITLE
feat(api-request-builder): add missing services to cover all API endpoints

### DIFF
--- a/packages/commercetools-api-request-builder/src/create-service.js
+++ b/packages/commercetools-api-request-builder/src/create-service.js
@@ -92,6 +92,7 @@ export default function createService (
     // Pass some options to further configure the URI:
     // - `projectKey`: will prefix the URI with the given projectKey
     build (options: BuildOptions = {}): string {
+      // FIXME: make it an option of `createRequestBuilder`
       const { projectKey } = options
 
       const queryParams = buildQueryString(this.params)
@@ -99,11 +100,19 @@ export default function createService (
       const uri =
         (projectKey ? `/${projectKey}` : '') +
         endpoint +
-        (this.params.id ? `/${this.params.id}` : '') +
+        getIdOrKey(this.params) +
         (queryParams ? `?${queryParams}` : '')
 
       setDefaultParams.call(this)
       return uri
     },
   })
+}
+
+function getIdOrKey (params: Object): string {
+  if (params.id)
+    return `/${params.id}`
+  else if (params.key)
+    return `/key=${params.key}`
+  return ''
 }

--- a/packages/commercetools-api-request-builder/src/create-service.js
+++ b/packages/commercetools-api-request-builder/src/create-service.js
@@ -92,7 +92,6 @@ export default function createService (
     // Pass some options to further configure the URI:
     // - `projectKey`: will prefix the URI with the given projectKey
     build (options: BuildOptions = {}): string {
-      // FIXME: make it an option of `createRequestBuilder`
       const { projectKey } = options
 
       const queryParams = buildQueryString(this.params)

--- a/packages/commercetools-api-request-builder/src/default-services.js
+++ b/packages/commercetools-api-request-builder/src/default-services.js
@@ -155,7 +155,6 @@ export default {
       features.projection,
     ],
   },
-  // TODO: productSuggestions
   products: {
     type: 'products',
     endpoint: '/products',

--- a/packages/commercetools-api-request-builder/src/default-services.js
+++ b/packages/commercetools-api-request-builder/src/default-services.js
@@ -1,6 +1,24 @@
 import * as features from './features'
 
 export default {
+  cartDiscounts: {
+    type: 'cart-discounts',
+    endpoint: '/cart-discounts',
+    features: [
+      features.query,
+      features.queryOne,
+      features.queryExpand,
+    ],
+  },
+  carts: {
+    type: 'carts',
+    endpoint: '/carts',
+    features: [
+      features.query,
+      features.queryOne,
+      features.queryExpand,
+    ],
+  },
   categories: {
     type: 'categories',
     endpoint: '/categories',
@@ -20,8 +38,79 @@ export default {
     ],
   },
   customerGroups: {
-    type: 'customerGroups',
+    type: 'customer-groups',
     endpoint: '/customer-groups',
+    features: [
+      features.query,
+      features.queryOne,
+      features.queryExpand,
+    ],
+  },
+  customers: {
+    type: 'customers',
+    endpoint: '/customers',
+    features: [
+      features.query,
+      features.queryOne,
+      features.queryExpand,
+    ],
+  },
+  customObjects: {
+    type: 'custom-objects',
+    endpoint: '/custom-objects',
+    features: [
+      features.query,
+      features.queryOne,
+    ],
+  },
+  discountCodes: {
+    type: 'discount-codes',
+    endpoint: '/discount-codes',
+    features: [
+      features.query,
+      features.queryOne,
+      features.queryExpand,
+    ],
+  },
+  inventory: {
+    type: 'inventory',
+    endpoint: '/inventory',
+    features: [
+      features.query,
+      features.queryOne,
+      features.queryExpand,
+    ],
+  },
+  messages: {
+    type: 'messages',
+    endpoint: '/messages',
+    features: [
+      features.query,
+      features.queryOne,
+      features.queryExpand,
+    ],
+  },
+  myCarts: {
+    type: 'my-carts',
+    endpoint: '/me/carts',
+    features: [
+      features.query,
+      features.queryOne,
+      features.queryExpand,
+    ],
+  },
+  myOrders: {
+    type: 'my-orders',
+    endpoint: '/me/orders',
+    features: [
+      features.query,
+      features.queryOne,
+      features.queryExpand,
+    ],
+  },
+  orders: {
+    type: 'orders',
+    endpoint: '/orders',
     features: [
       features.query,
       features.queryOne,
@@ -31,6 +120,15 @@ export default {
   payments: {
     type: 'payments',
     endpoint: '/payments',
+    features: [
+      features.query,
+      features.queryOne,
+      features.queryExpand,
+    ],
+  },
+  productDiscounts: {
+    type: 'product-discounts',
+    endpoint: '/product-discounts',
     features: [
       features.query,
       features.queryOne,
@@ -57,6 +155,7 @@ export default {
       features.projection,
     ],
   },
+  // TODO: productSuggestions
   products: {
     type: 'products',
     endpoint: '/products',
@@ -72,6 +171,43 @@ export default {
     features: [
       features.query,
       features.queryOne,
+      features.queryExpand,
+    ],
+  },
+  reviews: {
+    type: 'reviews',
+    endpoint: '/reviews',
+    features: [
+      features.query,
+      features.queryOne,
+      features.queryExpand,
+    ],
+  },
+  shippingMethods: {
+    type: 'shipping-methods',
+    endpoint: '/shipping-methods',
+    features: [
+      features.query,
+      features.queryOne,
+      features.queryExpand,
+    ],
+  },
+  states: {
+    type: 'states',
+    endpoint: '/states',
+    features: [
+      features.query,
+      features.queryOne,
+      features.queryExpand,
+    ],
+  },
+  subscriptions: {
+    type: 'subscriptions',
+    endpoint: '/subscriptions',
+    features: [
+      features.query,
+      features.queryOne,
+      features.queryExpand,
     ],
   },
   taxCategories: {
@@ -80,11 +216,21 @@ export default {
     features: [
       features.query,
       features.queryOne,
+      features.queryExpand,
     ],
   },
   types: {
     type: 'types',
     endpoint: '/types',
+    features: [
+      features.query,
+      features.queryOne,
+      features.queryExpand,
+    ],
+  },
+  zones: {
+    type: 'zones',
+    endpoint: '/zones',
     features: [
       features.query,
       features.queryOne,

--- a/packages/commercetools-api-request-builder/src/query-id.js
+++ b/packages/commercetools-api-request-builder/src/query-id.js
@@ -6,11 +6,35 @@
  * @throws If `id` is missing.
  * @return {Object} The instance of the service, can be chained.
  */
-// eslint-disable-next-line import/prefer-default-export
 export function byId (id: string): Object {
   if (!id)
     throw new Error('Required argument for `byId` is missing')
+  if (this.params.key)
+    throw new Error(
+      'A key for this resource has already been set. ' +
+      'You cannot use both `byKey` and `byId`.',
+    )
 
   this.params.id = id
+  return this
+}
+
+/**
+ * Set the given `key` to the internal state of the service instance.
+ *
+ * @param  {string} key - A resource `key`
+ * @throws If `key` is missing.
+ * @return {Object} The instance of the service, can be chained.
+ */
+export function byKey (key: string): Object {
+  if (!key)
+    throw new Error('Required argument for `byKey` is missing')
+  if (this.params.id)
+    throw new Error(
+      'An ID for this resource has already been set. ' +
+      'You cannot use both `byId` and `byKey`.',
+    )
+
+  this.params.key = key
   return this
 }

--- a/packages/commercetools-api-request-builder/src/query-projection.js
+++ b/packages/commercetools-api-request-builder/src/query-projection.js
@@ -11,9 +11,3 @@ export function staged (isStaged: boolean = true): Object {
   this.params.staged = isStaged
   return this
 }
-
-// TODO: add price selection query params
-// - priceCurrency
-// - priceCountry (requires priceCurrency)
-// - priceCustomerGroup (requires priceCurrency)
-// - priceChannel (requires priceCurrency)

--- a/packages/commercetools-api-request-builder/src/query-projection.js
+++ b/packages/commercetools-api-request-builder/src/query-projection.js
@@ -11,3 +11,9 @@ export function staged (isStaged: boolean = true): Object {
   this.params.staged = isStaged
   return this
 }
+
+// TODO: add price selection query params
+// - priceCurrency
+// - priceCountry (requires priceCurrency)
+// - priceCustomerGroup (requires priceCurrency)
+// - priceChannel (requires priceCurrency)

--- a/packages/commercetools-api-request-builder/test/create-request-builder.spec.js
+++ b/packages/commercetools-api-request-builder/test/create-request-builder.spec.js
@@ -5,16 +5,32 @@ import {
 
 // order matters!
 const expectedServiceKeys = [
+  'cartDiscounts',
+  'carts',
   'categories',
   'channels',
   'customerGroups',
+  'customers',
+  'customObjects',
+  'discountCodes',
+  'inventory',
+  'messages',
+  'myCarts',
+  'myOrders',
+  'orders',
   'payments',
+  'productDiscounts',
   'productProjections',
   'productProjectionsSearch',
   'products',
   'productTypes',
+  'reviews',
+  'shippingMethods',
+  'states',
+  'subscriptions',
   'taxCategories',
   'types',
+  'zones',
 ]
 
 

--- a/packages/commercetools-api-request-builder/test/create-service.spec.js
+++ b/packages/commercetools-api-request-builder/test/create-service.spec.js
@@ -19,6 +19,7 @@ const expectedServiceProperties = [
   'page',
   'perPage',
   'byId',
+  'byKey',
   'expand',
   'text',
   'facet',
@@ -89,6 +90,9 @@ describe('createService', () => {
     })
     it('endpoint with id', () => {
       expect(createService(options).byId('123').build()).toBe('/foo/123')
+    })
+    it('endpoint with key', () => {
+      expect(createService(options).byKey('bar').build()).toBe('/foo/key=bar')
     })
     it('endpoint with query params', () => {
       expect(createService(options).expand('channel').build())

--- a/packages/commercetools-api-request-builder/test/query-id.spec.js
+++ b/packages/commercetools-api-request-builder/test/query-id.spec.js
@@ -17,4 +17,31 @@ describe('queryId', () => {
       /Required argument for `byId` is missing/,
     )
   })
+
+  it('should set the key param', () => {
+    service.byKey('bar')
+    expect(service.params.key).toBe('bar')
+  })
+
+  it('should throw if key is missing', () => {
+    expect(() => service.byKey()).toThrowError(
+      /Required argument for `byKey` is missing/,
+    )
+  })
+
+  it('throw if byId is used after byKey', () => {
+    expect(() => service.byKey('bar').byId('123'))
+      .toThrowError(
+        'A key for this resource has already been set. ' +
+        'You cannot use both `byKey` and `byId`.',
+      )
+  })
+
+  it('throw if byKey is used after byId', () => {
+    expect(() => service.byId('123').byKey('bar'))
+      .toThrowError(
+        'An ID for this resource has already been set. ' +
+        'You cannot use both `byId` and `byKey`.',
+      )
+  })
 })

--- a/packages/commercetools-sdk-client/src/client.js
+++ b/packages/commercetools-sdk-client/src/client.js
@@ -27,7 +27,6 @@ export default function createClient (options: ClientOptions = {}): Client {
       Given a request object,
     */
     execute (request: ClientRequest): Promise<ClientResult> {
-      // TODO: validate request shape
       return new Promise((resolve, reject) => {
         const resolver = (rq: ClientRequest, rs: ClientResponse) => {
           // Note: pick the promise `resolve` and `reject` function from
@@ -62,10 +61,6 @@ export default function createClient (options: ClientOptions = {}): Client {
       fn: ProcessFn,
       opt: ProcessOptions = { accumulate: true },
     ): Promise<Array<Object>> {
-      // Validate arguments
-      // - request must be a GET request
-      // - fn must be a function
-
       return new Promise((resolve, reject) => {
         const [path, queryString] = request.uri.split('?')
         const query = {

--- a/packages/commercetools-sdk-middleware-http/src/http.js
+++ b/packages/commercetools-sdk-middleware-http/src/http.js
@@ -22,7 +22,6 @@ export default function createHttpMiddleware (
 ): Middleware {
   const {
     host = defaultApiHost,
-    // TODO: other options?
   } = options
 
   return next => (request: ClientRequest, response: ClientResponse) => {

--- a/packages/commercetools-sdk-middleware-logger/src/logger.js
+++ b/packages/commercetools-sdk-middleware-logger/src/logger.js
@@ -5,12 +5,6 @@ import type {
   ClientResponse,
 } from 'types/sdk'
 
-// TODO: allow to pass some configuration options:
-// - name for the logger
-// - predicate
-// - filter
-// - custom logger
-// - format / colors
 export default function createLoggerMiddleware (): Middleware {
   return next => (request: ClientRequest, response: ClientResponse) => {
     const { error, body, statusCode } = response

--- a/packages/commercetools-sync-actions/src/product-actions.js
+++ b/packages/commercetools-sync-actions/src/product-actions.js
@@ -112,7 +112,6 @@ export function actionsMapAttributes (
   newObj,
   sameForAllAttributeNames = [],
 ) {
-  // TODO: validate ProductType between products
   let actions = []
   const { masterVariant, variants } = diff
 


### PR DESCRIPTION
#### Summary
Define remaining services for API endpoints.

Note: there are a few extra things that should also be supported but they can be done separately.

#### Todo
- Tests
    - [x] Unit