### PR TITLE
User can't add/change inventory quantity to 0

### DIFF
--- a/packages/sync-actions/package.json
+++ b/packages/sync-actions/package.json
@@ -33,6 +33,7 @@
     "jsondiffpatch": "0.2.4",
     "lodash.flatten": "4.4.0",
     "lodash.foreach": "4.5.0",
+    "lodash.isnil": "4.0.0",
     "lodash.uniqwith": "4.5.0"
   }
 }

--- a/packages/sync-actions/src/utils/common-actions.js
+++ b/packages/sync-actions/src/utils/common-actions.js
@@ -1,3 +1,4 @@
+import isNil from 'lodash.isnil'
 import clone from './clone'
 import * as diffpatcher from './diffpatcher'
 
@@ -24,18 +25,19 @@ export function buildBaseAttributesActions ({
       const delta = diff[key]
       const before = oldObj[key]
       const now = newObj[key]
-
+      const hasBefore = !isNil(oldObj[key])
+      const hasNow = !isNil(newObj[key])
       if (!delta) return undefined
 
-      if (!now && !before) return undefined
+      if (!hasNow && !hasBefore) return undefined
 
-      if (now && !before) // no value previously set
+      if (hasNow && !hasBefore) // no value previously set
         return { action: item.action, [actionKey]: now }
 
-      if (!now && !{}.hasOwnProperty.call(newObj, key)) // no new value
+      if (!hasNow && !{}.hasOwnProperty.call(newObj, key)) // no new value
         return undefined
 
-      if (!now && {}.hasOwnProperty.call(newObj, key)) // value unset
+      if (!hasNow && {}.hasOwnProperty.call(newObj, key)) // value unset
         return { action: item.action }
 
       // We need to clone `before` as `patch` will mutate it

--- a/packages/sync-actions/src/utils/common-actions.js
+++ b/packages/sync-actions/src/utils/common-actions.js
@@ -25,19 +25,20 @@ export function buildBaseAttributesActions ({
       const delta = diff[key]
       const before = oldObj[key]
       const now = newObj[key]
-      const hasBefore = !isNil(oldObj[key])
-      const hasNow = !isNil(newObj[key])
+      const isNotDefinedBefore = isNil(oldObj[key])
+      const isNotDefinedNow = isNil(newObj[key])
       if (!delta) return undefined
 
-      if (!hasNow && !hasBefore) return undefined
+      if (isNotDefinedNow && isNotDefinedBefore) return undefined
 
-      if (hasNow && !hasBefore) // no value previously set
+      if (!isNotDefinedNow && isNotDefinedBefore) // no value previously set
         return { action: item.action, [actionKey]: now }
 
-      if (!hasNow && !{}.hasOwnProperty.call(newObj, key)) // no new value
+      /* no new value */
+      if (isNotDefinedNow && !{}.hasOwnProperty.call(newObj, key))
         return undefined
 
-      if (!hasNow && {}.hasOwnProperty.call(newObj, key)) // value unset
+      if (isNotDefinedNow && {}.hasOwnProperty.call(newObj, key)) // value unset
         return { action: item.action }
 
       // We need to clone `before` as `patch` will mutate it

--- a/packages/sync-actions/test/utils/common-actions.spec.js
+++ b/packages/sync-actions/test/utils/common-actions.spec.js
@@ -7,11 +7,35 @@ import * as diffpatcher from '../../src/utils/diffpatcher'
 describe('Common actions', () => {
   describe('::buildBaseAttributesActions', () => {
     const testActions = [
-      { action: 'changeName', key: 'name' },
-      { action: 'setDescription', key: 'description' },
-      { action: 'setExternalId', key: 'externalId' },
-      { action: 'changeSlug', key: 'slug' },
-      { action: 'setCustomerNumber', key: 'customerNumber' },
+      {
+        action: 'changeName',
+        key: 'name',
+      },
+      {
+        action: 'setDescription',
+        key: 'description',
+      },
+      {
+        action: 'setExternalId',
+        key: 'externalId',
+      },
+      {
+        action: 'changeSlug',
+        key: 'slug',
+      },
+      {
+        action: 'setCustomerNumber',
+        key: 'customerNumber',
+      },
+      {
+        action: 'setCustomerNumber',
+        key: 'customerNumber',
+      },
+      {
+        action: 'changeQuantity',
+        key: 'quantityOnStock',
+        actionKey: 'quantity',
+      },
     ]
 
     it('should build base actions', () => {
@@ -21,6 +45,7 @@ describe('Common actions', () => {
         externalId: '123',
         slug: { en: 'foo' },
         customerNumber: undefined,
+        quantityOnStock: 1,
       }
       const now = {
         name: { en: 'Foo1', de: 'Foo2' },
@@ -28,6 +53,7 @@ describe('Common actions', () => {
         externalId: null,
         slug: { en: 'foo' },
         customerNumber: null,
+        quantityOnStock: 0,
       }
 
       const actions = buildBaseAttributesActions({
@@ -41,6 +67,7 @@ describe('Common actions', () => {
         { action: 'changeName', name: now.name },
         { action: 'setDescription', description: now.description },
         { action: 'setExternalId' },
+        { action: 'changeQuantity', quantity: now.quantityOnStock },
       ])
     })
   })


### PR DESCRIPTION
This will fix https://github.com/commercetools/nodejs/issues/145

#### Summary
At the moment, if you try to add/change a inventory quantity with number "0" the API returns a bad request error

#### Description
This is happening because 0 is falsy, and on the buildBaseAttributesActions function it relies only on the value in order to define what to return
I have added a variable to check the existence of the value (`hasNow` and `hasBefore`), so 0 wouldn't return false in this case.

#### Todo

- Tests
    - [x] Acceptance
