### PR TITLE
feat(sdk-middleware-http): allow to pass credentials mode to fetch object

### DIFF
--- a/docs/sdk/api/sdkMiddlewareHttp.md
+++ b/docs/sdk/api/sdkMiddlewareHttp.md
@@ -21,6 +21,7 @@ Creates a [middleware](/sdk/Glossary.md#middleware) to handle HTTP requests for 
 #### Named arguments (options)
 
 1. `host` *(String)*: the host of the HTTP API service
+2. `credentialsMode` *(String)*: one of the supported `credentials` modes (`omit`, `same-origin`, `include`), useful when working with HTTP Cookies. (Default: undefined)
 2. `includeResponseHeaders` *(Boolean)*: flag whether to include the response headers in the response, if omitted headers is omitted from response
 3. `includeOriginalRequest` *(Boolean)*: flag whether to include the original request sent in the response. Can be useful if you want to see the final request being sent.
 4. `maskSensitiveHeaderData` *(Boolean)*: flag to mask sensitie data in the header. e.g. Authorization token

--- a/docs/sdk/api/sdkMiddlewareHttp.md
+++ b/docs/sdk/api/sdkMiddlewareHttp.md
@@ -21,7 +21,7 @@ Creates a [middleware](/sdk/Glossary.md#middleware) to handle HTTP requests for 
 #### Named arguments (options)
 
 1. `host` *(String)*: the host of the HTTP API service
-2. `credentialsMode` *(String)*: one of the supported `credentials` modes (`omit`, `same-origin`, `include`), useful when working with HTTP Cookies. (Default: undefined)
+2. `credentialsMode` *(String)*: one of the supported `credentials` modes (`omit`, `same-origin`, `include`), useful when working with HTTP Cookies. (optional)
 2. `includeResponseHeaders` *(Boolean)*: flag whether to include the response headers in the response, if omitted headers is omitted from response
 3. `includeOriginalRequest` *(Boolean)*: flag whether to include the original request sent in the response. Can be useful if you want to see the final request being sent.
 4. `maskSensitiveHeaderData` *(Boolean)*: flag to mask sensitie data in the header. e.g. Authorization token

--- a/packages/sdk-middleware-http/src/http.js
+++ b/packages/sdk-middleware-http/src/http.js
@@ -42,6 +42,7 @@ function calcDelayDuration(
 
 export default function createHttpMiddleware({
   host,
+  credentialsMode,
   includeResponseHeaders,
   includeOriginalRequest,
   maskSensitiveHeaderData,
@@ -68,6 +69,7 @@ export default function createHttpMiddleware({
     const requestObj: Object = new Request(url, {
       method: request.method,
       headers: new Headers(requestHeader),
+      ...(credentialsMode ? { credentials: credentialsMode } : {}),
       ...(body ? { body } : {}),
     })
     let retryCount = 0

--- a/types/sdk.js
+++ b/types/sdk.js
@@ -153,6 +153,7 @@ export type PasswordAuthMiddlewareOptions = {
 
 export type HttpMiddlewareOptions = {
   host: string,
+  credentialsMode?: 'omit' | 'same-origin' | 'include',
   includeHeaders?: boolean,
   includeResponseHeaders?: boolean,
   includeOriginalRequest?: boolean,


### PR DESCRIPTION
#### Summary
When working with HTTP Cookies, the SDK HTTP middleware should be able to be configured to set the `credentials` mode (https://github.com/github/fetch#sending-cookies).

#### Description
Adds a new option `credentialsMode` to the `createHttpMiddleware`.

NOTE: I wasn't able to properly write a test for this, it's kind of tricky to reach into the internals of `fetch`.