### PR TITLE
fix(inventories-exporter): Change custom field prefix name

### DIFF
--- a/integration-tests/cli/discount-code-importer.it.js
+++ b/integration-tests/cli/discount-code-importer.it.js
@@ -9,6 +9,7 @@ import { createRequestBuilder } from '@commercetools/api-request-builder'
 import { createHttpMiddleware } from '@commercetools/sdk-middleware-http'
 import { exec } from 'child_process'
 import { getCredentials } from '@commercetools/get-credentials'
+import { clearData } from './helpers/utils'
 import DiscountCodeImport from '../../packages/discount-code-importer/src/main'
 
 let projectKey
@@ -47,6 +48,10 @@ describe('DiscountCode tests', () => {
           createHttpMiddleware({ host: apiConfig.apiUrl }),
         ],
       })
+
+      return clearData(apiConfig, 'discountCodes')
+    })
+    .then(() => {
       const cartDiscountDraft = fs.readFileSync(
         path.join(__dirname, './helpers/cartDiscountDraft.json'), 'utf8',
       )

--- a/integration-tests/cli/discount-code-importer.it.js
+++ b/integration-tests/cli/discount-code-importer.it.js
@@ -51,6 +51,7 @@ describe('DiscountCode tests', () => {
 
       return clearData(apiConfig, 'discountCodes')
     })
+    .then(() => clearData(apiConfig, 'cartDiscounts'))
     .then(() => {
       const cartDiscountDraft = fs.readFileSync(
         path.join(__dirname, './helpers/cartDiscountDraft.json'), 'utf8',

--- a/integration-tests/cli/inventories-exporter.it.js
+++ b/integration-tests/cli/inventories-exporter.it.js
@@ -28,8 +28,9 @@ describe('StockExporter CLI', () => {
           clientSecret: credentials.clientSecret,
         },
       }
-      return clearData(apiConfig, 'inventory')
+      return clearData(apiConfig, 'orders')
     })
+    .then(() => clearData(apiConfig, 'inventory'))
     .then(() => clearData(apiConfig, 'types'))
     .then(() => createData(apiConfig, 'types', customFields))
     .then(() => createData(apiConfig, 'inventory', inventories))

--- a/integration-tests/cli/inventories-exporter.it.js
+++ b/integration-tests/cli/inventories-exporter.it.js
@@ -97,7 +97,7 @@ describe('StockExporter CLI', () => {
           expect(cliError && stderr).toBeFalsy()
           fs.readFile(csvFilePath, { encoding: 'utf8' }, (error, data) => {
             const expectedResult = stripIndent`
-              sku,quantityOnStock,customType,custom.description
+              sku,quantityOnStock,customType,customField.description
               12345,20,inventory-custom-type,integration tests!! arrgggh
             `
             expect(data).toEqual(expectedResult)

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "check-node-version": "2.1.0",
     "codecov": "2.2.0",
     "commitizen": "2.9.6",
+    "common-tags": "^1.4.0",
     "cross-env": "5.0.0",
     "cz-lerna-changelog": "1.2.1",
     "eslint": "3.19.0",

--- a/packages/inventories-exporter/src/main.js
+++ b/packages/inventories-exporter/src/main.js
@@ -199,7 +199,7 @@ export default class InventoryExporter {
       result.customType = customObj.type.obj.key
       const keys = Object.keys(customObj.fields)
       keys.forEach((key: string) => {
-        result[`custom.${key}`] = customObj.fields[key]
+        result[`customField.${key}`] = customObj.fields[key]
       })
     }
     return result

--- a/packages/inventories-exporter/test/main.spec.js
+++ b/packages/inventories-exporter/test/main.spec.js
@@ -283,8 +283,8 @@ describe('InventoryExporter', () => {
         ...inventory,
         supplyChannel: 'abi',
         customType: 'my-type',
-        'custom.nac': 'foo',
-        'custom.weg': 'Bearer',
+        'customField.nac': 'foo',
+        'customField.weg': 'Bearer',
       }
       delete expectedResult.custom // remove unused fields
       const result = InventoryExporter.inventoryMappings(inventory)


### PR DESCRIPTION
Fixes #246 

#### Summary
Inventories importer expects custom fields to be prefixed with `customField` name not just `custom`.

#### Todo

- Tests
    - [x] Unit
    - [x] Integration
    - [ ] Acceptance
- [ ] Documentation
<!-- Two persons should review a PR, don't forget to assign them. -->
