### PR TITLE
feat(api-request-builder): add parse option

### DIFF
--- a/packages/api-request-builder/src/create-service.js
+++ b/packages/api-request-builder/src/create-service.js
@@ -2,6 +2,7 @@
 import type {
   ServiceBuilder,
   ServiceBuilderDefinition,
+  ServiceBuilderDefaultParams,
 } from 'types/sdk'
 import {
   getDefaultQueryParams,
@@ -122,6 +123,29 @@ export default function createService (
 
       setDefaultParams.call(this)
       return uri
+    },
+
+    // Call this method to parse an object as params
+    parse (params: ServiceBuilderDefaultParams): Object {
+      return {
+        // Call this method to get the built request URI
+        // Pass some options to further configure the URI:
+        // - `withProjectKey: false`: will omit the projectKey from the URI
+        build (uriOptions: UseKey = { withProjectKey: true }): string {
+          const { withProjectKey } = uriOptions
+
+          const queryParams = buildQueryString(params)
+          const version = params.version
+
+          return (
+            (withProjectKey ? `/${options}` : '') +
+            endpoint +
+            getIdOrKey(params) +
+            (queryParams ? `?${queryParams}` : '') +
+            (version ? `?version=${version}` : '')
+          )
+        },
+      }
     },
   })
 }

--- a/packages/api-request-builder/test/create-service.spec.js
+++ b/packages/api-request-builder/test/create-service.spec.js
@@ -88,6 +88,81 @@ describe('createService', () => {
     )
   })
 
+  describe('parse', () => {
+    const options = {
+      type: 'foo',
+      endpoint: '/foo',
+      features: ['queryOne', 'queryExpand'],
+    }
+
+    it('should parse the object', () => {
+      expect(createService(options, projectKey)
+        .parse({ id: 'some-id' }).build())
+        .toBe('/my-project1/foo/some-id')
+    })
+
+    it('include projectkey in uri by default', () => {
+      expect(createService(options, projectKey)
+        .parse({})
+        .build())
+        .toBe('/my-project1/foo')
+    })
+
+    it('exclude projectkey from uri using flag', () => {
+      const excludeProjectKey = { withProjectKey: false }
+      expect(createService(options, projectKey)
+        .parse({})
+        .build(excludeProjectKey))
+        .toBe('/foo')
+    })
+    it('only base endpoint', () => {
+      expect(createService(options, projectKey)
+        .parse({})
+        .build())
+        .toBe('/my-project1/foo')
+    })
+    it('endpoint with id', () => {
+      expect(createService(options, projectKey)
+        .parse({ id: '123' })
+        .build())
+        .toBe('/my-project1/foo/123')
+    })
+    it('endpoint with customer id', () => {
+      expect(createService(options, projectKey)
+        .parse({ customerId: 'cust123' })
+        .build())
+        .toBe('/my-project1/foo/?customerId=cust123')
+    })
+    it('endpoint with key', () => {
+      expect(createService(options, projectKey)
+        .parse({ key: 'bar' })
+        .build())
+        .toBe('/my-project1/foo/key=bar')
+    })
+    it('endpoint with query params', () => {
+      expect(createService(options, projectKey)
+        .parse({ expand: ['channel'] })
+        .build())
+        .toBe('/my-project1/foo?expand=channel')
+    })
+    it('include version in uri', () => {
+      expect(createService(options, projectKey)
+        .parse({ version: 2 })
+        .build())
+        .toBe('/my-project1/foo?version=2')
+    })
+    it('full endpoint', () => {
+      expect(
+        createService(options, projectKey)
+        .parse({
+          id: '123',
+          expand: ['channel'],
+        })
+        .build(),
+      ).toBe('/my-project1/foo/123?expand=channel')
+    })
+  })
+
   describe('build', () => {
     const options = {
       type: 'foo',


### PR DESCRIPTION
affects: @commercetools/api-request-builder

#### Summary
At the moment there is only an imperative way to use `api-request-builder`:

```js
createService(options, projectKey)
  .byId('123')
  .expand('channel')
  .build()
```

On the side of people using the RequestBuilder this makes testing the usage of the package hard, as we either:
- have to mock the complete API or 
- break test-isolation by asserting the returned string from `service.build()` (we really only care about what we give to it, not what it returns; the conversion of the arguments to a string should be tested in `api-request-builder` itself - not in every test using the request builder)

An easier, more declarative API is to allow passing an object which describes what we want to fetch:

```js
const params = {
  id: 'some-id',
  version: 3,
  expand: ['foo=true'], // <- currently needs to be url-encoded; ideally not url-encoded
}

createService(options, projectKey)
  .parse(params)
  .build()
```

Now the tests application-level tests only need to ensure that `params` has the correct format. Tests stay isolated and there is no need for complicated mocking.

#### Description
<!-- Describe the changes in this PR here and provide some context -->

#### Todo

- Tests
    - [x] Unit
    - [ ] Integration
    - [ ] Acceptance
- [ ] Documentation
<!-- Two persons should review a PR, don't forget to assign them. -->

#### Intend of PR
This PR is meant to outline what we want to achieve, and to show the easiest way to achieve it, while also outlining the "better" way to achieve the same thing. In case people are on board with the more sophisticated approach, I'd close this PR and open a new one for that.

Otherwise we can go with this approach, as it's closer to what @emmenko suggested in the first place.

#### Future
The current approach is very limited, but was the fastet way to show what should be possible. The current approach lacks:
- verification of the passed `params`
- ability to mix `parse` and other calls. Ideally we'd support `service.byId().parse().perPage().build()`


## Ideal solution

A more complex, ideal solution would be:

```js
// create-service.js
import { setParams } from './default-params'

parse (params: ServiceBuilderDefaultParams): Object {
  setParams.call(this, params)
  return this
}
```

```js
// default-params.js
const hasKey = (obj: object, key: string): boolean =>
  Object.hasOwnProperty.call(obj, key)

/**
 * Set the supplied parameters given the current service object.
 *
 * @return {void}
 */
export function setParams (params: ServiceBuilderDefaultParams) {
  if (params.expand)
    params.expand.forEach((expansion: string) => { this.expand(expansion) })

  if (hasKey(params, 'version'))
    this.withVersion(params.version)

  // queryOne
  if (hasKey(params, 'id')) this.byId(params.id)
  if (hasKey(params, 'customerId')) this.byCustomerId(params.customerId)
  if (hasKey(params, 'key')) this.byKey(params.key)

  // and so on
}
```

**Advantages:**
- the object passed in (here `params`)  is not tightly coupled to the internal representation
  - it can provide convenience API (e.g. `{ expand: 'foo' }` instead of `{ expand: ['foo'] }`).
  - we don't have to change the url-encoding place (happens in the wrong place right now; should happen during stringification, happens for the internal representation)
- the values of the object are verified using existing setters