### PR TITLE
Redux style middlware

### DIFF
--- a/packages/sdk-middleware-logger/src/logger.js
+++ b/packages/sdk-middleware-logger/src/logger.js
@@ -1,15 +1,26 @@
 /* @flow */
-import type {
-  Middleware,
-  MiddlewareRequest,
-  MiddlewareResponse,
-} from '../../../types/sdk'
+import type { Middleware, MiddlewareRequest } from '../../../types/sdk'
 
 export default function createLoggerMiddleware(): Middleware {
-  return next => (request: MiddlewareRequest, response: MiddlewareResponse) => {
-    const { error, body, statusCode } = response
+  // return next => (request: MiddlewareRequest, response: MiddlewareResponse) => {
+  //   const { error, body, statusCode } = response
+  //   console.log('Request: ', request)
+  //   console.log('Response: ', { error, body, statusCode })
+  //   next(request, response)
+  // }
+  return (/* dispatch */) => next => (request: MiddlewareRequest) => {
     console.log('Request: ', request)
-    console.log('Response: ', { error, body, statusCode })
-    next(request, response)
+    return next(request).then(
+      response => {
+        const { error, body, statusCode } = response
+        console.log('Response: ', { error, body, statusCode })
+        return response
+      },
+      response => {
+        const { error, body, statusCode } = response
+        console.log('Response: ', { error, body, statusCode })
+        throw response
+      }
+    )
   }
 }


### PR DESCRIPTION
#### Summary

This is an example implementation of a redux-style middleware system suggested in #390.

This PR is meant to enable discussion on specific code, and to eventually build upon it. However I won't/can't continue with this without the company's support.

#### Next steps

We'd have to adapt all provided middlewares to this system. They will get easier to test (no mutability anymore) and more powerful.

For example, our OAuth middlewares are making HTTP requests (using `fetch`) on their own which seems weird, since the middleware / client itself should be the service used to make those requests. But this is a side-note and just a gut-feeling that something is off there. Doesn't really matter though.


#### Open questions

There is one built-in middleware in systems like this. In our case it returns the value passed through `next()`, serving as an identity middleware. This built-in middleware is the last one in the system before the return chain calls start. As described in the source code we could replace this built-in middleware for one which takes a request description and makes an http request based on it. It then returns the promise which results form it. This would declare an API contract which all other middlewares could adhere to (request description -> Promise). On the way back down they could each hook into the success- and error-cases with `return next(request).then(successHandler, failureHandler)`.

In the image below Middleware #3 would be the built-in one which turns the description into a promise: ![owin-middleware-chain_thumb](https://user-images.githubusercontent.com/1765075/34384821-f46a88ac-eb1e-11e7-90cf-969f4f846633.png) ([source](http://johnatten.com/2015/01/04/asp-net-understanding-owin-katana-and-the-middleware-pipeline/))

*Server* would actually be the client making a request, but apart from that the image is pretty fitting.

We could alternatively keep the existing identity middleware (which just returns the passed value) and provide a `fetch` middleware instead, which users would have to manually add at the end. This would enable them to put middlewares after that. But at this point they wouldn't have access to the original request anymore, so I'm not too sure this would be useful.


#### Removed features

This PR removes the `process` function. This function should probably be implemented in a middleware instead.

#### Todo

- [ ] integrate `fetch` middleware (integrated or standalone)
- [ ] offer pagination middleware as replacement for `process`
- [ ] adapt existing middlewares