### PR TITLE
feat(product/variants): add support for key field on variants

### DIFF
--- a/packages/sync-actions/src/product-actions.js
+++ b/packages/sync-actions/src/product-actions.js
@@ -143,7 +143,12 @@ export function actionsMapAttributes (
       masterVariant,
       oldObj.masterVariant,
     )
+    const keyAction = _buildKeyActions(
+      masterVariant,
+      oldObj.masterVariant,
+    )
     if (skuAction) actions.push(skuAction)
+    if (keyAction) actions.push(keyAction)
 
     const { attributes } = masterVariant
     const attrActions = _buildVariantAttributesActions(
@@ -160,7 +165,10 @@ export function actionsMapAttributes (
       if (REGEX_NUMBER.test(key) && !Array.isArray(variant)) {
         const skuAction =
           _buildSkuActions(variant, oldObj.variants[key])
+        const keyAction =
+          _buildKeyActions(variant, oldObj.variants[key])
         if (skuAction) actions.push(skuAction)
+        if (keyAction) actions.push(keyAction)
 
         const { attributes } = variant
         const attrActions = _buildVariantAttributesActions(
@@ -262,6 +270,20 @@ function _buildSkuActions (variantDiff, oldVariant) {
       action: 'setSku',
       variantId: oldVariant.id,
       sku: newValue || null,
+    }
+  }
+  return null
+}
+
+function _buildKeyActions (variantDiff, oldVariant) {
+  if ({}.hasOwnProperty.call(variantDiff, 'key')) {
+    const newValue = diffpatcher.getDeltaValue(variantDiff.key)
+    if (!newValue && !oldVariant.key) return null
+
+    return {
+      action: 'setProductVariantKey',
+      variantId: oldVariant.id,
+      key: newValue || null,
     }
   }
   return null


### PR DESCRIPTION
affects: @commercetools/sync-actions

The API supports a key and sku field for product variants. The sku field is supported as an action
on the sync actions they key field not so far.

#### Summary

Adds the setProductVariantKey action to be supported on the master variant as any other variant.

#### Todo

- Tests
    - [x] Unit
    - [ ] Integration
    - [ ] Acceptance
- [ ] Documentation
<!-- Two persons should review a PR, don't forget to assign them. -->
