### PR TITLE
feat(sync-actions): add custom fields to customer groups

### DIFF
--- a/packages/sync-actions/src/customer-group.js
+++ b/packages/sync-actions/src/customer-group.js
@@ -1,10 +1,11 @@
 import flatten from 'lodash.flatten'
 import createBuildActions from './utils/create-build-actions'
 import createMapActionGroup from './utils/create-map-action-group'
+import actionsMapCustom from './utils/action-map-custom'
 import { actionsMapBase } from './customer-group-actions'
 import * as diffpatcher from './utils/diffpatcher'
 
-export const actionGroups = ['base']
+export const actionGroups = ['base', 'custom']
 
 function createCustomerGroupMapActions(mapActionGroup) {
   return function doMapActions(diff, newObj, oldObj) {
@@ -12,6 +13,10 @@ function createCustomerGroupMapActions(mapActionGroup) {
 
     allActions.push(
       mapActionGroup('base', () => actionsMapBase(diff, oldObj, newObj))
+    )
+
+    allActions.push(
+      mapActionGroup('custom', () => actionsMapCustom(diff, newObj, oldObj))
     )
 
     return flatten(allActions)

--- a/packages/sync-actions/test/customer-group-sync.spec.js
+++ b/packages/sync-actions/test/customer-group-sync.spec.js
@@ -1,38 +1,136 @@
 import customerGroupSyncFn, { actionGroups } from '../src/customer-group'
 import { baseActionsList } from '../src/customer-group-actions'
 
-describe('Exports', () => {
+describe('Customer Groups Exports', () => {
   it('action group list', () => {
-    expect(actionGroups).toEqual(['base'])
+    expect(actionGroups).toEqual(['base', 'custom'])
   })
 
-  it('correctly defined based actions list', () => {
-    expect(baseActionsList).toEqual([
-      { action: 'changeName', key: 'name' },
-      { action: 'setKey', key: 'key' },
-    ])
+  describe('action list', () => {
+    it('should contain `changeName` action', () => {
+      expect(baseActionsList).toEqual(
+        expect.arrayContaining([{ action: 'changeName', key: 'name' }])
+      )
+    })
+
+    it('should contain `setKey` action', () => {
+      expect(baseActionsList).toEqual(
+        expect.arrayContaining([
+          {
+            action: 'setKey',
+            key: 'key',
+          },
+        ])
+      )
+    })
   })
 })
 
-describe('Actions', () => {
+describe('Customer Groups Actions', () => {
   let customerGroupSync
   beforeEach(() => {
     customerGroupSync = customerGroupSyncFn()
   })
 
-  it('should build `changeName` action', () => {
-    const before = { name: 'the-greatest-name-before' }
-    const now = { name: 'the-greatest-name-now' }
-    const expected = [{ action: 'changeName', ...now }]
+  it('should build the `changeName` action', () => {
+    const before = {
+      name: { en: 'en-name-before', de: 'de-name-before' },
+    }
+
+    const now = {
+      name: { en: 'en-name-now', de: 'de-name-now' },
+    }
+
+    const expected = [
+      {
+        action: 'changeName',
+        name: { en: 'en-name-now', de: 'de-name-now' },
+      },
+    ]
     const actual = customerGroupSync.buildActions(now, before)
     expect(actual).toEqual(expected)
   })
 
-  it('should build `setKey` action', () => {
-    const before = { key: 'unique-key-before' }
-    const now = { key: 'unique-key-now' }
-    const expected = [{ action: 'setKey', ...now }]
+  it('should build the `setKey` action', () => {
+    const before = {
+      key: 'foo-key',
+    }
+
+    const now = {
+      key: 'bar-key',
+    }
+
+    const expected = [
+      {
+        action: 'setKey',
+        key: 'bar-key',
+      },
+    ]
     const actual = customerGroupSync.buildActions(now, before)
+    expect(actual).toEqual(expected)
+  })
+
+  describe('custom fields', () => {
+    it('should build `setCustomType` action', () => {
+      const before = {
+        custom: {
+          type: {
+            typeId: 'type',
+            id: 'customType1',
+          },
+          fields: {
+            customField1: true,
+          },
+        },
+      }
+      const now = {
+        custom: {
+          type: {
+            typeId: 'type',
+            id: 'customType2',
+          },
+          fields: {
+            customField1: true,
+          },
+        },
+      }
+      const actual = customerGroupSync.buildActions(now, before)
+      const expected = [{ action: 'setCustomType', ...now.custom }]
+      expect(actual).toEqual(expected)
+    })
+  })
+
+  it('should build `setCustomField` action', () => {
+    const before = {
+      custom: {
+        type: {
+          typeId: 'type',
+          id: 'customType1',
+        },
+        fields: {
+          customField1: false,
+        },
+      },
+    }
+    const now = {
+      custom: {
+        type: {
+          typeId: 'type',
+          id: 'customType1',
+        },
+        fields: {
+          customField1: true,
+        },
+      },
+    }
+    const actual = customerGroupSync.buildActions(now, before)
+    const expected = [
+      {
+        action: 'setCustomField',
+        name: 'customField1',
+        value: true,
+      },
+    ]
     expect(actual).toEqual(expected)
   })
 })


### PR DESCRIPTION
#### Summary

Adds custom fields to customer groups. This PR adds it the same way we added it for cart discounts and discount codes etc. It also contains the same restructuring of the specs.