### PR TITLE
fix(sync-action): to only pass reference for reference actions

### DIFF
--- a/packages/sync-actions/src/utils/common-actions.js
+++ b/packages/sync-actions/src/utils/common-actions.js
@@ -84,7 +84,13 @@ export function buildReferenceActions ({
 
         return {
           action,
-          [key]: newValue,
+          // We only need to pass a reference to the object.
+          // This prevents accidentally sending the expanded (`obj`)
+          // over the wire.
+          [key]: {
+            typeId: newValue.typeId,
+            id: newValue.id,
+          },
         }
       }
 

--- a/packages/sync-actions/test/utils/common-actions.spec.js
+++ b/packages/sync-actions/test/utils/common-actions.spec.js
@@ -81,48 +81,179 @@ describe('Common actions', () => {
       { action: 'transitionState', key: 'state' },
     ]
 
-    it('should build reference actions', () => {
-      const before = {
-        taxCategory: { id: 'tc-1', typeId: 'tax-category' },
-        customerGroup: undefined,
-        supplyChannel: { id: 'sc-1', typeId: 'channel' },
-        productType: {
-          id: 'pt-1', typeId: 'product-type', obj: { id: 'pt-1' },
-        },
-        state: {
-          id: 's-1', typeId: 'state', obj: { id: 's-1' },
-        },
-      }
-      const now = {
-        // id changed
-        taxCategory: { id: 'tc-2', typeId: 'tax-category' },
-        // new ref
-        customerGroup: { id: 'cg-1', typeId: 'customer-group' },
-        // unset
-        supplyChannel: null,
-        // ignore update
-        productType: {
-          id: 'pt-1', typeId: 'product-type',
-        },
-        // transition state
-        state: {
-          id: 's-2', typeId: 'state',
-        },
-      }
+    describe('without expanded references', () => {
+      describe('taxCategory', () => {
+        let actions
+        const before = {
+          taxCategory: { id: 'tc-1', typeId: 'tax-category' },
+        }
+        const now = {
+          // id changed
+          taxCategory: { id: 'tc-2', typeId: 'tax-category' },
+        }
 
-      const actions = buildReferenceActions({
-        actions: testActions,
-        diff: diffpatcher.diff(before, now),
-        oldObj: before,
-        newObj: now,
+        beforeEach(() => {
+          actions = buildReferenceActions({
+            actions: testActions,
+            diff: diffpatcher.diff(before, now),
+            oldObj: before,
+            newObj: now,
+          })
+        })
+
+        it('should build reference action', () => {
+          expect(actions).toContainEqual(
+            { action: 'setTaxCategory', taxCategory: now.taxCategory },
+          )
+        })
       })
 
-      expect(actions).toEqual([
-        { action: 'setTaxCategory', taxCategory: now.taxCategory },
-        { action: 'setCustomerGroup', customerGroup: now.customerGroup },
-        { action: 'setSupplyChannel' },
-        { action: 'transitionState', state: now.state },
-      ])
+      describe('customerGroup', () => {
+        let actions
+        const before = {
+          customerGroup: undefined,
+        }
+        const now = {
+          // new ref
+          customerGroup: { id: 'cg-1', typeId: 'customer-group' },
+        }
+
+        beforeEach(() => {
+          actions = buildReferenceActions({
+            actions: testActions,
+            diff: diffpatcher.diff(before, now),
+            oldObj: before,
+            newObj: now,
+          })
+        })
+
+        it('should build reference action', () => {
+          expect(actions).toContainEqual(
+            { action: 'setCustomerGroup', customerGroup: now.customerGroup },
+          )
+        })
+      })
+
+      describe('supplyChannel', () => {
+        let actions
+        const before = {
+          supplyChannel: { id: 'sc-1', typeId: 'channel' },
+        }
+        const now = {
+          // unset
+          supplyChannel: null,
+        }
+
+        beforeEach(() => {
+          actions = buildReferenceActions({
+            actions: testActions,
+            diff: diffpatcher.diff(before, now),
+            oldObj: before,
+            newObj: now,
+          })
+        })
+
+        it('should build reference action', () => {
+          expect(actions).toContainEqual(
+            { action: 'setSupplyChannel' },
+          )
+        })
+      })
+
+      describe('productType', () => {
+        let actions
+        const before = {
+          productType: {
+            id: 'pt-1', typeId: 'product-type', obj: { id: 'pt-1' },
+          },
+        }
+        const now = {
+          // ignore update
+          productType: {
+            id: 'pt-1', typeId: 'product-type',
+          },
+        }
+        beforeEach(() => {
+          actions = buildReferenceActions({
+            actions: testActions,
+            diff: diffpatcher.diff(before, now),
+            oldObj: before,
+            newObj: now,
+          })
+        })
+
+        it('should not build reference action', () => {
+          expect(actions).not.toContainEqual(
+            { action: 'productType' },
+          )
+        })
+      })
+
+      describe('state', () => {
+        let actions
+        const before = {
+          state: {
+            id: 's-1', typeId: 'state', obj: { id: 's-1' },
+          },
+        }
+        const now = {
+          // new ref: transition state
+          state: {
+            id: 's-2', typeId: 'state',
+          },
+        }
+
+        beforeEach(() => {
+          actions = buildReferenceActions({
+            actions: testActions,
+            diff: diffpatcher.diff(before, now),
+            oldObj: before,
+            newObj: now,
+          })
+        })
+
+        it('should build reference action', () => {
+          expect(actions).toContainEqual(
+            { action: 'transitionState', state: now.state },
+          )
+        })
+      })
+    })
+
+    describe('with expanded references', () => {
+      describe('state', () => {
+        let actions
+        const before = {
+          state: {
+            id: 's-1', typeId: 'state', obj: { id: 's-1' },
+          },
+        }
+        const now = {
+          // new ref: transition state
+          state: {
+            id: 's-2', typeId: 'state', obj: { id: 's-1' },
+          },
+        }
+
+        beforeEach(() => {
+          actions = buildReferenceActions({
+            actions: testActions,
+            diff: diffpatcher.diff(before, now),
+            oldObj: before,
+            newObj: now,
+          })
+        })
+
+        it('should build reference action without expansion in action', () => {
+          expect(actions).toContainEqual(
+            { action: 'transitionState',
+              state: {
+                typeId: now.state.typeId,
+                id: now.state.id,
+              } },
+          )
+        })
+      })
     })
   })
 })


### PR DESCRIPTION
#### Summary

Actions based on references only need to send a reference of `typeId` and `id` in addition with the reference itself. Before `sync-actions`, whenever `now` contained the expanded object would also attach those to the action. 

```json
[{
	"action": "transitionState",
	"state": {
		"typeId": "state",
		"id": "fb77d7dc-94c5-45df-95bc-b8499286e4d5",
		"obj": {
			"id": "fb77d7dc-94c5-45df-95bc-b8499286e4d5",
			"version": 2,
			"key": "new",
			"type": "ProductState",
			"roles": [],
			"name": {
				"de": "Neu",
				"en": "New"
			},
			"builtIn": false,
			"transitions": [{
				"typeId": "state",
				"id": "1436898f-6080-4a18-99df-134e05a80f73"
			}],
			"initial": true,
			"createdAt": "2016-08-11T16:07:33.676Z",
			"lastModifiedAt": "2016-08-11T16:07:34.888Z"
		}
	}
}]
```

Whereas the update action should be

```json
[{
	"action": "transitionState",
	"state": {
		"typeId": "state",
		"id": "fb77d7dc-94c5-45df-95bc-b8499286e4d5",
	}
}]
```

This intends to fix that behaviour which will apply to taxCategories and states at least.