### PR TITLE
fix(tax-categories-actions): Fix issue when doing multiple complex actions on rates

### DIFF
--- a/packages/sync-actions/src/tax-categories-actions.js
+++ b/packages/sync-actions/src/tax-categories-actions.js
@@ -30,18 +30,12 @@ export function actionsMapRates(diff, oldObj, newObj) {
       action: 'removeTaxRate',
       taxRateId: objectToRemove.id,
     }),
-    [CHANGE_ACTIONS]: (oldObject, updatedObject) =>
-      oldObject.id === updatedObject.id
-        ? {
-            action: 'replaceTaxRate',
-            taxRateId: oldObject.id,
-            taxRate: updatedObject,
-          }
-        : {
-            action: 'replaceTaxRate',
-            taxRateId: updatedObject.id,
-            taxRate: updatedObject,
-          },
+    [CHANGE_ACTIONS]: (oldObject, updatedObject) => ({
+      action: 'replaceTaxRate',
+      taxRateId:
+        oldObject.id === updatedObject.id ? oldObject.id : updatedObject.id,
+      taxRate: updatedObject,
+    }),
   })
 
   return handler(diff, oldObj, newObj)

--- a/packages/sync-actions/src/tax-categories-actions.js
+++ b/packages/sync-actions/src/tax-categories-actions.js
@@ -30,11 +30,18 @@ export function actionsMapRates(diff, oldObj, newObj) {
       action: 'removeTaxRate',
       taxRateId: objectToRemove.id,
     }),
-    [CHANGE_ACTIONS]: (oldObject, updatedObject) => ({
-      action: 'replaceTaxRate',
-      taxRateId: oldObject.id,
-      taxRate: updatedObject,
-    }),
+    [CHANGE_ACTIONS]: (oldObject, updatedObject) =>
+      oldObject.id === updatedObject.id
+        ? {
+            action: 'replaceTaxRate',
+            taxRateId: oldObject.id,
+            taxRate: updatedObject,
+          }
+        : {
+            action: 'replaceTaxRate',
+            taxRateId: updatedObject.id,
+            taxRate: updatedObject,
+          },
   })
 
   return handler(diff, oldObj, newObj)

--- a/packages/sync-actions/test/tax-categories-sync.spec.js
+++ b/packages/sync-actions/test/tax-categories-sync.spec.js
@@ -128,7 +128,7 @@ describe('Actions', () => {
     expect(actual).toEqual(expected)
   })
 
-  test('should build complex mixed actions', () => {
+  test('should build complex mixed actions (1)', () => {
     const before = {
       rates: [
         {
@@ -190,6 +190,69 @@ describe('Actions', () => {
         taxRate: { amount: '0.15', id: 'taxRate-4', name: '15% FR' }, // adds new tax rate
       },
     ]
+    expect(actual).toEqual(expected)
+  })
+
+  test('should build complex mixed actions (2)', () => {
+    const before = {
+      rates: [
+        {
+          id: 'taxRate-1',
+          name: '11% US',
+          amount: '0.11',
+        },
+        {
+          id: 'taxRate-2',
+          name: '8% DE',
+          amount: '0.08',
+        },
+        {
+          id: 'taxRate-3',
+          name: '21% ES',
+          amount: '0.21',
+        },
+      ],
+    }
+    const now = {
+      rates: [
+        // REMOVED RATE 1
+        // REMOVED RATE 2
+        {
+          // CHANGED RATE 3
+          id: 'taxRate-3',
+          name: '21% ES',
+          state: 'NY',
+          amount: '0.21',
+        },
+        {
+          // ADD NEW RATE
+          id: 'taxRate-4',
+          name: '15% FR',
+          amount: '0.15',
+        },
+      ],
+    }
+
+    const actual = taxCategorySync.buildActions(now, before)
+    const expected = [
+      {
+        action: 'replaceTaxRate',
+        taxRate: {
+          amount: '0.21',
+          id: 'taxRate-3',
+          name: '21% ES',
+          state: 'NY',
+        },
+        taxRateId: 'taxRate-3',
+      },
+      { action: 'removeTaxRate', taxRateId: 'taxRate-1' }, // removed first tax rate
+      { action: 'removeTaxRate', taxRateId: 'taxRate-2' }, // removed second tax rate
+      {
+        action: 'addTaxRate',
+        taxRate: { amount: '0.15', id: 'taxRate-4', name: '15% FR' }, // adds new tax rate
+      },
+    ]
+
     expect(actual).toEqual(expected)
   })
 })


### PR DESCRIPTION
affects: @commercetools/sync-actions

**Summary**
This PR fixes an issue when doing multiple complex actions with tax categories rates.

I've added some test for this use case. Hope that makes sense 👍

**Description**
We were not taking into account if we were updating the correct rate in the `replaceTaxRate`, specially when we delete and update rates. I guess is because how the diff is returned.

NOTE--> I've already slap Dani for this 😝💪

```js
// before
rates: [{ id: 1, name: 'A' }, { id: 2, name: 'B' }]

// now
rates: [{ id: 2, name: 'C' }]

// Expected behaviour
actions: [{
      {
        action: 'replaceTaxRate',
        taxRate: { id: 2, name: 'C' },
        taxRateId: 2,
      },
      { action: 'removeTaxRate', taxRateId: 1 }, // removed first tax rate
}]

// Observed behaviour
actions: [{
      {
        action: 'replaceTaxRate',
        taxRate: { id: 2, name: 'C' }, 🤷‍♂️
        taxRateId: 1, 😡
      },
      { action: 'removeTaxRate', taxRateId: 1 }, // removed first tax rate
}]