### PR TITLE
fix(middleware-auth): fix usage of cached token, no default options

### DIFF
--- a/packages/commercetools-sdk-middleware-auth/src/build-requests.js
+++ b/packages/commercetools-sdk-middleware-auth/src/build-requests.js
@@ -12,34 +12,34 @@ type BuiltRequestParams = {
   body: string;
 }
 
-const defaultAuthHost = 'https://auth.sphere.io'
-
 // POST https://{host}/oauth/token?grant_type=client_credentials&scope={scope}
 // Authorization: Basic QWxhZGRpbjpvcGVuIHNlc2FtZQ==
 export function buildRequestForClientCredentialsFlow (
-  {
-    host = defaultAuthHost,
-    projectKey,
-    credentials,
-    scopes,
-  }: AuthMiddlewareOptions = {},
+  options: AuthMiddlewareOptions,
 ): BuiltRequestParams {
-  if (!projectKey)
+  // TODO: use a better validator
+  if (!options)
+    throw new Error('Missing required options')
+
+  if (!options.host)
+    throw new Error('Missing required option (host)')
+
+  if (!options.projectKey)
     throw new Error('Missing required option (projectKey)')
 
-  if (!credentials)
+  if (!options.credentials)
     throw new Error('Missing required option (credentials)')
 
-  const { clientId, clientSecret } = credentials
+  const { clientId, clientSecret } = options.credentials
 
   if (!(clientId && clientSecret))
     throw new Error('Missing required credentials (clientId, clientSecret)')
 
-  const defaultScope = `${authScopes.MANAGE_PROJECT}:${projectKey}`
-  const scope = (scopes || [defaultScope]).join(' ')
+  const defaultScope = `${authScopes.MANAGE_PROJECT}:${options.projectKey}`
+  const scope = (options.scopes || [defaultScope]).join(' ')
 
   const basicAuth = getBasicAuth(clientId, clientSecret)
-  const url = `${host}/oauth/token`
+  const url = `${options.host}/oauth/token`
   const body = `grant_type=client_credentials&scope=${scope}`
 
   return { basicAuth, url, body }

--- a/packages/commercetools-sdk-middleware-auth/src/build-requests.js
+++ b/packages/commercetools-sdk-middleware-auth/src/build-requests.js
@@ -17,7 +17,6 @@ type BuiltRequestParams = {
 export function buildRequestForClientCredentialsFlow (
   options: AuthMiddlewareOptions,
 ): BuiltRequestParams {
-  // TODO: use a better validator
   if (!options)
     throw new Error('Missing required options')
 

--- a/packages/commercetools-sdk-middleware-auth/test/build-requests.spec.js
+++ b/packages/commercetools-sdk-middleware-auth/test/build-requests.spec.js
@@ -9,17 +9,22 @@ import { scopes } from '../src'
 
 const allScopes = Object.values(scopes)
 
+function createTestOptions (options) {
+  return {
+    host: 'http://localhost:8080',
+    projectKey: 'test',
+    credentials: {
+      clientId: '123',
+      clientSecret: 'secret',
+    },
+    scopes: allScopes,
+    ...options,
+  }
+}
+
 describe('buildRequestForClientCredentialsFlow', () => {
   it('build request values with all the given options', () => {
-    const options = {
-      host: 'http://localhost:8080',
-      projectKey: 'test',
-      credentials: {
-        clientId: '123',
-        clientSecret: 'secret',
-      },
-      scopes: allScopes,
-    }
+    const options = createTestOptions()
     expect(buildRequestForClientCredentialsFlow(options)).toEqual({
       basicAuth: 'MTIzOnNlY3JldA==',
       url: 'http://localhost:8080/oauth/token',
@@ -27,60 +32,52 @@ describe('buildRequestForClientCredentialsFlow', () => {
     })
   })
 
-  it('build request values with default options', () => {
-    const options = {
-      projectKey: 'test',
-      credentials: {
-        clientId: '123',
-        clientSecret: 'secret',
-      },
-    }
-    expect(buildRequestForClientCredentialsFlow(options)).toEqual({
-      basicAuth: 'MTIzOnNlY3JldA==',
-      url: 'https://auth.sphere.io/oauth/token',
-      body: 'grant_type=client_credentials&scope=manage_project:test',
-    })
+  it('validate required options', () => {
+    expect(
+      () => buildRequestForClientCredentialsFlow(),
+    ).toThrowError('Missing required options')
+  })
+
+  it('validate required option (host)', () => {
+    expect(
+      () => buildRequestForClientCredentialsFlow({}),
+    ).toThrowError('Missing required option (host)')
   })
 
   it('validate required option (projectKey)', () => {
-    const options = {
-      credentials: {
-        clientId: '123',
-        clientSecret: 'secret',
-      },
-    }
+    const options = createTestOptions({
+      projectKey: undefined,
+    })
     expect(
       () => buildRequestForClientCredentialsFlow(options),
     ).toThrowError('Missing required option (projectKey)')
   })
 
   it('validate required option (credentials)', () => {
-    const options = {
-      projectKey: 'test',
-    }
+    const options = createTestOptions({
+      credentials: undefined,
+    })
     expect(
       () => buildRequestForClientCredentialsFlow(options),
     ).toThrowError('Missing required option (credentials)')
   })
 
   it('validate required option (clientId, clientSecret)', () => {
-    const options = {
-      projectKey: 'test',
+    const options = createTestOptions({
       credentials: {},
-    }
+    })
     expect(
       () => buildRequestForClientCredentialsFlow(options),
     ).toThrowError('Missing required credentials (clientId, clientSecret)')
+  })
 
-    it('both credentials are required', () => {
-      const options2 = {
-        projectKey: 'test',
-        credentials: { clientId: '123' },
-      }
-      expect(
-        () => buildRequestForClientCredentialsFlow(options2),
-      ).toThrowError('Missing required credentials (clientId, clientSecret)')
+  it('validate both credentials are required', () => {
+    const options = createTestOptions({
+      credentials: { clientId: '123' },
     })
+    expect(
+      () => buildRequestForClientCredentialsFlow(options),
+    ).toThrowError('Missing required credentials (clientId, clientSecret)')
   })
 })
 


### PR DESCRIPTION
BREAKING CHANGE: `host` is now a required option, no more default value

#### Summary
Yesterday I realized that the usage of the token cache was not properly done (new token would be retrieved for each new request).

Additionally, after some conversation yesterday, we should not put any _default_ `host` values, as our platform as already multiple data centers. It also keeps the middleware more decoupled from our platform. 

#### Todo
- Tests
    - [x] Unit
    - [ ] Integration
- [ ] Documentation
