### PR TITLE
feat(sdk-middleware-auth): allow to pass custom uri

### DIFF
--- a/packages/sdk-middleware-auth/src/build-requests.js
+++ b/packages/sdk-middleware-auth/src/build-requests.js
@@ -34,7 +34,10 @@ export function buildRequestForClientCredentialsFlow (
   const scope = (options.scopes || [defaultScope]).join(' ')
 
   const basicAuth = new Buffer(`${clientId}:${clientSecret}`).toString('base64')
-  const url = `${options.host.replace(/\/$/, '')}/oauth/token`
+  // This is mostly useful for internal testing purposes to be able to check
+  // other oauth endpoints.
+  const oauthUri = options.oauthUri || '/oauth/token'
+  const url = options.host.replace(/\/$/, '') + oauthUri
   const body = `grant_type=client_credentials&scope=${scope}`
 
   return { basicAuth, url, body }

--- a/packages/sdk-middleware-auth/test/build-requests.spec.js
+++ b/packages/sdk-middleware-auth/test/build-requests.spec.js
@@ -31,6 +31,15 @@ describe('buildRequestForClientCredentialsFlow', () => {
     })
   })
 
+  it('uses custom oauth uri, if given', () => {
+    const options = createTestOptions({ oauthUri: '/foo/bar' })
+    expect(buildRequestForClientCredentialsFlow(options)).toEqual({
+      basicAuth: 'MTIzOnNlY3JldA==',
+      url: 'http://localhost:8080/foo/bar',
+      body: `grant_type=client_credentials&scope=${allScopes.join(' ')}`,
+    })
+  })
+
   it('parses a host that ends with slash', () => {
     const options = createTestOptions({
       host: 'http://localhost:8080/',

--- a/types/sdk.js
+++ b/types/sdk.js
@@ -68,6 +68,8 @@ export type AuthMiddlewareOptions = {
     clientSecret: string;
   };
   scopes: Array<string>;
+  // For internal usage only
+  oauthUri: string;
 }
 export type HttpMiddlewareOptions = {
   host: string;


### PR DESCRIPTION
#### Summary
Allow to pass a custom `oauthUri`, mostly useful for internal usage.

#### Todo
- Tests
    - [x] Unit
- [ ] ~~Documentation~~ (because it's meant to be used only internally)
