### PR TITLE
feat(query-id): add ability to filter by cart id

### DIFF
--- a/docs/sdk/api/apiRequestBuilder.md
+++ b/docs/sdk/api/apiRequestBuilder.md
@@ -31,7 +31,7 @@ The `options` argument must be an object with a `projectKey` property, and optio
 A _service_ is created by defining its `features`. Features give a service specific _characteristics_ to correctly build URIs. For example, if a service can query a resource by ID you would include `queryOne`. Available features types are:
 
 - `query`: allows to use standard query capabilities (`page`, `perPage`, `sort`, `where`, `whereOperator`)
-- `queryOne`: allows to query a single resource (`byId`, `byKey`, `byCustomerId`)
+- `queryOne`: allows to query a single resource (`byId`, `byKey`, `byCustomerId`, `byCartId`)
 - `queryExpand`: allows to use reference expansion (`expand`)
 - `search`: allows to use search capabilities (`text`, `fuzzy`, `fuzzyLevel`, `facet`, `markMatchingVariants`, `filter`, `filterByQuery`, `filterByFacets`)
 - `projection`: allows to use projections capabilities (`staged`, `priceCurrency`, `priceCountry`, `priceCustomerGroup`, `priceChannel`)
@@ -121,6 +121,7 @@ This declarative `parse` API accepts an object of the following shape:
   id?: ?string;
   key?: ?string;
   customerId?: ?string;
+  cartId?: ?string;
 
   // query-page
   sort: Array<{ by: string, direction: 'asc' | 'desc' }>;

--- a/packages/api-request-builder/src/build-query-string.js
+++ b/packages/api-request-builder/src/build-query-string.js
@@ -26,10 +26,13 @@ export default function buildQueryString(
     searchKeywords,
     version,
     customerId,
+    cartId,
   } = params
   let queryString = []
 
   if (customerId) queryString.push(`customerId=${customerId}`)
+
+  if (cartId) queryString.push(`cartId=${cartId}`)
 
   if (typeof staged === 'boolean')
     queryString.push(`staged=${staged.toString()}`)

--- a/packages/api-request-builder/src/default-params.js
+++ b/packages/api-request-builder/src/default-params.js
@@ -97,6 +97,7 @@ export function setParams(params: ServiceBuilderParams) {
     'id',
     'key',
     'customerId',
+    'cartId',
     'sort',
     'page',
     'perPage',
@@ -132,6 +133,7 @@ export function setParams(params: ServiceBuilderParams) {
   if (hasKey(params, 'id')) this.byId(params.id)
   if (hasKey(params, 'key')) this.byKey(params.key)
   if (hasKey(params, 'customerId')) this.byCustomerId(params.customerId)
+  if (hasKey(params, 'cartId')) this.byCartId(params.cartId)
 
   // query-page
   if (params.sort)

--- a/packages/api-request-builder/src/query-id.js
+++ b/packages/api-request-builder/src/query-id.js
@@ -19,6 +19,12 @@ export function byId(id: string): Object {
         'You cannot use both `byId` and `byCustomerId`.'
     )
 
+  if (this.params.cartId)
+    throw new Error(
+      'A cartId for this resource has already been set. ' +
+        'You cannot use both `byId` and `byCartId`.'
+    )
+
   this.params.id = id
   return this
 }
@@ -60,5 +66,25 @@ export function byCustomerId(custId: string): Object {
     )
 
   this.params.customerId = custId
+  return this
+}
+
+/**
+ * Set the given `id` to the `cartId` internal state of the service instance.
+ * For querying shipping methods by cart id
+ *
+ * @param  {string} id - A resource `UUID`
+ * @throws If `id` is missing.
+ * @return {Object} The instance of the service, can be chained.
+ */
+export function byCartId(cartId: string): Object {
+  if (!cartId) throw new Error('Required argument for `byCartId` is missing')
+  if (this.params.id)
+    throw new Error(
+      'An ID for this resource has already been set. ' +
+        'You cannot use both `byId` and `byCartId`.'
+    )
+
+  this.params.cartId = cartId
   return this
 }

