### PR TITLE
feat(sync-actions): add `extract-matching-pairs`

### DIFF
--- a/packages/sync-actions/src/product-actions.js
+++ b/packages/sync-actions/src/product-actions.js
@@ -2,6 +2,7 @@
 import forEach from 'lodash.foreach'
 import uniqWith from 'lodash.uniqwith'
 import * as diffpatcher from './utils/diffpatcher'
+import extractMatchingPairs from './utils/extract-matching-pairs'
 import {
   buildBaseAttributesActions,
   buildReferenceActions,
@@ -153,23 +154,6 @@ function _buildSetAttributeAction(
   return action
 }
 
-// safely extract oldObj and newObj
-function _extractMatchingNewAndOld(hashMap, key, before, now) {
-  let oldObjPos
-  let newObjPos
-  let oldObj
-  let newObj
-
-  if (hashMap[key]) {
-    oldObjPos = hashMap[key][0]
-    newObjPos = hashMap[key][1]
-    if (before && before[oldObjPos]) oldObj = before[oldObjPos]
-
-    if (now && now[newObjPos]) newObj = now[newObjPos]
-  }
-  return { oldObj, newObj }
-}
-
 function _buildVariantImagesAction(
   diffedImages,
   oldVariant = {},
@@ -184,7 +168,7 @@ function _buildVariantImagesAction(
     'url'
   )
   forEach(diffedImages, (image, key) => {
-    const { oldObj, newObj } = _extractMatchingNewAndOld(
+    const { oldObj, newObj } = extractMatchingPairs(
       matchingImagePairs,
       key,
       oldVariant.images,
@@ -260,7 +244,7 @@ function _buildVariantPricesAction(
     newVariant.prices
   )
   forEach(diffedPrices, (price, key) => {
-    const { oldObj, newObj } = _extractMatchingNewAndOld(
+    const { oldObj, newObj } = extractMatchingPairs(
       matchingPricePairs,
       key,
       oldVariant.prices,
@@ -489,10 +473,7 @@ export function actionsMapAttributes(
 
   if (variants)
     forEach(variants, (variant, key) => {
-      const {
-        oldObj: oldVariant,
-        newObj: newVariant,
-      } = _extractMatchingNewAndOld(
+      const { oldObj: oldVariant, newObj: newVariant } = extractMatchingPairs(
         variantHashMap,
         key,
         oldObj.variants,
@@ -530,10 +511,7 @@ export function actionsMapImages(diff, oldObj, newObj, variantHashMap) {
   const { variants } = diff
   if (variants)
     forEach(variants, (variant, key) => {
-      const {
-        oldObj: oldVariant,
-        newObj: newVariant,
-      } = _extractMatchingNewAndOld(
+      const { oldObj: oldVariant, newObj: newVariant } = extractMatchingPairs(
         variantHashMap,
         key,
         oldObj.variants,
@@ -561,10 +539,7 @@ export function actionsMapPrices(diff, oldObj, newObj, variantHashMap) {
 
   if (variants)
     forEach(variants, (variant, key) => {
-      const {
-        oldObj: oldVariant,
-        newObj: newVariant,
-      } = _extractMatchingNewAndOld(
+      const { oldObj: oldVariant, newObj: newVariant } = extractMatchingPairs(
         variantHashMap,
         key,
         oldObj.variants,

--- a/packages/sync-actions/src/utils/extract-matching-pairs.js
+++ b/packages/sync-actions/src/utils/extract-matching-pairs.js
@@ -1,0 +1,16 @@
+export default function extractMatchingPairs(hashMap, key, before, now) {
+  let oldObjPos
+  let newObjPos
+  let oldObj
+  let newObj
+
+  if (hashMap[key]) {
+    oldObjPos = hashMap[key][0]
+    newObjPos = hashMap[key][1]
+    if (before && before[oldObjPos]) oldObj = before[oldObjPos]
+
+    if (now && now[newObjPos]) newObj = now[newObjPos]
+  }
+
+  return { oldObj, newObj }
+}

--- a/packages/sync-actions/test/utils/extract-matching-pairs.spec.js
+++ b/packages/sync-actions/test/utils/extract-matching-pairs.spec.js
@@ -1,0 +1,55 @@
+import extractMatchingPairs from '../../src/utils/extract-matching-pairs'
+
+describe('extractMatchingPairs', () => {
+  let key
+  let path
+  let oldObj
+  let newObj
+  let pairs
+  describe('with found path', () => {
+    beforeEach(() => {
+      key = '0'
+      path = {
+        [key]: ['0', '0'],
+      }
+      oldObj = [
+        {
+          name: 'foo',
+        },
+      ]
+      newObj = [
+        {
+          name: 'bar',
+        },
+      ]
+      pairs = extractMatchingPairs(path, key, oldObj, newObj)
+    })
+    it('should return `newObj` and `oldObj`', () => {
+      expect(pairs).toEqual({
+        oldObj: { name: 'foo' },
+        newObj: { name: 'bar' },
+      })
+    })
+  })
+  describe('without found pairs', () => {
+    beforeEach(() => {
+      key = '0'
+      path = {
+        [key]: ['0', '0'],
+      }
+      oldObj = [
+        {
+          name: 'foo',
+        },
+      ]
+      newObj = []
+      pairs = extractMatchingPairs(path, key, oldObj, newObj)
+    })
+    it('should return `oldObj` and empty `newObj`', () => {
+      expect(pairs).toEqual({
+        oldObj: { name: 'foo' },
+        newObj: undefined,
+      })
+    })
+  })
+})


### PR DESCRIPTION
#### Summary

Extracting this utility out of [`product-actions`](https://github.com/commercetools/nodejs/blob/master/packages/sync-actions/src/product-actions.js#L157-L172)

This is needed as well for attributes and enums on the [product-types-actions](https://github.com/commercetools/nodejs/blob/aa-add-product-types-sync-actions/packages/sync-actions/src/product-types-actions.js#L53-L58).

Import on the product-actions will follow.