### PR TITLE
feat(sync-actions): add sync actions for tax categories

### DIFF
--- a/packages/sync-actions/src/tax-categories-actions.js
+++ b/packages/sync-actions/src/tax-categories-actions.js
@@ -1,0 +1,41 @@
+import { buildBaseAttributesActions } from './utils/common-actions'
+import createBuildArrayActions, {
+  ADD_ACTIONS,
+  REMOVE_ACTIONS,
+  CHANGE_ACTIONS,
+} from './utils/create-build-array-actions'
+
+export const baseActionsList = [
+  { action: 'changeName', key: 'name' },
+  { action: 'setKey', key: 'key' },
+  { action: 'setDescription', key: 'description' },
+]
+
+export function actionsMapBase(diff, oldObj, newObj) {
+  return buildBaseAttributesActions({
+    actions: baseActionsList,
+    diff,
+    oldObj,
+    newObj,
+  })
+}
+
+export function actionsMapRates(diff, oldObj, newObj) {
+  const handler = createBuildArrayActions('rates', {
+    [ADD_ACTIONS]: newObject => ({
+      action: 'addTaxRate',
+      taxRate: newObject,
+    }),
+    [REMOVE_ACTIONS]: objectToRemove => ({
+      action: 'removeTaxRate',
+      taxRateId: objectToRemove.id,
+    }),
+    [CHANGE_ACTIONS]: (oldObject, updatedObject) => ({
+      action: 'replaceTaxRate',
+      taxRateId: oldObject.id,
+      taxRate: updatedObject,
+    }),
+  })
+
+  return handler(diff, oldObj, newObj)
+}

--- a/packages/sync-actions/src/tax-categories.js
+++ b/packages/sync-actions/src/tax-categories.js
@@ -1,0 +1,47 @@
+/* @flow */
+import flatten from 'lodash.flatten'
+import type { SyncAction, ActionGroup } from '../../../types/sdk'
+import createBuildActions from './utils/create-build-actions'
+import createMapActionGroup from './utils/create-map-action-group'
+import * as taxCategoriesActions from './tax-categories-actions'
+import * as diffpatcher from './utils/diffpatcher'
+
+export const actionGroups = ['base', 'rates']
+
+function createTaxCategoriesMapActions(mapActionGroup) {
+  return function doMapActions(diff, newObj, oldObj /* , options */) {
+    const allActions = []
+
+    allActions.push(
+      mapActionGroup('base', () =>
+        taxCategoriesActions.actionsMapBase(diff, oldObj, newObj)
+      )
+    )
+
+    allActions.push(
+      mapActionGroup('rates', () =>
+        taxCategoriesActions.actionsMapRates(diff, oldObj, newObj)
+      )
+    )
+
+    return flatten(allActions)
+  }
+}
+
+export default (config: Array<ActionGroup>): SyncAction => {
+  // config contains information about which action groups
+  // are white/black listed
+
+  // createMapActionGroup returns function 'mapActionGroup' that takes params:
+  // - action group name
+  // - callback function that should return a list of actions that correspond
+  //    to the for the action group
+
+  // this resulting function mapActionGroup will call the callback function
+  // for whitelisted action groups and return the return value of the callback
+  // It will return an empty array for blacklisted action groups
+  const mapActionGroup = createMapActionGroup(config)
+  const doMapActions = createTaxCategoriesMapActions(mapActionGroup)
+  const buildActions = createBuildActions(diffpatcher.diff, doMapActions)
+  return { buildActions }
+}

