### PR TITLE
 feat(auth-middleware): add middleware for existing token

### DIFF
--- a/docs/cli/product-exporter.md
+++ b/docs/cli/product-exporter.md
@@ -60,7 +60,7 @@ Options:
   - If the file specified already exists, it will be overwritten.
   - The default location for status report logging is the standard output.
   - If no output path is specified, the exported products will be logged to the standard output.
-- The `predicate` flag specifies an optional (where) query predicate to be included in the request. This predicate should be wrapped in single quotes ('single quoted predicate'). More info on predicates [here](https://docs.commercetools.com/http-api.html#predicates)
+- The `--predicate` flag specifies an optional (where) query predicate to be included in the request. This predicate should be wrapped in single quotes ('single quoted predicate'). More info on predicates [here](https://docs.commercetools.com/http-api.html#predicates)
 - The `--expand` flag specifies the Reference or References to expand in the returned products. The required references for expansion should be passed in as normal strings separated by a space. More information about reference expansion can be found [here](https://docs.commercetools.com/http-api.html#reference-expansion)
 - The `--exportType` flag specifies if products returned should be in JSON file format or chunks. The chunk output is particularly useful if a different output format is desired (such as CSV), in which case, the chunks can be piped to a parser to get the desired format.
 - The `--staged` flag specifies the projection of the products to be fetched.

--- a/docs/sdk/Middlewares.md
+++ b/docs/sdk/Middlewares.md
@@ -31,24 +31,4 @@ const loggerMiddleware = next => (request, response) => {
 }
 ```
 
----
-
-
-## Example
-
-We could implement a *Middleware* which when given an `accessToken` attaches it to the request headers.
-
-```js
-
-const accessToken = "123"; // My super-encrypted access token
-
-const authHeaderWithExistingTokenMiddleware = next => (request, response) => {
-  const requestWithAuth = {
-    ...request,
-    headers: { ...request.headers, Authorization: `Bearer: ${accessToken}` }
-  };
-  next(request, response);
-};
-```
-
 See [official middlewares](/sdk/api/README.md#middlewares) for more advanced examples.

--- a/docs/sdk/api/README.md
+++ b/docs/sdk/api/README.md
@@ -44,6 +44,7 @@ Middelware to authenticate the [request](/sdk/Glossary.md#clientrequest) using o
 * [createAuthMiddlewareForPasswordFlow(options)](/sdk/api/sdkMiddlewareAuth.md#createauthmiddlewareforpasswordflow)
 * [createAuthMiddlewareForRefreshTokenFlow(options)](/sdk/api/sdkMiddlewareAuth.md#createauthmiddlewareforrefreshtokenflow)
 * [createAuthMiddlewareForAnonymousSessionFlow(options)](/sdk/api/sdkMiddlewareAuth.md#createauthmiddlewareforanonymoussessionflow)
+* [createAuthMiddlewareForExistingToken(options)](/sdk/api/sdkMiddlewareAuth.md#createauthmiddlewareforexistingtoken)
 
 ### `sdk-middleware-http`
 Middelware to send the actual HTTP [request](/sdk/Glossary.md#clientrequest).

--- a/docs/sdk/api/README.md
+++ b/docs/sdk/api/README.md
@@ -44,7 +44,7 @@ Middelware to authenticate the [request](/sdk/Glossary.md#clientrequest) using o
 * [createAuthMiddlewareForPasswordFlow(options)](/sdk/api/sdkMiddlewareAuth.md#createauthmiddlewareforpasswordflow)
 * [createAuthMiddlewareForRefreshTokenFlow(options)](/sdk/api/sdkMiddlewareAuth.md#createauthmiddlewareforrefreshtokenflow)
 * [createAuthMiddlewareForAnonymousSessionFlow(options)](/sdk/api/sdkMiddlewareAuth.md#createauthmiddlewareforanonymoussessionflow)
-* [createAuthMiddlewareWithExistingToken(options)](/sdk/api/sdkMiddlewareAuth.md#createauthmiddlewarewithexistingtoken)
+* [createAuthMiddlewareWithExistingToken(authorization, options)](/sdk/api/sdkMiddlewareAuth.md#createauthmiddlewarewithexistingtoken)
 
 ### `sdk-middleware-http`
 Middelware to send the actual HTTP [request](/sdk/Glossary.md#clientrequest).

--- a/docs/sdk/api/README.md
+++ b/docs/sdk/api/README.md
@@ -44,7 +44,7 @@ Middelware to authenticate the [request](/sdk/Glossary.md#clientrequest) using o
 * [createAuthMiddlewareForPasswordFlow(options)](/sdk/api/sdkMiddlewareAuth.md#createauthmiddlewareforpasswordflow)
 * [createAuthMiddlewareForRefreshTokenFlow(options)](/sdk/api/sdkMiddlewareAuth.md#createauthmiddlewareforrefreshtokenflow)
 * [createAuthMiddlewareForAnonymousSessionFlow(options)](/sdk/api/sdkMiddlewareAuth.md#createauthmiddlewareforanonymoussessionflow)
-* [createAuthMiddlewareForExistingToken(options)](/sdk/api/sdkMiddlewareAuth.md#createauthmiddlewareforexistingtoken)
+* [createAuthMiddlewareWithExistingToken(options)](/sdk/api/sdkMiddlewareAuth.md#createauthmiddlewarewithexistingtoken)
 
 ### `sdk-middleware-http`
 Middelware to send the actual HTTP [request](/sdk/Glossary.md#clientrequest).

--- a/docs/sdk/api/sdkMiddlewareAuth.md
+++ b/docs/sdk/api/sdkMiddlewareAuth.md
@@ -151,9 +151,9 @@ const client = createClient({
 })
 ```
 
-## `createAuthMiddlewareForExistingToken(options)`
+## `createAuthMiddlewareWithExistingToken(options)`
 
-Creates a [middleware](/sdk/Glossary.md#middleware) that attaches a known access token a request header.
+Creates a [middleware](/sdk/Glossary.md#middleware) that attaches a known access token `Authorization` header.
 
 #### Named arguments (options)
 
@@ -165,11 +165,11 @@ Creates a [middleware](/sdk/Glossary.md#middleware) that attaches a known access
 
 ```js
 import { createClient } from '@commercetools/sdk-client'
-import { createAuthMiddlewareForExistingToken } from '@commercetools/sdk-middleware-auth'
+import { createAuthMiddlewareWithExistingToken } from '@commercetools/sdk-middleware-auth'
 
 const client = createClient({
   middlewares: [
-    createAuthMiddlewareForExistingToken({
+    createAuthMiddlewareWithExistingToken({
       token: 'my-access-token',
       tokenType: 'Bearer',
       force: true,

--- a/docs/sdk/api/sdkMiddlewareAuth.md
+++ b/docs/sdk/api/sdkMiddlewareAuth.md
@@ -151,7 +151,7 @@ const client = createClient({
 })
 ```
 
-## `createAuthMiddlewareWithExistingToken(options)`
+## `createAuthMiddlewareWithExistingToken(authorization, options)`
 
 Creates a [middleware](/sdk/Glossary.md#middleware) that attaches a known access token `Authorization` header.
 

--- a/docs/sdk/api/sdkMiddlewareAuth.md
+++ b/docs/sdk/api/sdkMiddlewareAuth.md
@@ -150,3 +150,30 @@ const client = createClient({
   ],
 })
 ```
+
+## `createAuthMiddlewareForExistingToken(options)`
+
+Creates a [middleware](/sdk/Glossary.md#middleware) that attaches a known access token a request header.
+
+#### Named arguments (options)
+
+`options` can be a string or an object. If `options` is a _(String)_, it is treated as the access token with other possible options set to their defaults. If `options` is an _(Object)_, it can have the following properties:
+
+1. `token` _(String)_: the access token to be attached to the request
+2. `tokenType` _(String)_: the type of the access token (Default: `Bearer`)
+3. `force` _(Boolean)_: if set to true, existing Authorization header (if any) in the request will be overridden with the supplied access token (Default: `true`)
+
+```js
+import { createClient } from '@commercetools/sdk-client'
+import { createAuthMiddlewareForExistingToken } from '@commercetools/sdk-middleware-auth'
+
+const client = createClient({
+  middlewares: [
+    createAuthMiddlewareForExistingToken({
+      token: 'my-access-token',
+      tokenType: 'Bearer',
+      force: true,
+    }),
+  ],
+})
+```

--- a/docs/sdk/api/sdkMiddlewareAuth.md
+++ b/docs/sdk/api/sdkMiddlewareAuth.md
@@ -155,25 +155,26 @@ const client = createClient({
 
 Creates a [middleware](/sdk/Glossary.md#middleware) that attaches a known access token `Authorization` header.
 
-#### Named arguments (options)
+#### Named arguments (authorization, options)
 
-`options` can be a string or an object. If `options` is a _(String)_, it is treated as the access token with other possible options set to their defaults. If `options` is an _(Object)_, it can have the following properties:
+`authorization` _(String)_: the Authorization to attach to the request header. Can be in the format `"Bearer myAccessToken"`
 
-1. `token` _(String)_: the access token to be attached to the request
-2. `tokenType` _(String)_: the type of the access token (Default: `Bearer`)
-3. `force` _(Boolean)_: if set to true, existing Authorization header (if any) in the request will be overridden with the supplied access token (Default: `true`)
+`options` is an optional _(Object)_, having the following properties:
+
+1. `force` _(Boolean)_: if set to true, existing Authorization header (if any) in the request will be overridden with the supplied access token (Default: `true`)
 
 ```js
 import { createClient } from '@commercetools/sdk-client'
 import { createAuthMiddlewareWithExistingToken } from '@commercetools/sdk-middleware-auth'
 
+const accessToken = 'my-access-token'
+
 const client = createClient({
   middlewares: [
-    createAuthMiddlewareWithExistingToken({
-      token: 'my-access-token',
-      tokenType: 'Bearer',
-      force: true,
-    }),
+    createAuthMiddlewareWithExistingToken(
+      `Bearer ${accessToken}`,
+      { force: true }
+    ),
   ],
 })
 ```

--- a/docs/sdk/api/sdkMiddlewareAuth.md
+++ b/docs/sdk/api/sdkMiddlewareAuth.md
@@ -153,11 +153,11 @@ const client = createClient({
 
 ## `createAuthMiddlewareWithExistingToken(authorization, options)`
 
-Creates a [middleware](/sdk/Glossary.md#middleware) that attaches a known access token `Authorization` header.
+Creates a [middleware](/sdk/Glossary.md#middleware) that attaches a provided access token `Authorization` header.
 
 #### Named arguments (authorization, options)
 
-`authorization` _(String)_: the Authorization to attach to the request header. Can be in the format `"Bearer myAccessToken"`
+`authorization` _(String)_: the value for the `Authorization` header. For example, you may pass the scheme `"Bearer"` (`"Bearer 1234"`) or `"Basic"` (`"Basic 134"`) and so on, depending on your authentication mechanism.
 
 `options` is an optional _(Object)_, having the following properties:
 

--- a/packages/sdk-middleware-auth/src/existing-token.js
+++ b/packages/sdk-middleware-auth/src/existing-token.js
@@ -1,0 +1,45 @@
+/* @flow */
+import type {
+  Middleware,
+  MiddlewareRequest,
+  MiddlewareResponse,
+  ExistingTokenMiddlewareOptions,
+  Next,
+} from '../../../types/sdk'
+
+export default function createAuthMiddlewareForExistingToken(
+  options: ExistingTokenMiddlewareOptions | string
+): Middleware {
+  return (next: Next) => (
+    request: MiddlewareRequest,
+    response: MiddlewareResponse
+  ) => {
+    const config = options
+      ? {
+          tokenType:
+            typeof options === 'object' && options !== null && options.tokenType
+              ? options.tokenType
+              : 'Bearer',
+          token: typeof options === 'string' ? options : options.token,
+          force: options.force !== undefined ? options.force : true,
+        }
+      : null
+
+    if (
+      config === null ||
+      (((request.headers && request.headers.authorization) ||
+        (request.headers && request.headers.Authorization)) &&
+        config.force === false)
+    ) {
+      return next(request, response)
+    }
+    const requestWithAuth = {
+      ...request,
+      headers: {
+        ...request.headers,
+        Authorization: `${config.tokenType} ${config.token}`,
+      },
+    }
+    return next(requestWithAuth, response)
+  }
+}

--- a/packages/sdk-middleware-auth/src/existing-token.js
+++ b/packages/sdk-middleware-auth/src/existing-token.js
@@ -25,8 +25,13 @@ export default function createAuthMiddlewareForExistingToken(
         }
       : null
 
+    /** The request will not be modified if:
+     *  1. no argument is passed
+     *  2. an object is passed that doesn't contain a `token`
+     *  3. force is false and authorization header exists
+     */
     if (
-      config === null ||
+      config === null || !config.token ||
       (((request.headers && request.headers.authorization) ||
         (request.headers && request.headers.Authorization)) &&
         config.force === false)

--- a/packages/sdk-middleware-auth/src/existing-token.js
+++ b/packages/sdk-middleware-auth/src/existing-token.js
@@ -31,7 +31,8 @@ export default function createAuthMiddlewareForExistingToken(
      *  3. force is false and authorization header exists
      */
     if (
-      config === null || !config.token ||
+      config === null ||
+      !config.token ||
       (((request.headers && request.headers.authorization) ||
         (request.headers && request.headers.Authorization)) &&
         config.force === false)

--- a/packages/sdk-middleware-auth/src/index.js
+++ b/packages/sdk-middleware-auth/src/index.js
@@ -9,4 +9,7 @@ export {
 export {
   default as createAuthMiddlewareForAnonymousSessionFlow,
 } from './anonymous-session-flow'
+export {
+  default as createAuthMiddlewareForExistingToken,
+} from './existing-token'
 export * as scopes from './scopes'

--- a/packages/sdk-middleware-auth/src/index.js
+++ b/packages/sdk-middleware-auth/src/index.js
@@ -10,6 +10,6 @@ export {
   default as createAuthMiddlewareForAnonymousSessionFlow,
 } from './anonymous-session-flow'
 export {
-  default as createAuthMiddlewareForExistingToken,
+  default as createAuthMiddlewareWithExistingToken,
 } from './existing-token'
 export * as scopes from './scopes'

--- a/packages/sdk-middleware-auth/test/existing-token.spec.js
+++ b/packages/sdk-middleware-auth/test/existing-token.spec.js
@@ -30,13 +30,22 @@ describe('Existing Token', () => {
     }
   }
 
-  describe('No ardument', () => {
+  describe('No token', () => {
     it('should not modify request if no argument passed', () => {
       const request = createRequest()
       const next = req => {
         expect(req).toBe(request)
       }
       const authMiddleware = createAuthMiddlewareForExistingToken()
+      authMiddleware(next)(request, response)
+    })
+
+    it('should not modify request if argument has no token', () => {
+      const request = createRequest()
+      const next = req => {
+        expect(req).toBe(request)
+      }
+      const authMiddleware = createAuthMiddlewareForExistingToken({})
       authMiddleware(next)(request, response)
     })
   })

--- a/packages/sdk-middleware-auth/test/existing-token.spec.js
+++ b/packages/sdk-middleware-auth/test/existing-token.spec.js
@@ -1,0 +1,116 @@
+import { createAuthMiddlewareForExistingToken } from '../src'
+
+describe('Existing Token', () => {
+  const response = {
+    statusText: 'OK',
+    status: 200,
+    body: null,
+    headers: {},
+  }
+  const restOfRequest = {
+    url: '',
+    method: 'GET',
+    body: null,
+  }
+  function createRequest(options) {
+    return {
+      url: '',
+      method: 'GET',
+      body: null,
+      headers: {},
+      ...options,
+    }
+  }
+  function createTestMiddlewareOptions(options) {
+    return {
+      token: 'my-optimized-access-token',
+      tokenType: 'Bearer',
+      force: true,
+      ...options,
+    }
+  }
+
+  describe('No ardument', () => {
+    it('should not modify request if no argument passed', () => {
+      const request = createRequest()
+      const next = req => {
+        expect(req).toBe(request)
+      }
+      const authMiddleware = createAuthMiddlewareForExistingToken()
+      authMiddleware(next)(request, response)
+    })
+  })
+
+  describe('with argument as object', () => {
+    it('should configure request header with options passed in', () => {
+      const next = req => {
+        expect(req).toEqual(expect.objectContaining(restOfRequest))
+        expect(req).toEqual(
+          expect.objectContaining({
+            headers: { Authorization: 'Bearer my-optimized-access-token' },
+          })
+        )
+      }
+      const request = createRequest()
+      const middlewareOptions = createTestMiddlewareOptions()
+      const authMiddleware = createAuthMiddlewareForExistingToken(
+        middlewareOptions
+      )
+      authMiddleware(next)(request, response)
+    })
+
+    it('should overide authorization if force is true', () => {
+      const next = req => {
+        expect(req).toEqual(expect.objectContaining(restOfRequest))
+        expect(req).toEqual(
+          expect.objectContaining({
+            headers: { Authorization: 'Bearer my-optimized-access-token' },
+          })
+        )
+      }
+      const request = createRequest({
+        headers: { Authorization: 'Basic old-access-token' },
+      })
+      const middlewareOptions = createTestMiddlewareOptions()
+      const authMiddleware = createAuthMiddlewareForExistingToken(
+        middlewareOptions
+      )
+      authMiddleware(next)(request, response)
+    })
+
+    it('should not overide authorization if force is false', () => {
+      const next = req => {
+        expect(req).toEqual(expect.objectContaining(restOfRequest))
+        expect(req).toEqual(
+          expect.objectContaining({
+            headers: { Authorization: 'Basic old-access-token' },
+          })
+        )
+      }
+      const request = createRequest({
+        headers: { Authorization: 'Basic old-access-token' },
+      })
+      const middlewareOptions = createTestMiddlewareOptions({ force: false })
+      const authMiddleware = createAuthMiddlewareForExistingToken(
+        middlewareOptions
+      )
+      authMiddleware(next)(request, response)
+    })
+  })
+
+  describe('with argument as string', () => {
+    it('should configure request header with default options and token', () => {
+      const next = req => {
+        expect(req).toEqual(expect.objectContaining(restOfRequest))
+        expect(req).toEqual(
+          expect.objectContaining({
+            headers: { Authorization: 'Bearer my-token' },
+          })
+        )
+      }
+      const request = createRequest()
+      const authMiddleware = createAuthMiddlewareForExistingToken('my-token')
+      authMiddleware(next)(request, response)
+    })
+  })
+})

--- a/packages/sdk-middleware-auth/test/existing-token.spec.js
+++ b/packages/sdk-middleware-auth/test/existing-token.spec.js
@@ -1,4 +1,4 @@
-import { createAuthMiddlewareForExistingToken } from '../src'
+import { createAuthMiddlewareWithExistingToken } from '../src'
 
 describe('Existing Token', () => {
   const response = {
@@ -21,37 +21,26 @@ describe('Existing Token', () => {
       ...options,
     }
   }
-  function createTestMiddlewareOptions(options) {
-    return {
-      token: 'my-optimized-access-token',
-      tokenType: 'Bearer',
-      force: true,
-      ...options,
-    }
-  }
 
-  describe('No token', () => {
+  describe('Basics', () => {
     it('should not modify request if no argument passed', () => {
       const request = createRequest()
       const next = req => {
         expect(req).toBe(request)
       }
-      const authMiddleware = createAuthMiddlewareForExistingToken()
+      const authMiddleware = createAuthMiddlewareWithExistingToken()
       authMiddleware(next)(request, response)
     })
 
-    it('should not modify request if argument has no token', () => {
-      const request = createRequest()
-      const next = req => {
-        expect(req).toBe(request)
-      }
-      const authMiddleware = createAuthMiddlewareForExistingToken({})
-      authMiddleware(next)(request, response)
+    it('should throw if `authorization` is not a string', () => {
+      expect(createAuthMiddlewareWithExistingToken({})()).toThrowError(
+        /authorization must be a string/
+      )
     })
   })
 
-  describe('with argument as object', () => {
-    it('should configure request header with options passed in', () => {
+  describe('with only authorization argument', () => {
+    it('should configure request header with authorization', () => {
       const next = req => {
         expect(req).toEqual(expect.objectContaining(restOfRequest))
         expect(req).toEqual(
@@ -61,14 +50,13 @@ describe('Existing Token', () => {
         )
       }
       const request = createRequest()
-      const middlewareOptions = createTestMiddlewareOptions()
-      const authMiddleware = createAuthMiddlewareForExistingToken(
-        middlewareOptions
+      const authMiddleware = createAuthMiddlewareWithExistingToken(
+        'Bearer my-optimized-access-token'
       )
       authMiddleware(next)(request, response)
     })
 
-    it('should overide authorization if force is true', () => {
+    it('should overide existing authorization', () => {
       const next = req => {
         expect(req).toEqual(expect.objectContaining(restOfRequest))
         expect(req).toEqual(
@@ -80,9 +68,29 @@ describe('Existing Token', () => {
       const request = createRequest({
         headers: { Authorization: 'Basic old-access-token' },
       })
-      const middlewareOptions = createTestMiddlewareOptions()
-      const authMiddleware = createAuthMiddlewareForExistingToken(
-        middlewareOptions
+      const authMiddleware = createAuthMiddlewareWithExistingToken(
+        'Bearer my-optimized-access-token'
+      )
+      authMiddleware(next)(request, response)
+    })
+  })
+
+  describe('with two arguments', () => {
+    it('should overide existing authorization if false is true', () => {
+      const next = req => {
+        expect(req).toEqual(expect.objectContaining(restOfRequest))
+        expect(req).toEqual(
+          expect.objectContaining({
+            headers: { Authorization: 'Bearer my-optimized-access-token' },
+          })
+        )
+      }
+      const request = createRequest({
+        headers: { Authorization: 'Basic old-access-token' },
+      })
+      const authMiddleware = createAuthMiddlewareWithExistingToken(
+        'Bearer my-optimized-access-token',
+        { force: true }
       )
       authMiddleware(next)(request, response)
     })
@@ -99,26 +107,10 @@ describe('Existing Token', () => {
       const request = createRequest({
         headers: { Authorization: 'Basic old-access-token' },
       })
-      const middlewareOptions = createTestMiddlewareOptions({ force: false })
-      const authMiddleware = createAuthMiddlewareForExistingToken(
-        middlewareOptions
+      const authMiddleware = createAuthMiddlewareWithExistingToken(
+        'Bearer my-optimized-access-token',
+        { force: false }
       )
-      authMiddleware(next)(request, response)
-    })
-  })
-
-  describe('with argument as string', () => {
-    it('should configure request header with default options and token', () => {
-      const next = req => {
-        expect(req).toEqual(expect.objectContaining(restOfRequest))
-        expect(req).toEqual(
-          expect.objectContaining({
-            headers: { Authorization: 'Bearer my-token' },
-          })
-        )
-      }
-      const request = createRequest()
-      const authMiddleware = createAuthMiddlewareForExistingToken('my-token')
       authMiddleware(next)(request, response)
     })
   })

--- a/types/sdk.js
+++ b/types/sdk.js
@@ -310,7 +310,5 @@ export type ActionGroup = {
 }
 
 export type ExistingTokenMiddlewareOptions = {
-  token: string,
-  tokenType?: string,
   force?: boolean,
 }

--- a/types/sdk.js
+++ b/types/sdk.js
@@ -308,3 +308,9 @@ export type ActionGroup = {
   type: string,
   group: 'black' | 'white',
 }
+
+export type ExistingTokenMiddlewareOptions = {
+  token: string,
+  tokenType?: string,
+  force?: boolean,
+}


### PR DESCRIPTION
#### Summary
<!-- Provide a short summary of your changes -->
Add middleware for directly attaching token to  request headers
#### Description
<!-- Describe the changes in this PR here and provide some context -->
Related to #446 this package adds the middleware to attach an already known access token to the request header
#### Talking points
It will be nice to get input on a few things before this gets merged:
 - The object properties used are `token`, `tokenType` and `force`. Does this method make sense? Are `force` and `tokenType` necessary? should they be renamed to `accessToken`, `access_token`, `accessTokenType`, `access_token_type`, etc?
 - Also, I implemented it such that it simply passes the request and response to the next middleware if there is no token passed in? I think this makes sense in certain situations such as modules that can be built to use this middleware, or an authentication flow if there is no access token. Does this make sense?

Would be nice to get your feedback/review.

resolves #464 