### PR TITLE
feat(sdk-client): limit returned items with processFn

### DIFF
--- a/docs/sdk/api/sdkClient.md
+++ b/docs/sdk/api/sdkClient.md
@@ -62,6 +62,7 @@ Returns a `Promise` with the accumulated result of each `processFn` calls.
 - `processFn` *(Function)*: A function that gets called on each API page iteration. The function gets as an argument the response of the API request and should return a `Promise` which will trigger the next iteration.
 - `options` *(Object)*
   - `accumulate` *(Boolean)*: (default `true`) a flag to indicate whether all the results of the iterations should be accumulated. This is useful if you want to e.g. fetch all the entities of an API endpoint and do something with it at the end. _Be careful that this might lead to memory problems if the fetched data gets too big. If it's not necessary to have all the data when the process function resolves, it's recommended to disable this option_.
+  - `total` *(Number)*: a number to indicate the total amount of items to be fetched from all API calls
 
 #### Usage example
 
@@ -111,7 +112,7 @@ client.process(
       ),
     )
   },
-  { accumulate: false },
+  { accumulate: false, total: 40 },
 )
 .then(result => ...)
 .catch(error => ...)

--- a/packages/sdk-client/src/client.js
+++ b/packages/sdk-client/src/client.js
@@ -82,11 +82,12 @@ export default function createClient (options: ClientOptions): Client {
 
       return new Promise((resolve, reject) => {
         const [path, queryString] = request.uri.split('?')
+        const requestQuery = qs.parse(queryString)
         const query = {
           // defaults
           limit: 20,
           // merge given query params
-          ...qs.parse(queryString),
+          ...requestQuery,
         }
         const originalQueryString = qs.stringify(query)
 
@@ -111,13 +112,13 @@ export default function createClient (options: ClientOptions): Client {
               if (opt.accumulate)
                 accumulated = acc.concat(result || [])
 
-              // If we get less results in a page then the limit set it means
-              // that there are no more pages and that we can finally resolve
-              // the promise.
-              if (resultsLength < query.limit) {
+              // If a limit was specified in the original request, fetch the
+              // limit and resolve.
+              // Also, if we get less results in a page then the limit set it
+              // means that there are no more pages and that we can finally
+              // resolve the promise.
+              if ((resultsLength < query.limit) || requestQuery.limit)
                 resolve(accumulated || [])
-                return
-              }
 
               const last = payload.body.results[resultsLength - 1]
               const newLastId = last && last.id

--- a/packages/sdk-client/src/client.js
+++ b/packages/sdk-client/src/client.js
@@ -82,7 +82,7 @@ export default function createClient (options: ClientOptions): Client {
 
       return new Promise((resolve, reject) => {
         const [path, queryString] = request.uri.split('?')
-        const requestQuery = qs.parse(queryString)
+        const requestQuery = { ...qs.parse(queryString) }
         const query = {
           // defaults
           limit: 20,
@@ -117,8 +117,10 @@ export default function createClient (options: ClientOptions): Client {
               // Also, if we get less results in a page then the limit set it
               // means that there are no more pages and that we can finally
               // resolve the promise.
-              if ((resultsLength < query.limit) || requestQuery.limit)
+              if ((resultsLength < query.limit) || requestQuery.limit) {
                 resolve(accumulated || [])
+                return
+              }
 
               const last = payload.body.results[resultsLength - 1]
               const newLastId = last && last.id

--- a/packages/sdk-client/src/client.js
+++ b/packages/sdk-client/src/client.js
@@ -72,7 +72,7 @@ export default function createClient (options: ClientOptions): Client {
     process (
       request: ClientRequest,
       fn: ProcessFn,
-      opt: ProcessOptions = { accumulate: true },
+      processOpt: ProcessOptions,
     ): Promise<Array<Object>> {
       validate('process', request, { allowedMethods: ['GET'] })
 
@@ -80,6 +80,12 @@ export default function createClient (options: ClientOptions): Client {
       // eslint-disable-next-line max-len
         throw new Error('The "process" function accepts a "Function" as a second argument that returns a Promise. See https://commercetools.github.io/nodejs/sdk/api/sdkClient.html#processrequest-processfn-options')
 
+      // Set default process options
+      const opt = {
+        total: Number.POSITIVE_INFINITY,
+        accumulate: true,
+        ...processOpt,
+      }
       return new Promise((resolve, reject) => {
         const [path, queryString] = request.uri.split('?')
         const requestQuery = { ...qs.parse(queryString) }
@@ -89,9 +95,13 @@ export default function createClient (options: ClientOptions): Client {
           // merge given query params
           ...requestQuery,
         }
-        const originalQueryString = qs.stringify(query)
 
+        let itemsToGet = opt.total
         const processPage = (lastId?: string, acc?: Array<any> = []) => {
+          // Use the lesser value between limit and itemsToGet in query
+          const limit = query.limit < itemsToGet ? query.limit : itemsToGet
+          const originalQueryString = qs.stringify({ ...query, limit })
+
           const enhancedQuery = {
             sort: 'id asc',
             withTotal: false,
@@ -112,12 +122,14 @@ export default function createClient (options: ClientOptions): Client {
               if (opt.accumulate)
                 accumulated = acc.concat(result || [])
 
-              // If a limit was specified in the original request, fetch the
-              // limit and resolve.
+              itemsToGet -= resultsLength
+              // If there are no more items to get, it means the total number
+              // of items in the original request have been fetched so we
+              // resolve the promise.
               // Also, if we get less results in a page then the limit set it
               // means that there are no more pages and that we can finally
               // resolve the promise.
-              if ((resultsLength < query.limit) || requestQuery.limit) {
+              if ((resultsLength < query.limit) || !(itemsToGet)) {
                 resolve(accumulated || [])
                 return
               }

--- a/packages/sdk-client/test/client.spec.js
+++ b/packages/sdk-client/test/client.spec.js
@@ -319,8 +319,7 @@ describe('process', () => {
       expect(response).toEqual([
         'OK',
       ])
-      // client.execute is always called n + 1 times
-      expect(client.execute).toHaveBeenCalledTimes(2)
+      expect(client.execute).toHaveBeenCalledTimes(1)
       spy.mockReset()
       spy.mockRestore()
     })

--- a/types/sdk.js
+++ b/types/sdk.js
@@ -47,6 +47,7 @@ export type Client = {
 export type ProcessFn = (result: SuccessResult) => Promise<any>;
 export type ProcessOptions = {
   accumulate?: boolean;
+  total?: number;
 }
 
 /* Middlewares */


### PR DESCRIPTION
### This is a breaking change
BREAKING CHANGES: Calling `process` with a limit query now returns the `limit` number of items total and not the `limit` amount for **_"n"_** requests

resolves #294 