--- a/packages/sync-actions/test/tax-categories-sync.spec.js
+++ b/packages/sync-actions/test/tax-categories-sync.spec.js
@@ -1,0 +1,195 @@
+import taxCategorySyncFn, { actionGroups } from '../src/tax-categories'
+import { baseActionsList } from '../src/tax-categories-actions'
+
+describe('Exports', () => {
+  it('action group list', () => {
+    expect(actionGroups).toEqual(['base', 'rates'])
+  })
+
+  it('correctly define base actions list', () => {
+    expect(baseActionsList).toEqual([
+      { action: 'changeName', key: 'name' },
+      { action: 'setKey', key: 'key' },
+      { action: 'setDescription', key: 'description' },
+    ])
+  })
+})
+
+describe('Actions', () => {
+  let taxCategorySync
+  beforeEach(() => {
+    taxCategorySync = taxCategorySyncFn()
+  })
+
+  it('should build `changeName` action', () => {
+    const before = {
+      name: 'John',
+    }
+    const now = {
+      name: 'Robert',
+    }
+
+    const actual = taxCategorySync.buildActions(now, before)
+    const expected = [{ action: 'changeName', name: now.name }]
+    expect(actual).toEqual(expected)
+  })
+
+  it('should build `setKey` action', () => {
+    const before = {
+      key: '1234',
+    }
+    const now = {
+      key: '4321',
+    }
+
+    const actual = taxCategorySync.buildActions(now, before)
+    const expected = [
+      {
+        action: 'setKey',
+        key: now.key,
+      },
+    ]
+    expect(actual).toEqual(expected)
+  })
+
+  it('should build `setDescription` action', () => {
+    const before = {
+      description: 'some description',
+    }
+    const now = {
+      description: 'some updated description',
+    }
+
+    const actual = taxCategorySync.buildActions(now, before)
+    const expected = [
+      {
+        action: 'setDescription',
+        description: now.description,
+      },
+    ]
+    expect(actual).toEqual(expected)
+  })
+
+  it('should build `addTaxRate` action', () => {
+    const before = { addresses: [] }
+    const now = {
+      rates: [{ name: '5% US', amount: '0.05' }],
+    }
+
+    const actual = taxCategorySync.buildActions(now, before)
+    const expected = [{ action: 'addTaxRate', taxRate: now.rates[0] }]
+    expect(actual).toEqual(expected)
+  })
+
+  it('should build `replaceTaxRate` action', () => {
+    const before = {
+      rates: [
+        {
+          id: 'taxRate-1',
+          name: '5% US',
+          amount: '0.05',
+        },
+      ],
+    }
+    const now = {
+      rates: [
+        {
+          id: 'taxRate-1',
+          name: '11% US',
+          amount: '0.11',
+        },
+      ],
+    }
+
+    const actual = taxCategorySync.buildActions(now, before)
+    const expected = [
+      {
+        action: 'replaceTaxRate',
+        taxRateId: before.rates[0].id,
+        taxRate: now.rates[0],
+      },
+    ]
+    expect(actual).toEqual(expected)
+  })
+
+  it('should build `removeTaxRate` action', () => {
+    const before = {
+      rates: [{ id: 'taxRate-1' }],
+    }
+    const now = { rates: [] }
+
+    const actual = taxCategorySync.buildActions(now, before)
+    const expected = [
+      {
+        action: 'removeTaxRate',
+        taxRateId: before.rates[0].id,
+      },
+    ]
+    expect(actual).toEqual(expected)
+  })
+
+  it('should build complex mixed actions', () => {
+    const before = {
+      rates: [
+        {
+          id: 'taxRate-1',
+          name: '11% US',
+          amount: '0.11',
+        },
+        {
+          id: 'taxRate-2',
+          name: '8% DE',
+          amount: '0.08',
+        },
+        {
+          id: 'taxRate-3',
+          name: '21% ES',
+          amount: '0.21',
+        },
+      ],
+    }
+    const now = {
+      rates: [
+        {
+          id: 'taxRate-1',
+          name: '11% US',
+          amount: '0.11',
+          country: 'US',
+        },
+        // REMOVED RATE 2
+        {
+          // UNCHANGED RATE 3
+          id: 'taxRate-3',
+          name: '21% ES',
+          amount: '0.21',
+        },
+        {
+          // ADD NEW RATE
+          id: 'taxRate-4',
+          name: '15% FR',
+          amount: '0.15',
+        },
+      ],
+    }
+
+    const actual = taxCategorySync.buildActions(now, before)
+    const expected = [
+      {
+        action: 'replaceTaxRate',
+        taxRate: {
+          amount: '0.11',
+          country: 'US', // added country to an existing rate
+          id: 'taxRate-1',
+          name: '11% US',
+        },
+        taxRateId: 'taxRate-1',
+      },
+      { action: 'removeTaxRate', taxRateId: 'taxRate-2' }, // removed second tax rate
+      {
+        action: 'addTaxRate',
+        taxRate: { amount: '0.15', id: 'taxRate-4', name: '15% FR' }, // adds new tax rate
+      },
+    ]
+    expect(actual).toEqual(expected)
+  })
+})


### PR DESCRIPTION
affects: @commercetools/sync-actions

#### Summary
add sync actions for tax categories

#### Description
This PR adds the sync actions for the tax categories.