### PR TITLE
fix(HTTP): Make error maskSensitiveHeaderData

### DIFF
--- a/packages/sdk-middleware-http/src/http.js
+++ b/packages/sdk-middleware-http/src/http.js
@@ -145,6 +145,9 @@ export default function createHttpMiddleware({
               retryCount += 1
               return
             }
+          if (maskSensitiveHeaderData) {
+            request.headers.Authorization = 'Bearer ********'
+          }
           const error = new NetworkError(e.message, {
             originalRequest: request,
             retryCount,

--- a/packages/sdk-middleware-http/src/http.js
+++ b/packages/sdk-middleware-http/src/http.js
@@ -146,7 +146,7 @@ export default function createHttpMiddleware({
               return
             }
           if (maskSensitiveHeaderData) {
-            request.headers.Authorization = 'Bearer ********'
+            request.headers.authorization = 'Bearer ********'
           }
           const error = new NetworkError(e.message, {
             originalRequest: request,

--- a/packages/sdk-middleware-http/test/http.spec.js
+++ b/packages/sdk-middleware-http/test/http.spec.js
@@ -473,7 +473,7 @@ describe('Http', () => {
       const request = createTestRequest({
         uri: '/foo/bar',
         headers: {
-          Authorization: 'Bearer 123',
+          authorization: 'Bearer 123',
         },
       })
       const response = { resolve, reject }
@@ -484,7 +484,7 @@ describe('Http', () => {
           method: 'GET',
           uri: '/foo/bar',
           headers: {
-            Authorization: 'Bearer ********',
+            authorization: 'Bearer ********',
           },
         })
         resolve()


### PR DESCRIPTION
#### Summary
When API returns an error respons, e.g. 404 not found, we leak authorization token in error object. I will create another ticket for an eventual change to `maskSensitiveHeaderData` so it defaults to `true`
#### Todo

- Tests
    - [x] Unit
    - [x] Integration

resolves #518
