### PR TITLE
fix(shipping-methods): Fix issue when adding a new zoneRate with shippingRates

### DIFF
--- a/packages/sync-actions/src/shipping-methods-actions.js
+++ b/packages/sync-actions/src/shipping-methods-actions.js
@@ -55,10 +55,19 @@ function actionsMapZoneRatesShippingRates(diff, oldObj, newObj) {
 
 export function actionsMapZoneRates(diff, oldObj, newObj) {
   const handler = createBuildArrayActions('zoneRates', {
-    [ADD_ACTIONS]: newZoneRate => ({
-      action: 'addZone',
-      zone: newZoneRate.zone,
-    }),
+    [ADD_ACTIONS]: newZoneRate => [
+      {
+        action: 'addZone',
+        zone: newZoneRate.zone,
+      },
+      ...(newZoneRate.shippingRates
+        ? newZoneRate.shippingRates.map(shippingRate => ({
+            action: 'addShippingRate',
+            zone: newZoneRate.zone,
+            shippingRate,
+          }))
+        : []),
+    ],
     [REMOVE_ACTIONS]: oldZoneRate => ({
       action: 'removeZone',
       zone: oldZoneRate.zone,

--- a/packages/sync-actions/test/shipping-methods.spec.js
+++ b/packages/sync-actions/test/shipping-methods.spec.js
@@ -457,4 +457,54 @@ describe('Actions', () => {
       expect(actual).toEqual(expected)
     })
   })
+
+  describe('When adding a new zoneRate with zone and shippingRates (fixed rates)', () => {
+    it('should build different actions for adding zone and shippingRates', () => {
+      const before = {
+        zoneRates: [
+          {
+            zone: { typeId: 'zone', id: 'z1' },
+            shippingRates: [
+              { price: { currencyCode: 'EUR', centAmount: 1000 } },
+              { price: { currencyCode: 'USD', centAmount: 1000 } },
+            ],
+          },
+        ],
+      }
+      const now = {
+        zoneRates: [
+          {
+            zone: { typeId: 'zone', id: 'z1' },
+            shippingRates: [
+              { price: { currencyCode: 'EUR', centAmount: 1000 } },
+              { price: { currencyCode: 'USD', centAmount: 1000 } },
+            ],
+          },
+          {
+            zone: { typeId: 'zone 2', id: 'z2' },
+            shippingRates: [
+              { price: { currencyCode: 'EUR', centAmount: 1000 } },
+              { price: { currencyCode: 'USD', centAmount: 1000 } },
+            ],
+          },
+        ],
+      }
+
+      const actual = shippingMethodsSync.buildActions(now, before)
+      const expected = [
+        { action: 'addZone', zone: now.zoneRates[1].zone },
+        {
+          action: 'addShippingRate',
+          shippingRate: now.zoneRates[1].shippingRates[0],
+          zone: now.zoneRates[1].zone,
+        },
+        {
+          action: 'addShippingRate',
+          shippingRate: now.zoneRates[1].shippingRates[1],
+          zone: now.zoneRates[1].zone,
+        },
+      ]
+      expect(actual).toEqual(expected)
+    })
+  })
 })


### PR DESCRIPTION
affects: @commercetools/sync-actions

#### Summary

This PR fixes an issue when trying to add a new zoneRate to a shipping method with also shippingRates.

I've added some test for this use case. Hope that makes sense 👍 

#### Description

Basically in the `ADD_ACTION` section we were not checking if when we `addZone` , we are also adding shippingRates. Example:

```js
// before
zoneRates: []

// now
zoneRates:[ { zone: {....}, shippingRates: [{ price: {...} }, { price: {...} ]

// Expected behaviour
actions: 'addZone', 'addShippingRate', 'addShippingRate'

// Observed behaviour
actions: 'addZone'
