### PR TITLE
feat(apiRequestBuilder): Add a support for project endpoint

### DIFF
--- a/packages/api-request-builder/src/default-services.js
+++ b/packages/api-request-builder/src/default-services.js
@@ -183,6 +183,13 @@ export default {
       features.queryExpand,
     ],
   },
+  project: {
+    type: 'project',
+    endpoint: '/',
+    features: [
+      features.query,
+    ],
+  },
   reviews: {
     type: 'reviews',
     endpoint: '/reviews',

--- a/packages/api-request-builder/test/create-request-builder.spec.js
+++ b/packages/api-request-builder/test/create-request-builder.spec.js
@@ -25,6 +25,7 @@ const expectedServiceKeys = [
   'productProjectionsSuggest',
   'products',
   'productTypes',
+  'project',
   'reviews',
   'shippingMethods',
   'shoppingLists',


### PR DESCRIPTION
#### Summary
Resolves #132 

#### Description
This PR adds a project endpoint to the list of default endpoints so it can be used on Impex.

#### Todo
- Tests
    - [x] Unit
    - [ ] Integration
    - [ ] Acceptance
- [ ] Documentation
<!-- Two persons should review a PR, don't forget to assign them. -->