--- a/packages/api-request-builder/test/create-service.spec.js
+++ b/packages/api-request-builder/test/create-service.spec.js
@@ -22,6 +22,7 @@ const expectedServiceProperties = [
   'perPage',
   'byId',
   'byCustomerId',
+  'byCartId',
   'byKey',
   'expand',
   'text',
@@ -379,6 +380,24 @@ describe('createService', () => {
         ).toBe('/my-project1/test?customerId=foo&version=3')
       })
 
+      it('should mix cartId and queryParams', () => {
+        expect(
+          service
+            .byCartId('foo')
+            .expand('baz')
+            .build()
+        ).toBe('/my-project1/test?cartId=foo&expand=baz')
+      })
+
+      it('should mix cartId and version', () => {
+        expect(
+          service
+            .byCartId('foo')
+            .withVersion(3)
+            .build()
+        ).toBe('/my-project1/test?cartId=foo&version=3')
+      })
+
       it('should mix queryParams and version', () => {
         expect(
           service
@@ -405,6 +424,11 @@ describe('createService', () => {
     it('endpoint with customer id', () => {
       expect(service.byCustomerId('cust123').build()).toBe(
         '/my-project1/foo?customerId=cust123'
+      )
+    })
+    it('endpoint with cart id', () => {
+      expect(service.byCartId('cart123').build()).toBe(
+        '/my-project1/foo?cartId=cart123'
       )
     })
     it('endpoint with key', () => {

--- a/packages/api-request-builder/test/query-id.spec.js
+++ b/packages/api-request-builder/test/query-id.spec.js
@@ -40,6 +40,17 @@ describe('queryId', () => {
     )
   })
 
+  it('should set the cartId param', () => {
+    service.byCartId('myCart')
+    expect(service.params.cartId).toBe('myCart')
+  })
+
+  it('should throw if cartId is missing', () => {
+    expect(() => service.byCartId()).toThrowError(
+      /Required argument for `byCartId` is missing/
+    )
+  })
+
   it('throw if byId is used after byKey', () => {
     expect(() => service.byKey('bar').byId('123')).toThrowError(
       'A key for this resource has already been set. ' +
@@ -65,6 +76,20 @@ describe('queryId', () => {
     expect(() => service.byCustomerId('foo').byId('789')).toThrowError(
       'A customerId for this resource has already been set. ' +
         'You cannot use both `byId` and `byCustomerId`.'
+    )
+  })
+
+  it('throw if byCartId is used after byId', () => {
+    expect(() => service.byId('theId').byCartId('theCartId')).toThrowError(
+      'An ID for this resource has already been set. ' +
+        'You cannot use both `byId` and `byCartId`.'
+    )
+  })
+
+  it('throw if byId is used after byCartId', () => {
+    expect(() => service.byCartId('foo').byId('789')).toThrowError(
+      'A cartId for this resource has already been set. ' +
+        'You cannot use both `byId` and `byCartId`.'
     )
   })
 })

--- a/types/sdk.js
+++ b/types/sdk.js
@@ -214,6 +214,7 @@ export type ServiceBuilderDefaultParams = {
   },
   version?: number,
   customerId?: string,
+  cartId?: string,
 }
 export type ServiceBuilderParams = {
   // query-expand
@@ -223,6 +224,7 @@ export type ServiceBuilderParams = {
   id?: ?string,
   key?: ?string,
   customerId?: ?string,
+  cartId?: ?string,
 
   // query-page
   sort: Array<{ by: string, direction: 'asc' | 'desc' }>,


### PR DESCRIPTION
#### Summary
adds the `cartId` param as a valid one to filter like we already have with `customerId` in the `queryOne` feature.

#### Description
we can call the `shipping-method` endpoint by passing a `cartId` param with the cart id in order to get the available shipping methods for the cart. See [here](https://dev.commercetools.com/http-api-projects-shippingMethods.html#get-shippingmethods-for-a-cart) the docs.

This PR adds the possibility to send as param a `cartId` in order to be able to use this feature when retrieving shipping methods.

- Tests
    - [x] Unit
- [x] Documentation
