### PR TITLE
431 code groups csv parser

### DIFF
--- a/packages/csv-parser-discount-code/package.json
+++ b/packages/csv-parser-discount-code/package.json
@@ -19,7 +19,7 @@
   "contributors": [
     "Williams Omayuku <williams.omayuku@commercetools.com>"
   ],
-  "main": "lib/index.js",
+  "main": "lib/main.js",
   "bin": {
     "csvparserdiscountcode": "bin/csvparserdiscountcode.js"
   },

--- a/packages/csv-parser-discount-code/package.json
+++ b/packages/csv-parser-discount-code/package.json
@@ -35,7 +35,6 @@
     "csv-parser": "^1.11.0",
     "flat": "^2.0.1",
     "highland": "^2.10.5",
-    "lodash": "^4.17.4",
     "npmlog": "^4.1.0",
     "pretty-error": "^2.1.0",
     "tmp": "0.0.31",

--- a/packages/csv-parser-discount-code/src/index.js
+++ b/packages/csv-parser-discount-code/src/index.js
@@ -1,1 +1,0 @@
-export default from './main'

--- a/packages/csv-parser-discount-code/src/main.js
+++ b/packages/csv-parser-discount-code/src/main.js
@@ -48,11 +48,10 @@ export default class CsvParserDiscountCode {
 
   // Remove fields with empty values from the code objects
   static _removeEmptyFields(item: Object) {
-    const fileredObj = {}
-    Object.keys(item).forEach(key => {
-      if (item[key] !== '') fileredObj[key] = item[key]
-    })
-    return fileredObj
+    return Object.keys(item).reduce((acc, key) => {
+      if (item[key] !== '') acc[key] = item[key]
+      return acc
+    }, {})
   }
 
   parse(input: stream$Readable, output: stream$Writable) {
@@ -91,9 +90,9 @@ export default class CsvParserDiscountCode {
       ? Object.assign(rest, {
           cartDiscounts: cartDiscounts
             .split(this.multiValueDelimiter)
-            .map(cartDiscount => ({
+            .map(cartDiscountId => ({
               typeId: 'cart-discount',
-              id: cartDiscount,
+              id: cartDiscountId,
             })),
         })
       : rest

--- a/packages/csv-parser-discount-code/src/main.js
+++ b/packages/csv-parser-discount-code/src/main.js
@@ -1,5 +1,4 @@
 /* @flow */
-import _ from 'lodash'
 import csv from 'csv-parser'
 import JSONStream from 'JSONStream'
 import highland from 'highland'
@@ -21,6 +20,7 @@ export default class CsvParserDiscountCode {
   _summary: ParserSummary
   _cartDiscountsToArray: Function
   _handleErrors: Function
+  _groupsToArray: Function
   _rowIndex: number
 
   // should take in optional parameters: a logger and a configuration object
@@ -40,6 +40,7 @@ export default class CsvParserDiscountCode {
     }
 
     this._cartDiscountsToArray = this._cartDiscountsToArray.bind(this)
+    this._groupsToArray = this._groupsToArray.bind(this)
     this._handleErrors = this._handleErrors.bind(this)
 
     this._rowIndex = 0
@@ -47,7 +48,11 @@ export default class CsvParserDiscountCode {
 
   // Remove fields with empty values from the code objects
   static _removeEmptyFields(item: Object) {
-    return _.omitBy(item, val => val === '')
+    const fileredObj = {}
+    Object.keys(item).forEach(key => {
+      if (item[key] !== '') fileredObj[key] = item[key]
+    })
+    return fileredObj
   }
 
   parse(input: stream$Readable, output: stream$Writable) {
@@ -62,6 +67,7 @@ export default class CsvParserDiscountCode {
       .map(CsvParserDiscountCode._removeEmptyFields)
       .map(unflatten)
       .map(this._cartDiscountsToArray)
+      .map(this._groupsToArray)
       .map(castTypes)
       .errors(this._handleErrors) // <- Pass errors to errorHandler
       .stopOnError(error => {
@@ -79,16 +85,25 @@ export default class CsvParserDiscountCode {
   // Convert the cartDiscounts field to an array of references to commercetools
   // cartDiscounts
   _cartDiscountsToArray(item: Object) {
-    if (item.cartDiscounts) {
-      const cartDiscounts = item.cartDiscounts
-        .split(this.multiValueDelimiter)
-        .map(cartDiscount => ({
-          typeId: 'cart-discount',
-          id: cartDiscount,
-        }))
-      return Object.assign(item, { cartDiscounts })
-    }
-    return item
+    const { cartDiscounts, ...rest } = item
+
+    return cartDiscounts
+      ? Object.assign(rest, {
+          cartDiscounts: cartDiscounts
+            .split(this.multiValueDelimiter)
+            .map(cartDiscount => ({
+              typeId: 'cart-discount',
+              id: cartDiscount,
+            })),
+        })
+      : rest
+  }
+
+  _groupsToArray(item: Object) {
+    const { groups, ...rest } = item
+    return groups
+      ? Object.assign(rest, { groups: groups.split(this.multiValueDelimiter) })
+      : rest
   }
 
   _handleErrors(error: any, cb: Function) {

--- a/packages/csv-parser-discount-code/test/main.spec.js
+++ b/packages/csv-parser-discount-code/test/main.spec.js
@@ -72,6 +72,25 @@ describe('CsvParserDiscountCode', () => {
     })
   })
 
+  describe('::_groupsToArray', () => {
+    it('should convert `groups` property to an Array', () => {
+      const actual = {
+        foo: 'bar',
+        groups: 'my-group-1;my-group-2',
+      }
+      const expected = {
+        foo: 'bar',
+        groups: ['my-group-1', 'my-group-2'],
+      }
+      expect(csvParser._groupsToArray(actual)).toEqual(expected)
+    })
+
+    it('should do nothing if there is no `groups` property', () => {
+      const sample = { foo: 'bar' }
+      expect(csvParser._cartDiscountsToArray(sample)).toEqual({ foo: 'bar' })
+    })
+  })
+
   describe(':: parse', () => {
     it('should successfully parse CSV to JSON', done => {
       const inputStream = fs.createReadStream(


### PR DESCRIPTION
#### Summary
<!-- Provide a short summary of your changes -->
Support parsing of (discount-code)[https://dev.commercetools.com/http-api-projects-discountCodes.html#discountcode] groups in CSV for importing

Also contains minor refactorings to make code more readable, removes the redundant `index.js` file, and removes `lodash` dependency (Minor step in "delodashing" this repo 😃)

resolves #431 