### PR TITLE
Safely check for browser env when accessing global.window

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,13 +13,13 @@
     "build": "lerna exec -- babel src --out-dir lib",
     "dist": "lerna run dist",
     "lint": "flow check && ./scripts/lint packages",
-    "test": "npm run build && lerna exec -- jest",
+    "test": "npm run build && jest --config test-config.json",
     "test:package": "npm run build && ./scripts/test-package",
     "it": "npm run it:install && npm run it:run",
     "it:run": "jest --config integration-tests/config.json",
     "it:install": "npm run build && ./scripts/install-npm-packages-for-integration-tests",
-    "coverage": "npm run build && jest --no-watchman --coverage",
-    "coverage:ci": "jest --no-watchman --coverage && codecov",
+    "coverage": "npm run build && jest --config test-config.json --no-watchman --coverage",
+    "coverage:ci": "jest --config test-config.json --no-watchman --coverage && codecov",
     "semantic-release": "lerna-semantic-release pre && lerna-semantic-release post && lerna-semantic-release perform",
     "docs:clean": "rimraf _book",
     "docs:prepare": "gitbook install",
@@ -120,19 +120,5 @@
         "babel-module": {}
       }
     }
-  },
-  "jest": {
-    "globals": {
-      "process.env": {
-        "NODE_ENV": "test"
-      }
-    },
-    "testPathIgnorePatterns": [
-      "/node_modules/",
-      "/integration-tests/",
-      "/packages/.*/node_modules",
-      "/packages/.*/dist",
-      "/packages/.*/lib"
-    ]
   }
 }

--- a/packages/commercetools-http-user-agent/src/create-user-agent.js
+++ b/packages/commercetools-http-user-agent/src/create-user-agent.js
@@ -1,12 +1,9 @@
 /* @flow */
