### PR TITLE
feat(sync-actions): add transitionsState action on products

### DIFF
--- a/packages/sync-actions/src/product-actions.js
+++ b/packages/sync-actions/src/product-actions.js
@@ -30,6 +30,7 @@ export const metaActionsList = [
 
 export const referenceActionsList = [
   { action: 'setTaxCategory', key: 'taxCategory' },
+  { action: 'transitionState', key: 'state' },
 ]
 
 

--- a/packages/sync-actions/test/product-sync-base.spec.js
+++ b/packages/sync-actions/test/product-sync-base.spec.js
@@ -42,6 +42,7 @@ describe('Exports', () => {
   it('correctly define reference actions list', () => {
     expect(referenceActionsList).toEqual([
       { action: 'setTaxCategory', key: 'taxCategory' },
+      { action: 'transitionState', key: 'state' },
     ])
   })
 })

--- a/packages/sync-actions/test/utils/common-actions.spec.js
+++ b/packages/sync-actions/test/utils/common-actions.spec.js
@@ -78,6 +78,7 @@ describe('Common actions', () => {
       { action: 'setCustomerGroup', key: 'customerGroup' },
       { action: 'setSupplyChannel', key: 'supplyChannel' },
       { action: 'setProductType', key: 'productType' },
+      { action: 'transitionState', key: 'state' },
     ]
 
     it('should build reference actions', () => {
@@ -87,6 +88,9 @@ describe('Common actions', () => {
         supplyChannel: { id: 'sc-1', typeId: 'channel' },
         productType: {
           id: 'pt-1', typeId: 'product-type', obj: { id: 'pt-1' },
+        },
+        state: {
+          id: 's-1', typeId: 'state', obj: { id: 's-1' },
         },
       }
       const now = {
@@ -99,6 +103,10 @@ describe('Common actions', () => {
         // ignore update
         productType: {
           id: 'pt-1', typeId: 'product-type',
+        },
+        // transition state
+        state: {
+          id: 's-2', typeId: 'state',
         },
       }
 
@@ -113,6 +121,7 @@ describe('Common actions', () => {
         { action: 'setTaxCategory', taxCategory: now.taxCategory },
         { action: 'setCustomerGroup', customerGroup: now.customerGroup },
         { action: 'setSupplyChannel' },
+        { action: 'transitionState', state: now.state },
       ])
     })
   })


### PR DESCRIPTION
#### Summary

This pull requests adds state transitions on products to the `sync-actions` package.

#### Description

A product can have a state assigned. A state is a reference to a defined state machine. The state itself is a reference type (http://dev.commercetools.com/http-api-projects-products.html#product). When transitioning a state the API offers the `transitionState` update action http://dev.commercetools.com/http-api-projects-products.html#transition-state.

#### Todo

- Tests
    - [x] Unit