### PR TITLE
chore(travis): add manual install of buffer-shims

### DIFF
--- a/.travis/after_success.sh
+++ b/.travis/after_success.sh
@@ -27,7 +27,7 @@ if [[ "$TRAVIS_BRANCH" == "master" ]]; then
   # Without this releasing is broken as the dependency is not installed
   # with yarn. Switching to npm does not seem to be a sane alternative.
   echo "Installing buffer-shims"
-  npm install buffer-shims
+  npm install buffer-shims@1.0.0
 
   echo "Running npm run semantic-release"
   npm run semantic-release

--- a/.travis/after_success.sh
+++ b/.travis/after_success.sh
@@ -24,6 +24,11 @@ if [[ "$TRAVIS_BRANCH" == "master" ]]; then
   echo "Running npm prune"
   npm prune
 
+  # Without this releasing is broken as the dependency is not installed
+  # with yarn. Switching to npm does not seem to be a sane alternative.
+  echo "Installing buffer-shims"
+  npm install buffer-shims
+
   echo "Running npm run semantic-release"
   npm run semantic-release
 


### PR DESCRIPTION
#### Summary

Currently we fail to release as `buffer-shims` is not installed as a dependency. Before we migrated to only use `npm` but that does not seem to be a sane approach when dealing with a monorepo and opting out of `yarns` workspace support.

To be fair: we don't know why this dependency it not installed correctly and it must be a problem somewhere downstream.

Link to a borked release: https://travis-ci.org/commercetools/nodejs/jobs/301317444#L708

```bash
Running npm run semantic-release
module.js:471
    throw err;
    ^
Error: Cannot find module 'buffer-shims'
    at Function.Module._resolveFilename (module.js:469:15)
    at Function.Module._load (module.js:417:25)
    at Module.require (module.js:497:17)
    at require (internal/module.js:20:19)
    at Object.<anonymous> (/home/travis/build/commercetools/nodejs/node_modules/npm/node_modules/readable-stream/lib/_stream_readable.js:36:18)
    at Module._compile (module.js:570:32)
    at Object.Module._extensions..js (module.js:579:10)
    at Module.load (module.js:487:32)
    at tryModuleLoad (module.js:446:12)
    at Function.Module._load (module.js:438:3)
```