### PR TITLE
feat(zones-sync-actions): Add sync actions for zones

### DIFF
--- a/packages/sync-actions/src/zones-actions.js
+++ b/packages/sync-actions/src/zones-actions.js
@@ -1,0 +1,34 @@
+import { buildBaseAttributesActions } from './utils/common-actions'
+import createBuildArrayActions, {
+  ADD_ACTIONS,
+  REMOVE_ACTIONS,
+} from './utils/create-build-array-actions'
+
+export const baseActionsList = [
+  { action: 'changeName', key: 'name' },
+  { action: 'setDescription', key: 'description' },
+]
+
+export function actionsMapBase(diff, oldObj, newObj) {
+  return buildBaseAttributesActions({
+    actions: baseActionsList,
+    diff,
+    oldObj,
+    newObj,
+  })
+}
+
+export function actionsMapLocations(diff, oldObj, newObj) {
+  const handler = createBuildArrayActions('locations', {
+    [ADD_ACTIONS]: newObject => ({
+      action: 'addLocation',
+      location: newObject,
+    }),
+    [REMOVE_ACTIONS]: objectToRemove => ({
+      action: 'removeLocation',
+      location: objectToRemove,
+    }),
+  })
+
+  return handler(diff, oldObj, newObj)
+}

--- a/packages/sync-actions/src/zones.js
+++ b/packages/sync-actions/src/zones.js
@@ -1,0 +1,47 @@
+/* @flow */
+import flatten from 'lodash.flatten'
+import type { SyncAction, ActionGroup } from '../../../types/sdk'
+import createBuildActions from './utils/create-build-actions'
+import createMapActionGroup from './utils/create-map-action-group'
+import * as zonesActions from './zones-actions'
+import * as diffpatcher from './utils/diffpatcher'
+
+export const actionGroups = ['base', 'locations']
+
+function createZonesMapActions(mapActionGroup) {
+  return function doMapActions(diff, newObj, oldObj /* , options */) {
+    const allActions = []
+
+    allActions.push(
+      mapActionGroup('base', () =>
+        zonesActions.actionsMapBase(diff, oldObj, newObj)
+      )
+    )
+
+    allActions.push(
+      mapActionGroup('locations', () =>
+        zonesActions.actionsMapLocations(diff, oldObj, newObj)
+      )
+    )
+
+    return flatten(allActions)
+  }
+}
+
+export default (config: Array<ActionGroup>): SyncAction => {
+  // config contains information about which action groups
+  // are white/black listed
+
+  // createMapActionGroup returns function 'mapActionGroup' that takes params:
+  // - action group name
+  // - callback function that should return a list of actions that correspond
+  //    to the for the action group
+
+  // this resulting function mapActionGroup will call the callback function
+  // for whitelisted action groups and return the return value of the callback
+  // It will return an empty array for blacklisted action groups
+  const mapActionGroup = createMapActionGroup(config)
+  const doMapActions = createZonesMapActions(mapActionGroup)
+  const buildActions = createBuildActions(diffpatcher.diff, doMapActions)
+  return { buildActions }
+}

--- a/packages/sync-actions/test/zones.spec.js
+++ b/packages/sync-actions/test/zones.spec.js
@@ -1,0 +1,99 @@
+import zonesSyncFn, { actionGroups } from '../src/zones'
+import { baseActionsList } from '../src/zones-actions'
+
+describe('Exports', () => {
+  it('action group list', () => {
+    expect(actionGroups).toEqual(['base', 'locations'])
+  })
+
+  it('correctly define base actions list', () => {
+    expect(baseActionsList).toEqual([
+      { action: 'changeName', key: 'name' },
+      { action: 'setDescription', key: 'description' },
+    ])
+  })
+})
+
+describe('Actions', () => {
+  let zonesSync
+  beforeEach(() => {
+    zonesSync = zonesSyncFn()
+  })
+
+  it('should build `changeName` action', () => {
+    const before = {
+      name: 'Europe',
+    }
+    const now = {
+      name: 'Asia',
+    }
+
+    const actual = zonesSync.buildActions(now, before)
+    const expected = [{ action: 'changeName', name: now.name }]
+    expect(actual).toEqual(expected)
+  })
+
+  it('should build `setDescription` action', () => {
+    const before = {
+      description: 'Zone for Europe',
+    }
+    const now = {
+      description: 'Zone for Asia',
+    }
+
+    const actual = zonesSync.buildActions(now, before)
+    const expected = [
+      {
+        action: 'setDescription',
+        description: now.description,
+      },
+    ]
+    expect(actual).toEqual(expected)
+  })
+
+  describe('`addLocation`', () => {
+    it('should build `addLocation` action with one location', () => {
+      const before = { locations: [] }
+      const now = { locations: [{ country: 'Spain' }] }
+
+      const actual = zonesSync.buildActions(now, before)
+      const expected = [{ action: 'addLocation', location: now.locations[0] }]
+      expect(actual).toEqual(expected)
+    })
+    it('should build `addLocation` action with two locations', () => {
+      const before = { locations: [] }
+      const now = { locations: [{ country: 'Spain' }, { country: 'Italy' }] }
+
+      const actual = zonesSync.buildActions(now, before)
+      const expected = [
+        { action: 'addLocation', location: now.locations[0] },
+        { action: 'addLocation', location: now.locations[1] },
+      ]
+      expect(actual).toEqual(expected)
+    })
+  })
+
+  describe('`removeLocation`', () => {
+    it('should build `removeLocation` action removing one location', () => {
+      const before = { locations: [{ country: 'Spain' }, { country: 'Italy' }] }
+      const now = { locations: [{ country: 'Spain' }] }
+
+      const actual = zonesSync.buildActions(now, before)
+      const expected = [
+        { action: 'removeLocation', location: before.locations[1] },
+      ]
+      expect(actual).toEqual(expected)
+    })
+    it('should build `removeLocation` action removing two locations', () => {
+      const before = { locations: [{ country: 'Spain' }, { country: 'Italy' }] }
+      const now = { locations: [] }
+
+      const actual = zonesSync.buildActions(now, before)
+      const expected = [
+        { action: 'removeLocation', location: before.locations[0] },
+        { action: 'removeLocation', location: before.locations[1] },
+      ]
+      expect(actual).toEqual(expected)
+    })
+  })
+})


### PR DESCRIPTION
affects: @commercetools/sync-actions

add sync actions for zones

#### Summary
Adds sync actions for Zones.

#### Description
Add sync actions for handling changes with Zones in the `project-settings` section of the MC 🥇 


