### PR TITLE
Add `stackingMode` to cart discounts in sync-actions

### DIFF
--- a/packages/sync-actions/src/cart-discounts-actions.js
+++ b/packages/sync-actions/src/cart-discounts-actions.js
@@ -11,6 +11,7 @@ export const baseActionsList = [
   { action: 'setDescription', key: 'description' },
   { action: 'setValidFrom', key: 'validFrom' },
   { action: 'setValidUntil', key: 'validUntil' },
+  { action: 'changeStackingMode', key: 'stackingMode' },
 ]
 
 export function actionsMapBase(diff, oldObj, newObj) {

--- a/packages/sync-actions/test/cart-discounts-sync.spec.js
+++ b/packages/sync-actions/test/cart-discounts-sync.spec.js
@@ -6,20 +6,94 @@ describe('Cart Discounts Exports', () => {
     expect(actionGroups).toEqual(['base'])
   })
 
-  it('correctly defined base actions list', () => {
-    expect(baseActionsList).toEqual([
-      { action: 'changeIsActive', key: 'isActive' },
-      { action: 'changeName', key: 'name' },
-      { action: 'changeCartPredicate', key: 'cartPredicate' },
-      { action: 'changeSortOrder', key: 'sortOrder' },
-      { action: 'changeValue', key: 'value' },
-      { action: 'changeRequiresDiscountCode', key: 'requiresDiscountCode' },
-      { action: 'changeTarget', key: 'target' },
-      { action: 'setDescription', key: 'description' },
-      { action: 'setValidFrom', key: 'validFrom' },
-      { action: 'setValidUntil', key: 'validUntil' },
-      { action: 'changeStackingMode', key: 'stackingMode' },
-    ])
+  describe('action list', () => {
+    it('should contain `changeIsActive` action', () => {
+      expect(baseActionsList).toEqual(
+        expect.arrayContaining([{ action: 'changeIsActive', key: 'isActive' }])
+      )
+    })
+
+    it('should contain `changeName` action', () => {
+      expect(baseActionsList).toEqual(
+        expect.arrayContaining([{ action: 'changeName', key: 'name' }])
+      )
+    })
+
+    it('should contain `changeCartPredicate` action', () => {
+      expect(baseActionsList).toEqual(
+        expect.arrayContaining([
+          {
+            action: 'changeCartPredicate',
+            key: 'cartPredicate',
+          },
+        ])
+      )
+    })
+
+    it('should contain `changeSortOrder` action', () => {
+      expect(baseActionsList).toEqual(
+        expect.arrayContaining([
+          { action: 'changeSortOrder', key: 'sortOrder' },
+        ])
+      )
+    })
+
+    it('should contain `changeValue` action', () => {
+      expect(baseActionsList).toEqual(
+        expect.arrayContaining([{ action: 'changeValue', key: 'value' }])
+      )
+    })
+
+    it('should contain `changeRequiresDiscountCode` action', () => {
+      expect(baseActionsList).toEqual(
+        expect.arrayContaining([
+          {
+            action: 'changeRequiresDiscountCode',
+            key: 'requiresDiscountCode',
+          },
+        ])
+      )
+    })
+
+    it('should contain `changeTarget` action', () => {
+      expect(baseActionsList).toEqual(
+        expect.arrayContaining([{ action: 'changeTarget', key: 'target' }])
+      )
+    })
+
+    it('should contain `setDescription` action', () => {
+      expect(baseActionsList).toEqual(
+        expect.arrayContaining([
+          {
+            action: 'setDescription',
+            key: 'description',
+          },
+        ])
+      )
+    })
+
+    it('should contain `setValidFrom` action', () => {
+      expect(baseActionsList).toEqual(
+        expect.arrayContaining([{ action: 'setValidFrom', key: 'validFrom' }])
+      )
+    })
+
+    it('should contain `setValidUntil` action', () => {
+      expect(baseActionsList).toEqual(
+        expect.arrayContaining([{ action: 'setValidUntil', key: 'validUntil' }])
+      )
+    })
+
+    it('should contain `changeStackingMode` action', () => {
+      expect(baseActionsList).toEqual(
+        expect.arrayContaining([
+          {
+            action: 'changeStackingMode',
+            key: 'stackingMode',
+          },
+        ])
+      )
+    })
   })
 })
 

--- a/packages/sync-actions/test/cart-discounts-sync.spec.js
+++ b/packages/sync-actions/test/cart-discounts-sync.spec.js
@@ -18,6 +18,7 @@ describe('Cart Discounts Exports', () => {
       { action: 'setDescription', key: 'description' },
       { action: 'setValidFrom', key: 'validFrom' },
       { action: 'setValidUntil', key: 'validUntil' },
+      { action: 'changeStackingMode', key: 'stackingMode' },
     ])
   })
 })
@@ -233,6 +234,25 @@ describe('Cart Discounts Actions', () => {
       {
         action: 'setValidUntil',
         validUntil: 'date2',
+      },
+    ]
+    const actual = cartDiscountsSync.buildActions(now, before)
+    expect(actual).toEqual(expected)
+  })
+
+  it('should build the `changeStackingMode` action', () => {
+    const before = {
+      stackingMode: 'Stacking',
+    }
+
+    const now = {
+      stackingMode: 'StopAfterThisDiscount',
+    }
+
+    const expected = [
+      {
+        action: 'changeStackingMode',
+        stackingMode: 'StopAfterThisDiscount',
       },
     ]
     const actual = cartDiscountsSync.buildActions(now, before)


### PR DESCRIPTION
#### Summary

Adds the `stackingMode` to cart discounts in the `sync-actions` package. This pull request closes #358.