### PR TITLE
chore(circle): require unit tests before releasing

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -165,7 +165,13 @@ workflows:
       - prepare_release:
           context: org-global
           requires:
+            # Requiring test_integration implicitly
+            # requires test_unit_node_8 but waits for
+            # the integration tests. However, also
+            # all other unit tests should pass.
             - test_integration
+            - test_unit_node_4
+            - test_unit_node_6
           filters:
             branches:
               only:


### PR DESCRIPTION
#### Summary

Makes sure unit tests on all platforms pass before performing an release after integration tests are green.