### PR TITLE
fix(api-request-builder): update link to the docs

### DIFF
--- a/packages/api-request-builder/README.md
+++ b/packages/api-request-builder/README.md
@@ -2,7 +2,7 @@
 
 Helper functions collection to easily construct API requests URI in a declarative way, for usage with `@commercetools/sdk-client`.
 
-https://commercetools.github.io/nodejs/docs/sdk/api/#api-request-builder
+https://commercetools.github.io/nodejs/sdk/api/apiRequestBuilder.html
 
 ## Install
 


### PR DESCRIPTION
#### Description
The old endpoint didn't work anymore.

