### PR TITLE
fix(zones-locations): fix zone locations updates

### DIFF
--- a/packages/sync-actions/src/zones-actions.js
+++ b/packages/sync-actions/src/zones-actions.js
@@ -25,20 +25,45 @@ export function actionsMapLocations(diff, oldObj, newObj) {
       action: 'addLocation',
       location: newLocation,
     }),
-    [REMOVE_ACTIONS]: oldLocation => ({
-      action: 'removeLocation',
-      location: oldLocation,
-    }),
-    [CHANGE_ACTIONS]: (oldLocation, newLocation) => [
-      {
-        action: 'removeLocation',
-        location: oldLocation,
-      },
-      {
-        action: 'addLocation',
-        location: newLocation,
-      },
-    ],
+    [REMOVE_ACTIONS]: oldLocation =>
+      // We only add the action if the location is not included in the new object.
+      !newObj.locations.find(
+        location => location.country === oldLocation.country
+      )
+        ? {
+            action: 'removeLocation',
+            location: oldLocation,
+          }
+        : null,
+    [CHANGE_ACTIONS]: (oldLocation, newLocation) => {
+      const result = []
+
+      // We only remove the location in case that the oldLocation is not
+      // included in the new object
+      if (
+        !newObj.locations.find(
+          location => location.country === oldLocation.country
+        )
+      )
+        result.push({
+          action: 'removeLocation',
+          location: oldLocation,
+        })
+
+      // We only add the location in case that the newLocation was not
+      // included in the old object
+      if (
+        !oldObj.locations.find(
+          location => location.country === newLocation.country
+        )
+      )
+        result.push({
+          action: 'addLocation',
+          location: newLocation,
+        })
+
+      return result
+    },
   })
 
   return handler(diff, oldObj, newObj)

--- a/packages/sync-actions/src/zones-actions.js
+++ b/packages/sync-actions/src/zones-actions.js
@@ -10,6 +10,9 @@ export const baseActionsList = [
   { action: 'setDescription', key: 'description' },
 ]
 
+const hasLocation = (locations, otherLocation) =>
+  locations.some(location => location.country === otherLocation.country)
+
 export function actionsMapBase(diff, oldObj, newObj) {
   return buildBaseAttributesActions({
     actions: baseActionsList,
@@ -27,9 +30,7 @@ export function actionsMapLocations(diff, oldObj, newObj) {
     }),
     [REMOVE_ACTIONS]: oldLocation =>
       // We only add the action if the location is not included in the new object.
-      !newObj.locations.find(
-        location => location.country === oldLocation.country
-      )
+      !hasLocation(newObj.locations, oldLocation)
         ? {
             action: 'removeLocation',
             location: oldLocation,
@@ -40,11 +41,7 @@ export function actionsMapLocations(diff, oldObj, newObj) {
 
       // We only remove the location in case that the oldLocation is not
       // included in the new object
-      if (
-        !newObj.locations.find(
-          location => location.country === oldLocation.country
-        )
-      )
+      if (!hasLocation(newObj.locations, oldLocation))
         result.push({
           action: 'removeLocation',
           location: oldLocation,
@@ -52,11 +49,7 @@ export function actionsMapLocations(diff, oldObj, newObj) {
 
       // We only add the location in case that the newLocation was not
       // included in the old object
-      if (
-        !oldObj.locations.find(
-          location => location.country === newLocation.country
-        )
-      )
+      if (!hasLocation(oldObj.locations, newLocation))
         result.push({
           action: 'addLocation',
           location: newLocation,

--- a/packages/sync-actions/test/zones.spec.js
+++ b/packages/sync-actions/test/zones.spec.js
@@ -133,4 +133,58 @@ describe('Actions', () => {
       expect(actual).toEqual(expected)
     })
   })
+
+  describe('Delete first locations', () => {
+    it('should build multiple actions for required changes', () => {
+      const before = {
+        locations: [
+          { country: 'Spain' },
+          { country: 'Italy' },
+          { country: 'France' },
+        ],
+      }
+      const now = {
+        locations: [{ country: 'France' }],
+      }
+
+      const actual = zonesSync.buildActions(now, before)
+      const expected = [
+        { action: 'removeLocation', location: before.locations[0] },
+        { action: 'removeLocation', location: before.locations[1] },
+      ]
+      expect(actual).toEqual(expected)
+    })
+  })
+
+  describe('Delete multiple locations', () => {
+    it('should build multiple actions for required changes', () => {
+      const before = {
+        locations: [
+          { country: 'Spain' },
+          { country: 'Italy' },
+          { country: 'Poland' },
+          { country: 'France' },
+          { country: 'Portugal' },
+          { country: 'Germany' },
+        ],
+      }
+      const now = {
+        locations: [
+          { country: 'Italy' },
+          { country: 'Poland' },
+          { country: 'Portugal' },
+          { country: 'Russia' },
+        ],
+      }
+
+      const actual = zonesSync.buildActions(now, before)
+      const expected = [
+        { action: 'removeLocation', location: before.locations[0] },
+        { action: 'removeLocation', location: before.locations[3] },
+        { action: 'addLocation', location: now.locations[3] },
+        { action: 'removeLocation', location: before.locations[5] },
+      ]
+      expect(actual).toEqual(expected)
+    })
+  })
 })


### PR DESCRIPTION
affects: @commercetools/sync-actions

#### Summary

This PR fixes some issues that appear during the UX/UAT that were indeed related to the sync-actions of zones.

I've added some code comment to explaining the use cases. Hope that makes sense 👍 

#### Description
Basically there were some cases that the sync-actions were not handling correctly guiding us to some UI errors (API errors) in the MC FE.

Working example. Let's say I have this object:

`locations: [{country: 'Spain'} ,{country: 'Germany'}]`

And my new object is:

`locations: [{country: 'Germany'}]`

The sync actions builded were:
```js
  [
    {action: "removeLocation", location: {country: "Spain"}},
    {action: "addLocation", location: {country: "Germany"}},
    {action: "removeLocation", location: {country: "Germany"}}
  ] 
```

That set of actions leads us to an API error because we can't add a location that is already assigned to the zone (Germany).

