### PR TITLE
fix(api-request-builder): adds the whereOperator to the knownKeys array

### DIFF
--- a/packages/api-request-builder/src/default-params.js
+++ b/packages/api-request-builder/src/default-params.js
@@ -115,6 +115,7 @@ export function setParams(params: ServiceBuilderParams) {
     'filterByFacets',
     'searchKeywords',
     'where',
+    'whereOperator',
     'version',
   ]
   Object.keys(params).forEach((key: string) => {


### PR DESCRIPTION
#### Summary
Include the `whereOperator` as known key in the corresponding `knownKeys` array.

#### Description
When passing the `whereOperator` as param we were getting the following error:
![image](https://user-images.githubusercontent.com/14823601/33311008-d402caf0-d423-11e7-9d70-b693af4640b6.png)

Basically the `whereOperator` key is not in the `knownKeys`array making it useless. This PR just fixes that by adding the operator in the array.
