### PR TITLE
Generate changelog for published packages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ node_modules
 
 # Build artifacts
 _book
+.changelog
 dist
 lib
 coverage

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,97 @@
+## @commercetools/api-request-builder@1.6.0 (2017-01-21)
+
+#### :rocket: New Feature
+* `commercetools-api-request-builder`
+  * [#33](https://github.com/commercetools/nodejs/pull/33) feat(api-request-builder): add missing services to cover all API endpoints. ([@emmenko](https://github.com/emmenko))
+
+#### :house: Maintenance
+* Other
+  * [#31](https://github.com/commercetools/nodejs/pull/31) build(travis): fail fast and avoid running it tests for PRs coming from forks. ([@emmenko](https://github.com/emmenko))
+
+#### Committers: 1
+- Nicola Molinari ([emmenko](https://github.com/emmenko))
+
+
+## @commercetools/api-request-builder@1.4.0 (2017-01-19)
+
+#### :rocket: New Feature
+* `commercetools-api-request-builder`
+  * [#29](https://github.com/commercetools/nodejs/pull/29) feat(api-request-builder): add the payments service. ([@nkuehn](https://github.com/nkuehn))
+
+#### Committers: 1
+- Nikolaus Kühn ([nkuehn](https://github.com/nkuehn))
+
+
+## @commercetools/sync-actions@1.1.0 (2017-01-19)
+
+#### :house: Maintenance
+* `commercetools-sync-actions`
+  * [#25](https://github.com/commercetools/nodejs/pull/25) refactor(sync-actions): upgrade jsondiffpatch and properly import it. ([@emmenko](https://github.com/emmenko))
+
+#### Committers: 1
+- Nicola Molinari ([emmenko](https://github.com/emmenko))
+
+
+## @commercetools/sdk-client@1.2.0 (2017-01-13)
+
+#### :rocket: New Feature
+* `commercetools-sdk-client`
+  * [#18](https://github.com/commercetools/nodejs/pull/18) feat(sdk-client): implement process function to iterate through pages. ([@emmenko](https://github.com/emmenko))
+  * [Documentation](https://commercetools.github.io/nodejs/docs/sdk/api/createClient.html#processrequest-processfn-options)
+
+#### Committers: 1
+- Nicola Molinari ([emmenko](https://github.com/emmenko))
+
+
+## @commercetools/sdk-middleware-user-agent@1.1.0 (2017-01-12)
+
+#### :nail_care: Enhancement
+* `commercetools-sdk-middleware-user-agent`
+  * [#17](https://github.com/commercetools/nodejs/pull/17) Use http-user-agent as dependency in middleware-user-agent. ([@emmenko](https://github.com/emmenko))
+
+#### Committers: 1
+- Nicola Molinari ([emmenko](https://github.com/emmenko))
+
+
+## @commercetools/http-user-agent@1.0.0 (2017-01-12)
+
+#### :rocket: New Feature
+* `commercetools-http-user-agent`
+  * [#16](https://github.com/commercetools/nodejs/pull/16) Add standalone package for creating a proper HTTP user-agent. ([@emmenko](https://github.com/emmenko))
+  * [Documentation](https://commercetools.github.io/nodejs/docs/sdk/api/#http-user-agent)
+
+#### Committers: 1
+- Nicola Molinari ([emmenko](https://github.com/emmenko))
+
+
+## @commercetools/sdk-middleware-user-agent@1.0.0 (2017-01-10)
+
+#### :rocket: New Feature
+* `commercetools-sdk-middleware-user-agent`
+  * [#15](https://github.com/commercetools/nodejs/pull/15) Add middleware to define the user-agent for http requests. ([@emmenko](https://github.com/emmenko))
+  * [Documentation](https://commercetools.github.io/nodejs/docs/sdk/api/#sdk-middleware-user-agent)
+
+#### Committers: 1
+- Nicola Molinari ([emmenko](https://github.com/emmenko))
+
+
+## @commercetools/api-request-builder@1.2.0 (2017-01-08)
+
+#### :rocket: New Feature
+* `commercetools-sync-actions`
+  * [#12](https://github.com/commercetools/nodejs/pull/12) feat(sync-actions): migrate over sync-actions package. ([@emmenko](https://github.com/emmenko))
+  * [Documentation](https://commercetools.github.io/nodejs/docs/sdk/api/#sync-actions)
+
+#### Committers: 1
+- Nicola Molinari ([emmenko](https://github.com/emmenko))
+
+
+## @commercetools/sdk-middleware-logger@1.0.0 (2016-12-23)
+
+#### :rocket: New Feature
+* `commercetools-sdk-middleware-logger`
+  * [#4](https://github.com/commercetools/nodejs/pull/4) feat(sdk-middleware-logger): add package for middleware-logger. ([@emmenko](https://github.com/emmenko))
+  * [Documentation]( https://commercetools.github.io/nodejs/docs/sdk/api/#sdk-middleware-logger)
+
+#### Committers: 1
+- Nicola Molinari ([emmenko](https://github.com/emmenko))

--- a/lerna.json
+++ b/lerna.json
@@ -1,4 +1,18 @@
 {
   "lerna": "2.0.0-beta.30",
-  "version": "independent"
+  "version": "independent",
+  "changelog": {
+    "rootPath": ".",
+    "repo": "commercetools/nodejs",
+    "labels": {
+      "Type: New Feature": ":rocket: New Feature",
+      "Type: Breaking Change": ":boom: Breaking Change",
+      "Type: Bug": ":bug: Bug Fix",
+      "Type: Enhancement": ":nail_care: Enhancement",
+      "Type: Documentation": ":memo: Documentation",
+      "Type: Maintenance": ":house: Maintenance"
+    },
+    "cacheDir": ".changelog",
+    "ignoreCommitters": ["greenkeeper"]
+  }
 }


### PR DESCRIPTION
#### Summary
Add initial historical changelog, using `lerna-changelog`.

> Note: I've created it using the new version of `lerna-changelog` [with some new features](https://github.com/lerna/lerna-changelog/pull/31). When it will be merged / released I'll add also the dependency, until then please ask me if you want to do something with it.