### PR TITLE
feat(sync-actions/product-discounts): add validFrom and validUntil

### DIFF
--- a/packages/sync-actions/src/product-discounts-actions.js
+++ b/packages/sync-actions/src/product-discounts-actions.js
@@ -7,6 +7,8 @@ export const baseActionsList = [
   { action: 'changeSortOrder', key: 'sortOrder' },
   { action: 'changeValue', key: 'value' },
   { action: 'setDescription', key: 'description' },
+  { action: 'setValidFrom', key: 'validFrom' },
+  { action: 'setValidUntil', key: 'validUntil' },
 ]
 
 export function actionsMapBase(diff, oldObj, newObj) {

--- a/packages/sync-actions/test/product-discounts-sync.spec.js
+++ b/packages/sync-actions/test/product-discounts-sync.spec.js
@@ -6,15 +6,66 @@ describe('Exports', () => {
     expect(actionGroups).toEqual(['base'])
   })
 
-  it('correctly defined base actions list', () => {
-    expect(baseActionsList).toEqual([
-      { action: 'changeIsActive', key: 'isActive' },
-      { action: 'changeName', key: 'name' },
-      { action: 'changePredicate', key: 'predicate' },
-      { action: 'changeSortOrder', key: 'sortOrder' },
-      { action: 'changeValue', key: 'value' },
-      { action: 'setDescription', key: 'description' },
-    ])
+  describe('Exports', () => {
+    it('should contain `changeIsActive` action', () => {
+      expect(baseActionsList).toEqual(
+        expect.arrayContaining([{ action: 'changeIsActive', key: 'isActive' }])
+      )
+    })
+
+    it('should contain `changeName` action', () => {
+      expect(baseActionsList).toEqual(
+        expect.arrayContaining([{ action: 'changeName', key: 'name' }])
+      )
+    })
+
+    it('should contain `changePredicate` action', () => {
+      expect(baseActionsList).toEqual(
+        expect.arrayContaining([
+          {
+            action: 'changePredicate',
+            key: 'predicate',
+          },
+        ])
+      )
+    })
+
+    it('should contain `changeSortOrder` action', () => {
+      expect(baseActionsList).toEqual(
+        expect.arrayContaining([
+          { action: 'changeSortOrder', key: 'sortOrder' },
+        ])
+      )
+    })
+
+    it('should contain `changeValue` action', () => {
+      expect(baseActionsList).toEqual(
+        expect.arrayContaining([{ action: 'changeValue', key: 'value' }])
+      )
+    })
+
+    it('should contain `setDescription` action', () => {
+      expect(baseActionsList).toEqual(
+        expect.arrayContaining([
+          {
+            action: 'setDescription',
+            key: 'description',
+          },
+        ])
+      )
+    })
+
+    it('should contain `setValidFrom` action', () => {
+      expect(baseActionsList).toEqual(
+        expect.arrayContaining([{ action: 'setValidFrom', key: 'validFrom' }])
+      )
+    })
+
+    it('should contain `setValidUntil` action', () => {
+      expect(baseActionsList).toEqual(
+        expect.arrayContaining([{ action: 'setValidUntil', key: 'validUntil' }])
+      )
+    })
   })
 })
 
@@ -22,6 +73,25 @@ describe('Actions', () => {
   let productDiscountsSync
   beforeEach(() => {
     productDiscountsSync = productDiscountsSyncFn()
+  })
+
+  it('should build the `changeIsActive` action', () => {
+    const before = {
+      isActive: false,
+    }
+
+    const now = {
+      isActive: true,
+    }
+
+    const expected = [
+      {
+        action: 'changeIsActive',
+        isActive: true,
+      },
+    ]
+    const actual = productDiscountsSync.buildActions(now, before)
+    expect(actual).toEqual(expected)
   })
 
   it('should build "changeName" action', () => {
@@ -37,6 +107,132 @@ describe('Actions', () => {
       {
         action: 'changeName',
         name: { en: 'en-name-now', de: 'de-name-now' },
+      },
+    ]
+    const actual = productDiscountsSync.buildActions(now, before)
+    expect(actual).toEqual(expected)
+  })
+
+  it('should build the `changePredicate` action', () => {
+    const before = {
+      predicate: '1=1',
+    }
+
+    const now = {
+      predicate: 'sku="test-sku"',
+    }
+
+    const expected = [
+      {
+        action: 'changePredicate',
+        predicate: 'sku="test-sku"',
+      },
+    ]
+    const actual = productDiscountsSync.buildActions(now, before)
+    expect(actual).toEqual(expected)
+  })
+
+  it('should build the `changeSortOrder` action', () => {
+    const before = {
+      sortOrder: '0.1',
+    }
+
+    const now = {
+      sortOrder: '0.2',
+    }
+
+    const expected = [
+      {
+        action: 'changeSortOrder',
+        sortOrder: '0.2',
+      },
+    ]
+    const actual = productDiscountsSync.buildActions(now, before)
+    expect(actual).toEqual(expected)
+  })
+
+  it('should build the `changeValue` action', () => {
+    const before = {
+      value: {
+        type: 'relative',
+        permyriad: 100,
+      },
+    }
+
+    const now = {
+      value: {
+        type: 'relative',
+        permyriad: 200,
+      },
+    }
+
+    const expected = [
+      {
+        action: 'changeValue',
+        value: {
+          type: 'relative',
+          permyriad: 200,
+        },
+      },
+    ]
+    const actual = productDiscountsSync.buildActions(now, before)
+    expect(actual).toEqual(expected)
+  })
+
+  it('should build the `setDescription` action', () => {
+    const before = {
+      description: {
+        en: 'en-description-before',
+        de: 'de-description-before',
+      },
+    }
+
+    const now = {
+      description: { en: 'en-description-now', de: 'de-description-now' },
+    }
+
+    const expected = [
+      {
+        action: 'setDescription',
+        description: { en: 'en-description-now', de: 'de-description-now' },
+      },
+    ]
+    const actual = productDiscountsSync.buildActions(now, before)
+    expect(actual).toEqual(expected)
+  })
+
+  it('should build the `setValidFrom` action', () => {
+    const before = {
+      validFrom: 'date1',
+    }
+
+    const now = {
+      validFrom: 'date2',
+    }
+
+    const expected = [
+      {
+        action: 'setValidFrom',
+        validFrom: 'date2',
+      },
+    ]
+    const actual = productDiscountsSync.buildActions(now, before)
+    expect(actual).toEqual(expected)
+  })
+
+  it('should build the `setValidUntil` action', () => {
+    const before = {
+      validUntil: 'date1',
+    }
+
+    const now = {
+      validUntil: 'date2',
+    }
+
+    const expected = [
+      {
+        action: 'setValidUntil',
+        validUntil: 'date2',
       },
     ]
     const actual = productDiscountsSync.buildActions(now, before)


### PR DESCRIPTION
#### Summary

⚠️  Please do not merge yet until this feature is available in the platform ⚠️ 

Closes #374
