### PR TITLE
refactor(sdk): use more specific types for middlewares args

### DIFF
--- a/docs/sdk/Glossary.md
+++ b/docs/sdk/Glossary.md
@@ -21,8 +21,6 @@ A *ClientRequest* is an object describing the request that needs to be executed 
 
 ```js
 type ClientResponse = {
-  resolve(): void;
-  reject(): void;
   body?: Object;
   error?: HttpErrorType;
   statusCode: number;
@@ -34,7 +32,16 @@ A *ClientResponse* is an object describing the **response** object passed to a [
 ## Middleware
 
 ```js
-type Dispatch = (request: ClientRequest, response: ClientResponse) => any;
+type MiddlewareRequest = ClientRequest;
+type MiddlewareResponse = {
+  resolve(): void;
+  reject(): void;
+  body?: Object;
+  error?: HttpErrorType;
+  statusCode: number;
+}
+
+type Dispatch = (request: MiddlewareRequest, response: MiddlewareResponse) => any;
 type Middleware = (next: Dispatch) => Dispatch;
 ```
 

--- a/docs/sdk/README.md
+++ b/docs/sdk/README.md
@@ -47,7 +47,7 @@ const ignoredResponseKeys = [ 'id', 'createdAt', 'lastModifiedAt' ]
 const service = createRequestBuilder().channels
 
 const authMiddleware = createAuthMiddlewareForClientCredentialsFlow({
-  host: 'https://auth.sphere.io',
+  host: 'https://auth.commercetools.com',
   projectKey 'test',
   credentials: {
     clientId: '123',
@@ -55,7 +55,7 @@ const authMiddleware = createAuthMiddlewareForClientCredentialsFlow({
   },
 })
 const httpMiddleware = createHttpMiddleware({
-  host: 'https://api.sphere.io',
+  host: 'https://api.commercetools.com',
 })
 const queueMiddleware = createQueueMiddleware({
   concurrency: 5,

--- a/docs/sdk/Testing.md
+++ b/docs/sdk/Testing.md
@@ -8,7 +8,7 @@ This library allows to deeply customize how you want to mock the actual node `ht
 
 ```js
 // We'll mock a request to fetch some products
-nock('https://api.sphere.io')
+nock('https://api.commercetools.com')
   .defaultReplyHeaders({ 'Content-Type': 'application/json' })
   .get('/my-project/products')
   .reply(
@@ -21,7 +21,7 @@ nock('https://api.sphere.io')
   )
 
 // or mock a request to create a channel
-nock('https://api.sphere.io')
+nock('https://api.commercetools.com')
   .defaultReplyHeaders({ 'Content-Type': 'application/json' })
   .filteringRequestBody(() => '*')
   .post('/my-project/channels', '*')

--- a/docs/sdk/api/sdkMiddlewareAuth.md
+++ b/docs/sdk/api/sdkMiddlewareAuth.md
@@ -20,7 +20,7 @@ Creates a [middleware](/sdk/Glossary.md#middleware) to handle authentication for
 
 #### Named arguments (options)
 
-1. `host` *(String)*: the host of the OAuth API service (default `https://auth.sphere.io`)
+1. `host` *(String)*: the host of the OAuth API service
 2. `projectKey` *(String)*: the key of the project to assign the default scope to
 3. `credentials` *(Object)*: the client credentials for authentication (`clientId`, `clientSecret`)
 4. `scopes` *(Array)*: a list of [scopes](http://dev.commercetools.com/http-api-authorization.html#scopes) (default `manage_project:{projectKey}`) to assign to the OAuth token

--- a/docs/sdk/api/sdkMiddlewareHttp.md
+++ b/docs/sdk/api/sdkMiddlewareHttp.md
@@ -20,7 +20,7 @@ Creates a [middleware](/sdk/Glossary.md#middleware) to handle HTTP requests for 
 
 #### Named arguments (options)
 
-1. `host` *(String)*: the host of the HTTP API service (default `https://api.sphere.io`)
+1. `host` *(String)*: the host of the HTTP API service
 
 #### Usage example
 
@@ -38,8 +38,6 @@ const client = createClient({
 ```
 
 ## `getErrorByCode(code)`
-
-> From package [@commercetools/sdk-middleware-http](/sdk/api/README.md#sdk-middleware-http).
 
 Returns a [custom error type](/sdk/Glossary.md#httperrortype) given its status *code*.
 

--- a/docs/sdk/upgrading-from-sphere-node-sdk.md
+++ b/docs/sdk/upgrading-from-sphere-node-sdk.md
@@ -48,9 +48,9 @@ const client = new SphereClient({
     client_secret: 'secret',
   },
   user_agent: 'sphere-node-sdk',
-  host: 'api.sphere.io',
+  host: 'api.commercetools.com',
   protocol: 'https',
-  oauth_host: 'auth.sphere.io',
+  oauth_host: 'auth.commercetools.com',
   oauth_protocol: 'https',
 })
 const sync = new ProductSync()
@@ -76,7 +76,7 @@ const client = createClient({
   // The order of the middlewares is important !!!
   middlewares: [
     createAuthMiddlewareForClientCredentialsFlow({
-      host: 'https://auth.sphere.io',
+      host: 'https://auth.commercetools.com',
       projectKey: 'my-project',
       credentials: {
         clientId: '123',
@@ -84,7 +84,7 @@ const client = createClient({
       },
     }),
     createQueueMiddleware({ concurrency: 10 }),
-    createHttpMiddleware({ host: 'https://api.sphere.io' }),
+    createHttpMiddleware({ host: 'https://api.commercetools.com' }),
     createHttpUserAgent({
       libraryName: 'my-library',
       libraryVersion: '1.0.0',

--- a/packages/commercetools-sdk-client/src/client.js
+++ b/packages/commercetools-sdk-client/src/client.js
@@ -3,23 +3,27 @@ import type {
   Client,
   ClientOptions,
   ClientRequest,
-  ClientResponse,
   ClientResult,
+  MiddlewareRequest,
+  MiddlewareResponse,
   ProcessFn,
   ProcessOptions,
   SuccessResult,
 } from 'types/sdk'
 import qs from 'querystring'
 
-export default function createClient (options: ClientOptions = {}): Client {
-  const {
-    middlewares,
-  } = options
+export default function createClient (options: ClientOptions): Client {
+  if (!options)
+    throw new Error('Missing required options')
 
-  if (middlewares && !Array.isArray(middlewares))
+  if (options.middlewares && !Array.isArray(options.middlewares))
     throw new Error('Middlewares should be an array')
 
-  if (!middlewares || !Array.isArray(middlewares) || !middlewares.length)
+  if (
+    !options.middlewares ||
+    !Array.isArray(options.middlewares) ||
+    !options.middlewares.length
+  )
     throw new Error('You need to provide at least one middleware')
 
   return {
@@ -28,7 +32,7 @@ export default function createClient (options: ClientOptions = {}): Client {
     */
     execute (request: ClientRequest): Promise<ClientResult> {
       return new Promise((resolve, reject) => {
-        const resolver = (rq: ClientRequest, rs: ClientResponse) => {
+        const resolver = (rq: MiddlewareRequest, rs: MiddlewareResponse) => {
           // Note: pick the promise `resolve` and `reject` function from
           // the response object. This is not necessary the same function
           // given from the `new Promise` constructor, as middlewares could
@@ -42,7 +46,7 @@ export default function createClient (options: ClientOptions = {}): Client {
             })
         }
 
-        const dispatch = compose(...middlewares)(resolver)
+        const dispatch = compose(...options.middlewares)(resolver)
         dispatch(
           request,
           // Initial response shape

--- a/packages/commercetools-sdk-client/test/client.spec.js
+++ b/packages/commercetools-sdk-client/test/client.spec.js
@@ -6,7 +6,7 @@ import {
 describe('validate options', () => {
   it('middlewares (required)', () => {
     expect(() => createClient()).toThrowError(
-      'You need to provide at least one middleware',
+      'Missing required options',
     )
   })
   it('middlewares (array)', () => {

--- a/packages/commercetools-sdk-middleware-auth/src/client-credentials-flow.js
+++ b/packages/commercetools-sdk-middleware-auth/src/client-credentials-flow.js
@@ -2,8 +2,8 @@
 import type {
   AuthMiddlewareOptions,
   Middleware,
-  ClientRequest,
-  ClientResponse,
+  MiddlewareRequest,
+  MiddlewareResponse,
 } from 'types/sdk'
 
 /* global fetch */
@@ -17,8 +17,8 @@ type TokenCache = {
   expirationTime: number;
 }
 type Task = {
-  request: ClientRequest;
-  response: ClientResponse;
+  request: MiddlewareRequest;
+  response: MiddlewareResponse;
 }
 
 export default function createAuthMiddlewareForClientCredentialsFlow (
@@ -28,7 +28,7 @@ export default function createAuthMiddlewareForClientCredentialsFlow (
   let pendingTasks: Array<Task> = []
   let isFetchingToken = false
 
-  return next => (request: ClientRequest, response: ClientResponse) => {
+  return next => (request: MiddlewareRequest, response: MiddlewareResponse) => {
     // Check if there is already a `Authorization` header in the request.
     // If so, then go directly to the next middleware.
     if (
@@ -118,7 +118,10 @@ export default function createAuthMiddlewareForClientCredentialsFlow (
   }
 }
 
-function mergeAuthHeader (token: string, req: ClientRequest): ClientRequest {
+function mergeAuthHeader (
+  token: string,
+  req: MiddlewareRequest,
+): MiddlewareRequest {
   return {
     ...req,
     headers: {

--- a/packages/commercetools-sdk-middleware-http/src/http.js
+++ b/packages/commercetools-sdk-middleware-http/src/http.js
@@ -15,15 +15,11 @@ import getErrorByCode, {
   HttpError,
 } from './errors'
 
-const defaultApiHost = 'https://api.sphere.io'
-
 export default function createHttpMiddleware (
-  {
-    host = defaultApiHost,
-  }: HttpMiddlewareOptions = {},
+  options: HttpMiddlewareOptions,
 ): Middleware {
   return next => (request: ClientRequest, response: ClientResponse) => {
-    const url = host + request.uri
+    const url = options.host + request.uri
     const body = typeof request.body === 'string'
       ? request.body
       : JSON.stringify(request.body)

--- a/packages/commercetools-sdk-middleware-http/src/http.js
+++ b/packages/commercetools-sdk-middleware-http/src/http.js
@@ -3,8 +3,8 @@ import type {
   HttpErrorType,
   HttpMiddlewareOptions,
   Middleware,
-  ClientRequest,
-  ClientResponse,
+  MiddlewareRequest,
+  MiddlewareResponse,
 } from 'types/sdk'
 
 /* global fetch */
@@ -18,7 +18,7 @@ import getErrorByCode, {
 export default function createHttpMiddleware (
   options: HttpMiddlewareOptions,
 ): Middleware {
-  return next => (request: ClientRequest, response: ClientResponse) => {
+  return next => (request: MiddlewareRequest, response: MiddlewareResponse) => {
     const url = options.host + request.uri
     const body = typeof request.body === 'string'
       ? request.body

--- a/packages/commercetools-sdk-middleware-http/test/http.spec.js
+++ b/packages/commercetools-sdk-middleware-http/test/http.spec.js
@@ -14,14 +14,7 @@ function createTestRequest (options) {
   }
 }
 
-function createTestResponse (options) {
-  return {
-    ...options,
-  }
-}
-
-const defaultHost = 'https://api.sphere.io'
-const customHost = 'https://api.commercetools.co'
+const testHost = 'https://api.commercetools.com'
 
 describe('Http', () => {
   beforeEach(() => {
@@ -33,10 +26,7 @@ describe('Http', () => {
       const request = createTestRequest({
         uri: '/foo/bar',
       })
-      const response = createTestResponse({
-        resolve,
-        reject,
-      })
+      const response = { resolve, reject }
       const next = (req, res) => {
         expect(res).toEqual({
           ...response,
@@ -46,8 +36,8 @@ describe('Http', () => {
         resolve()
       }
       // Use default options
-      const httpMiddleware = createHttpMiddleware()
-      nock(defaultHost)
+      const httpMiddleware = createHttpMiddleware({ host: testHost })
+      nock(testHost)
         .defaultReplyHeaders({
           'Content-Type': 'application/json',
         })
@@ -65,10 +55,7 @@ describe('Http', () => {
         method: 'POST',
         body: { hello: 'world' },
       })
-      const response = createTestResponse({
-        resolve,
-        reject,
-      })
+      const response = { resolve, reject }
       const next = (req, res) => {
         expect(res).toEqual({
           ...response,
@@ -78,8 +65,8 @@ describe('Http', () => {
         resolve()
       }
       // Use custom options
-      const httpMiddleware = createHttpMiddleware({ host: customHost })
-      nock(customHost)
+      const httpMiddleware = createHttpMiddleware({ host: testHost })
+      nock(testHost)
         .defaultReplyHeaders({
           'Content-Type': 'application/json',
         })
@@ -96,24 +83,21 @@ describe('Http', () => {
       const request = createTestRequest({
         uri: '/foo/bar',
       })
-      const response = createTestResponse({
-        resolve,
-        reject,
-      })
+      const response = { resolve, reject }
       const next = (req, res) => {
         expect(res.error.name).toBe('NetworkError')
         expect(res.error.headers).toBeUndefined()
         expect(res.error.originalRequest).toBeDefined()
         expect(res.error.message).toBe(
           // eslint-disable-next-line max-len
-          `request to ${defaultHost}/foo/bar failed, reason: Connection timeout`,
+          `request to ${testHost}/foo/bar failed, reason: Connection timeout`,
         )
         expect(res.body).toBeUndefined()
         expect(res.statusCode).toBe(0)
         resolve()
       }
-      const httpMiddleware = createHttpMiddleware()
-      nock(defaultHost)
+      const httpMiddleware = createHttpMiddleware({ host: testHost })
+      nock(testHost)
         .defaultReplyHeaders({
           'Content-Type': 'application/json',
         })
@@ -129,10 +113,7 @@ describe('Http', () => {
       const request = createTestRequest({
         uri: '/foo/bar',
       })
-      const response = createTestResponse({
-        resolve,
-        reject,
-      })
+      const response = { resolve, reject }
       const next = (req, res) => {
         const expectedError = new Error('oops')
         expectedError.body = {
@@ -151,8 +132,8 @@ describe('Http', () => {
         })
         resolve()
       }
-      const httpMiddleware = createHttpMiddleware()
-      nock(defaultHost)
+      const httpMiddleware = createHttpMiddleware({ host: testHost })
+      nock(testHost)
         .defaultReplyHeaders({
           'Content-Type': 'application/json',
         })
@@ -171,10 +152,7 @@ describe('Http', () => {
       const request = createTestRequest({
         uri: '/foo/bar',
       })
-      const response = createTestResponse({
-        resolve,
-        reject,
-      })
+      const response = { resolve, reject }
       const next = (req, res) => {
         expect(res.error.message).toBe('URI not found: /foo/bar')
         expect(res.error.body).toBeUndefined()
@@ -182,8 +160,8 @@ describe('Http', () => {
         expect(res.statusCode).toBe(404)
         resolve()
       }
-      const httpMiddleware = createHttpMiddleware()
-      nock(defaultHost)
+      const httpMiddleware = createHttpMiddleware({ host: testHost })
+      nock(testHost)
         .defaultReplyHeaders({
           'Content-Type': 'application/json',
         })
@@ -199,10 +177,7 @@ describe('Http', () => {
       const request = createTestRequest({
         uri: '/foo/bar',
       })
-      const response = createTestResponse({
-        resolve,
-        reject,
-      })
+      const response = { resolve, reject }
       const next = (req, res) => {
         expect(res.error.message).toBe('oops')
         expect(res.error.name).toBe('HttpError')
@@ -211,8 +186,8 @@ describe('Http', () => {
         expect(res.statusCode).toBe(415)
         resolve()
       }
-      const httpMiddleware = createHttpMiddleware()
-      nock(defaultHost)
+      const httpMiddleware = createHttpMiddleware({ host: testHost })
+      nock(testHost)
         .defaultReplyHeaders({
           'Content-Type': 'application/json',
         })

--- a/packages/commercetools-sdk-middleware-logger/src/logger.js
+++ b/packages/commercetools-sdk-middleware-logger/src/logger.js
@@ -1,12 +1,12 @@
 /* @flow */
 import type {
   Middleware,
-  ClientRequest,
-  ClientResponse,
+  MiddlewareRequest,
+  MiddlewareResponse,
 } from 'types/sdk'
 
 export default function createLoggerMiddleware (): Middleware {
-  return next => (request: ClientRequest, response: ClientResponse) => {
+  return next => (request: MiddlewareRequest, response: MiddlewareResponse) => {
     const { error, body, statusCode } = response
     console.log('Request: ', request)
     console.log('Response: ', { error, body, statusCode })

--- a/packages/commercetools-sdk-middleware-queue/src/queue.js
+++ b/packages/commercetools-sdk-middleware-queue/src/queue.js
@@ -3,13 +3,13 @@ import type {
   QueueMiddlewareOptions,
   Dispatch,
   Middleware,
-  ClientRequest,
-  ClientResponse,
+  MiddlewareRequest,
+  MiddlewareResponse,
 } from 'types/sdk'
 
 type Task = {
-  request: ClientRequest;
-  response: ClientResponse;
+  request: MiddlewareRequest;
+  response: MiddlewareResponse;
 }
 
 export default function createQueueMiddleware (
@@ -32,7 +32,7 @@ export default function createQueueMiddleware (
     }
   }
 
-  return next => (request: ClientRequest, response: ClientResponse) => {
+  return next => (request: MiddlewareRequest, response: MiddlewareResponse) => {
     // Override response `resolve` and `reject` to know when the request has
     // been completed and therefore trigger a pending task in the queue.
     const patchedResponse = {

--- a/packages/commercetools-sdk-middleware-user-agent/src/user-agent.js
+++ b/packages/commercetools-sdk-middleware-user-agent/src/user-agent.js
@@ -1,8 +1,8 @@
 /* @flow */
 import type {
   Middleware,
-  ClientRequest,
-  ClientResponse,
+  MiddlewareRequest,
+  MiddlewareResponse,
   UserAgentMiddlewareOptions,
 } from 'types/sdk'
 import createHttpUserAgent from '@commercetools/http-user-agent'
@@ -15,7 +15,7 @@ export default function createUserAgentMiddleware (
     ...options,
   })
 
-  return next => (request: ClientRequest, response: ClientResponse) => {
+  return next => (request: MiddlewareRequest, response: MiddlewareResponse) => {
     const requestWithUserAgent = {
       ...request,
       headers: {

--- a/types/sdk.js
+++ b/types/sdk.js
@@ -22,20 +22,11 @@ export type HttpErrorType = {
   }
 }
 export type ClientResponse = {
-  resolve(): void;
-  reject(): void;
   body?: Object;
   error?: HttpErrorType;
   statusCode: number;
 }
 
-// eslint-disable-next-line max-len
-export type Dispatch = (request: ClientRequest, response: ClientResponse) => any;
-export type Middleware = (next: Dispatch) => Dispatch;
-
-export type ClientOptions = {
-  middlewares?: Array<Middleware>;
-}
 export type SuccessResult = {
   body: Object;
   statusCode: number;
@@ -50,6 +41,20 @@ export type ProcessOptions = {
 }
 
 /* Middlewares */
+export type MiddlewareRequest = ClientRequest;
+export type MiddlewareResponse = {
+  resolve(): void;
+  reject(): void;
+  body?: Object;
+  error?: HttpErrorType;
+  statusCode: number;
+}
+// eslint-disable-next-line max-len
+export type Dispatch = (request: MiddlewareRequest, response: MiddlewareResponse) => any;
+export type Middleware = (next: Dispatch) => Dispatch;
+export type ClientOptions = {
+  middlewares: Array<Middleware>;
+}
 export type AuthMiddlewareOptions = {
   host: string;
   projectKey: string;


### PR DESCRIPTION
#### Summary
Add `MiddlewareRequest` and `MiddlewareResponse` types, which are slightly different from `ClientRequest` and `ClientResponse`. This is to avoid some confusions around some return types.
