### PR TITLE
chore(integration-tests): add separate project for each int test

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -31,7 +31,7 @@ accurate comments, etc.) and any other requirements (such as test coverage).
 
 5. Integration tests are separated out in another folder "/integration-tests". To run the integration test, you need to create a env file as specified [here](https://commercetools.github.io/nodejs/sdk/api/getCredentials.html). Then run integration test with
   ```
-  npm run it -- --projectkey=testing-project
+  npm run it -- --projectkey=testing-project --runInBand
   ```
   replace "testing-project" with your project
 

--- a/integration-tests/cli/csv-parser-price.it.js
+++ b/integration-tests/cli/csv-parser-price.it.js
@@ -17,7 +17,7 @@ import { version } from '../../packages/csv-parser-price/package.json'
 
 let projectKey
 if (process.env.CI === 'true')
-  projectKey = 'node-sdk-integration-tests'
+  projectKey = 'price-parser-integration-test'
 else
   projectKey = process.env.npm_config_projectkey
 

--- a/integration-tests/cli/discount-codes.it.js
+++ b/integration-tests/cli/discount-codes.it.js
@@ -11,7 +11,7 @@ import DiscountCodeImport from '../../packages/discount-code-importer/src/main'
 
 let projectKey
 if (process.env.CI === 'true')
-  projectKey = 'node-sdk-integration-tests'
+  projectKey = 'discount-codes-integration-test'
 else
   projectKey = process.env.npm_config_projectkey
 

--- a/integration-tests/cli/inventories-exporter.it.js
+++ b/integration-tests/cli/inventories-exporter.it.js
@@ -10,7 +10,7 @@ import { version } from '../../packages/inventories-exporter/package.json'
 
 let projectKey
 if (process.env.CI === 'true')
-  projectKey = 'node-sdk-integration-tests'
+  projectKey = 'inventories-export-integration-test'
 else
   projectKey = process.env.npm_config_projectkey
 


### PR DESCRIPTION
Add separate project for each int test to avoid race conditions in CI
update contributing to run
int tests in sequence on user machine with the same project

resolves #265 