-import type {
-  HttpUserAgentOptions,
-} from 'types/sdk'
+import type { HttpUserAgentOptions } from 'types/sdk'
 /* global window */
 
 export default function createUserAgent (
   options: HttpUserAgentOptions,
-  windowObject: Object = window,
 ): string {
   if (
     !options ||
@@ -37,7 +34,7 @@ export default function createUserAgent (
     contactInfo = `(+${options.contactUrl}; +${options.contactEmail})`
 
   // System info
-  const systemInfo = getSystemInfo(windowObject)
+  const systemInfo = getSystemInfo()
 
   return [
     baseInfo,
@@ -47,9 +44,29 @@ export default function createUserAgent (
   ].filter((x: ?string): boolean => Boolean(x)).join(' ')
 }
 
-function getSystemInfo (windowObject: Object): string {
-  if (windowObject && windowObject.navigator)
-    return windowObject.navigator.userAgent
+
+/*
+  This is the easiest way, for this use case, to detect if we're running in
+  Node.js or in a browser environment. In other cases, this won't be even a
+  problem as webpack will provide the correct polyfill in the bundle.
+  The main advantage by doing it this way is that it allows to easily test
+  the code running in both environments, by overriding `global.window` in
+  the specific test.
+  If we were to use checks at compile time (e.g. `webpack.DefinePlugin`) it
+  would not be possible / easy to test such cases.
+  Same thing for defining different entry points.
+
+  The code below, on runtime, will evaluate the function expression, returning
+  `true` or `false` if `window` is a global object.
+*/
+// eslint-disable-next-line no-new-func
+const isBrowser = new Function(
+  'try { return typeof window === "object" } catch (e) { return false }',
+)
+
+function getSystemInfo (): string {
+  if (isBrowser())
+    return window.navigator.userAgent
 
   const nodeVersion = process.version.slice(1)
   const platformInfo = `(${process.platform}; ${process.arch})`

--- a/packages/commercetools-http-user-agent/test/create-user-agent.spec.js
+++ b/packages/commercetools-http-user-agent/test/create-user-agent.spec.js
@@ -1,6 +1,15 @@
 import createHttpUserAgent from '../src'
 
+// eslint-disable-next-line max-len
+const userAgentBrowser = 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_11_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/55.0.2883.95 Safari/537.36'
+
 describe('for browser', () => {
+  const originalWindow = global.window
+  global.window = {
+    navigator: {
+      userAgent: userAgentBrowser,
+    },
+  }
   const userAgent = createHttpUserAgent({
     name: 'commercetools-node-sdk',
     version: '1.0.0',
@@ -9,17 +18,15 @@ describe('for browser', () => {
     contactUrl: 'https://commercetools.com',
     contactEmail: 'helpdesk@commercetools.com',
   })
+  // Reset original `global.window`
+  global.window = originalWindow
 
   it('has sdk info', () => {
     expect(userAgent).toMatch('commercetools-node-sdk/1.0.0')
   })
   it('has browser info', () => {
     // because we use jsdom
-    expect(userAgent).toMatch('Node.js')
-  })
-  it('has browser version', () => {
-    // because we use jsdom
-    expect(userAgent).toMatch(process.version.slice(1))
+    expect(userAgent).toMatch(userAgentBrowser)
   })
   it('has library info', () => {
     expect(userAgent).toMatch('my-awesome-library/1.0.0')
@@ -33,17 +40,14 @@ describe('for browser', () => {
 })
 
 describe('for node', () => {
-  const userAgent = createHttpUserAgent(
-    {
-      name: 'commercetools-node-sdk',
-      version: '1.0.0',
-      libraryName: 'my-awesome-library',
-      libraryVersion: '1.0.0',
-      contactUrl: 'https://commercetools.com',
-      contactEmail: 'helpdesk@commercetools.com',
-    },
-    { /* to prevent using the window object */ },
-  )
+  const userAgent = createHttpUserAgent({
+    name: 'commercetools-node-sdk',
+    version: '1.0.0',
+    libraryName: 'my-awesome-library',
+    libraryVersion: '1.0.0',
+    contactUrl: 'https://commercetools.com',
+    contactEmail: 'helpdesk@commercetools.com',
+  })
 
   it('has sdk info', () => {
     expect(userAgent).toMatch('commercetools-node-sdk/1.0.0')
@@ -79,59 +83,44 @@ describe('validation', () => {
 
 describe('optional information', () => {
   it('create user agent with only library name (missing version)', () => {
-    const userAgent = createHttpUserAgent(
-      {
-        name: 'commercetools-node-sdk',
-        libraryName: 'my-awesome-library',
-      },
-      { /* to prevent using the window object */ },
-    )
+    const userAgent = createHttpUserAgent({
+      name: 'commercetools-node-sdk',
+      libraryName: 'my-awesome-library',
+    })
     // eslint-disable-next-line max-len
     expect(userAgent).toBe(`commercetools-node-sdk Node.js/${process.version.slice(1)} (${process.platform}; ${process.arch}) my-awesome-library`)
   })
   it('create user agent with library name and version', () => {
-    const userAgent = createHttpUserAgent(
-      {
-        name: 'commercetools-node-sdk',
-        libraryName: 'my-awesome-library',
-        libraryVersion: '1.0.0',
-      },
-      { /* to prevent using the window object */ },
-    )
+    const userAgent = createHttpUserAgent({
+      name: 'commercetools-node-sdk',
+      libraryName: 'my-awesome-library',
+      libraryVersion: '1.0.0',
+    })
     // eslint-disable-next-line max-len
     expect(userAgent).toBe(`commercetools-node-sdk Node.js/${process.version.slice(1)} (${process.platform}; ${process.arch}) my-awesome-library/1.0.0`)
   })
   it('create user agent with contact url', () => {
-    const userAgent = createHttpUserAgent(
-      {
-        name: 'commercetools-node-sdk',
-        contactUrl: 'https://commercetools.com',
-      },
-      { /* to prevent using the window object */ },
-    )
+    const userAgent = createHttpUserAgent({
+      name: 'commercetools-node-sdk',
+      contactUrl: 'https://commercetools.com',
+    })
     // eslint-disable-next-line max-len
     expect(userAgent).toBe(`commercetools-node-sdk Node.js/${process.version.slice(1)} (${process.platform}; ${process.arch}) (+https://commercetools.com)`)
   })
   it('create user agent with contact email', () => {
-    const userAgent = createHttpUserAgent(
-      {
-        name: 'commercetools-node-sdk',
-        contactEmail: 'helpdesk@commercetools.com',
-      },
-      { /* to prevent using the window object */ },
-    )
+    const userAgent = createHttpUserAgent({
+      name: 'commercetools-node-sdk',
+      contactEmail: 'helpdesk@commercetools.com',
+    })
     // eslint-disable-next-line max-len
     expect(userAgent).toBe(`commercetools-node-sdk Node.js/${process.version.slice(1)} (${process.platform}; ${process.arch}) (+helpdesk@commercetools.com)`)
   })
   it('create user agent with full contact info', () => {
-    const userAgent = createHttpUserAgent(
-      {
-        name: 'commercetools-node-sdk',
-        contactUrl: 'https://commercetools.com',
-        contactEmail: 'helpdesk@commercetools.com',
-      },
-      { /* to prevent using the window object */ },
-    )
+    const userAgent = createHttpUserAgent({
+      name: 'commercetools-node-sdk',
+      contactUrl: 'https://commercetools.com',
+      contactEmail: 'helpdesk@commercetools.com',
+    })
     // eslint-disable-next-line max-len
     expect(userAgent).toBe(`commercetools-node-sdk Node.js/${process.version.slice(1)} (${process.platform}; ${process.arch}) (+https://commercetools.com; +helpdesk@commercetools.com)`)
   })

--- a/packages/commercetools-sdk-middleware-auth/src/build-requests.js
+++ b/packages/commercetools-sdk-middleware-auth/src/build-requests.js
@@ -1,9 +1,5 @@
 /* @flow */
-import type {
-  AuthMiddlewareOptions,
-} from 'types/sdk'
-
-/* global window */
+import type { AuthMiddlewareOptions } from 'types/sdk'
 import * as authScopes from './scopes'
 
 type BuiltRequestParams = {
@@ -37,7 +33,7 @@ export function buildRequestForClientCredentialsFlow (
   const defaultScope = `${authScopes.MANAGE_PROJECT}:${options.projectKey}`
   const scope = (options.scopes || [defaultScope]).join(' ')
 
-  const basicAuth = getBasicAuth(clientId, clientSecret)
+  const basicAuth = new Buffer(`${clientId}:${clientSecret}`).toString('base64')
   const url = `${options.host}/oauth/token`
   const body = `grant_type=client_credentials&scope=${scope}`
 
@@ -54,20 +50,4 @@ export function buildRequestForRefreshTokenFlow () {
 
 export function buildRequestForAnonymousSessionFlow () {
   // TODO
-}
-
-export function getBasicAuth (
-  username: string,
-  password: string,
-  windowObject: Object = window,
-): string {
-  const basicAuth = `${username}:${password}`
-  if (
-    windowObject &&
-    windowObject.btoa &&
-    typeof windowObject.btoa === 'function'
-  )
-    return windowObject.btoa(basicAuth)
-
-  return new Buffer(basicAuth).toString('base64')
 }

--- a/packages/commercetools-sdk-middleware-auth/src/client-credentials-flow.js
+++ b/packages/commercetools-sdk-middleware-auth/src/client-credentials-flow.js
@@ -8,9 +8,7 @@ import type {
 
 /* global fetch */
 import 'isomorphic-fetch'
-import {
-  buildRequestForClientCredentialsFlow,
-} from './build-requests'
+import { buildRequestForClientCredentialsFlow } from './build-requests'
 
 type TokenCache = {
   token: string;

--- a/packages/commercetools-sdk-middleware-auth/test/build-requests.spec.js
+++ b/packages/commercetools-sdk-middleware-auth/test/build-requests.spec.js
@@ -3,7 +3,6 @@ import {
   // buildRequestForPasswordFlow,
   // buildRequestForRefreshTokenFlow,
   // buildRequestForAnonymousSessionFlow,
-  getBasicAuth,
 } from '../src/build-requests'
 import { scopes } from '../src'
 
@@ -78,19 +77,5 @@ describe('buildRequestForClientCredentialsFlow', () => {
     expect(
       () => buildRequestForClientCredentialsFlow(options),
     ).toThrowError('Missing required credentials (clientId, clientSecret)')
-  })
-})
-
-describe('getBasicAuth', () => {
-  it('return encoded base64 value', () => {
-    expect(getBasicAuth('foo', 'bar', {})).toBe('Zm9vOmJhcg==')
-  })
-
-  it('simulate encoding in browser environment', () => {
-    const spy = jest.fn((value) => {
-      expect(value).toBe('foo:bar')
-      return new Buffer(value).toString('base64')
-    })
-    expect(getBasicAuth('foo', 'bar', { btoa: spy })).toBe('Zm9vOmJhcg==')
   })
 })

--- a/scripts/test-package
+++ b/scripts/test-package
@@ -23,7 +23,7 @@ select package in "${packages[@]}"; do
 done
 
 if [ -z "$flag" ]; then
-  $(npm bin)/lerna --scope $selected_package exec -- $(pwd)/node_modules/.bin/jest
+  $(npm bin)/lerna --scope $selected_package exec -- $(pwd)/node_modules/.bin/jest --config $(pwd)/test-config.json
 else
-  $(npm bin)/lerna --scope $selected_package exec -- $(pwd)/node_modules/.bin/jest $flag
+  $(npm bin)/lerna --scope $selected_package exec -- $(pwd)/node_modules/.bin/jest --config $(pwd)/test-config.json $flag
 fi

--- a/test-config.json
+++ b/test-config.json
@@ -1,0 +1,15 @@
+{
+  "globals": {
+    "process.env": {
+      "NODE_ENV": "test"
+    }
+  },
+  "testEnvironment": "node",
+  "testPathIgnorePatterns": [
+    "/node_modules/",
+    "/integration-tests/",
+    "/packages/.*/node_modules",
+    "/packages/.*/dist",
+    "/packages/.*/lib"
+  ]
+}


### PR DESCRIPTION
Fixes #46

#### Summary
This PR fixes the problem in `node` environment caused by `global.window`.

#### Description
For `auth`, since we were using `Buffer` anyway, we can simply use the polyfill provided by webpack.
For `user-agent` it's fixed (see comment) in a different way, but allows to easily test it.

Additionally, I realised that running the tests scoped by package didn't use the jest config defined in `package.json` (because of the directory context), so I've put the config into a `test-config.json` file and each script running `jest` will reference to the file config.
And tests run in `node` environment now by default (jest uses `jsdom` by default). 