### PR TITLE
feat(order-update): Implement encoding flag for CSV

### DIFF
--- a/docs/cli/csv-parser-orders.md
+++ b/docs/cli/csv-parser-orders.md
@@ -23,7 +23,7 @@ Options:
   --outputFile, -o  Path to output JSON file.                    [default: "stdout"]
   --batchSize, -b   Number of CSV rows to handle simultaneously. [default: 100]
   --delimiter, -d   Used CSV delimiter.                          [default: ","]
-  --encoding, -e    Encoding used in the CSV.                    [string] [default: "utf8"]
+  --encoding, -e    Encoding used in the CSV.                    [default: "utf8"]
   --strictMode, -s  Parse CSV strictly.                          [default: true]
   --logLevel, -l    Logging level: error, warn, info or verbose. [default: "info"]
   --logFile         Path to file where to save logs.             [default: "csvparserorder.log"]

--- a/docs/cli/csv-parser-orders.md
+++ b/docs/cli/csv-parser-orders.md
@@ -23,7 +23,7 @@ Options:
   --outputFile, -o  Path to output JSON file.                    [default: "stdout"]
   --batchSize, -b   Number of CSV rows to handle simultaneously. [default: 100]
   --delimiter, -d   Used CSV delimiter.                          [default: ","]
-	--encoding, -e    Encoding used in the CSV										 [string] [default: "utf8"]
+  --encoding, -e    Encoding used in the CSV.                    [string] [default: "utf8"]
   --strictMode, -s  Parse CSV strictly.                          [default: true]
   --logLevel, -l    Logging level: error, warn, info or verbose. [default: "info"]
   --logFile         Path to file where to save logs.             [default: "csvparserorder.log"]

--- a/docs/cli/csv-parser-orders.md
+++ b/docs/cli/csv-parser-orders.md
@@ -23,6 +23,7 @@ Options:
   --outputFile, -o  Path to output JSON file.                    [default: "stdout"]
   --batchSize, -b   Number of CSV rows to handle simultaneously. [default: 100]
   --delimiter, -d   Used CSV delimiter.                          [default: ","]
+	--encoding, -e    Encoding used in the CSV										 [string] [default: "utf8"]
   --strictMode, -s  Parse CSV strictly.                          [default: true]
   --logLevel, -l    Logging level: error, warn, info or verbose. [default: "info"]
   --logFile         Path to file where to save logs.             [default: "csvparserorder.log"]

--- a/integration-tests/cli/__snapshots__/csv-parser-orders.it.js.snap
+++ b/integration-tests/cli/__snapshots__/csv-parser-orders.it.js.snap
@@ -15,6 +15,7 @@ Options:
   --outputFile, -o  Path to output JSON file.                [default: \\"stdout\\"]
   --batchSize, -b   Number of CSV rows to handle simultaneously.  [default: 100]
   --delimiter, -d   Used CSV delimiter.                           [default: \\",\\"]
+  --encoding, -e    Used CSV encoding.                         [default: \\"utf8\\"]
   --strictMode, -s  Parse CSV strictly.                          [default: true]
   --logLevel, -l    Logging level: error, warn, info or verbose.
                                                                [default: \\"info\\"]

--- a/packages/csv-parser-orders/src/cli.js
+++ b/packages/csv-parser-orders/src/cli.js
@@ -64,6 +64,11 @@ Convert commercetools order CSV data to JSON.`
     default: CONSTANTS.standardOption.delimiter,
     describe: 'Used CSV delimiter.',
   })
+  .option('encoding', {
+    alias: 'e',
+    default: CONSTANTS.standardOption.encoding,
+    describe: 'Used CSV encoding.',
+  })
   .option('strictMode', {
     alias: 's',
     default: CONSTANTS.standardOption.strictMode,
@@ -119,7 +124,7 @@ const methodMapping = {
 
 // Register error listener
 args.outputFile.on('error', errorHandler)
-
+args.inputFile.setEncoding(args.encoding)
 methodMapping[args.type](getModuleConfig()).parse(
   args.inputFile,
   args.outputFile

--- a/packages/csv-parser-orders/src/constants.js
+++ b/packages/csv-parser-orders/src/constants.js
@@ -31,6 +31,7 @@ const CONSTANTS = {
     defaultLogLevel: 'info',
     batchSize: 100,
     delimiter: ',',
+    encoding: 'utf8',
     strictMode: true,
   },
 }


### PR DESCRIPTION
#### Summary
PR enables encoding option (default is `utf8`).

#### Description
Client was reporting a bug where they could not update orders with CSV's that used `hex` encoding instead of default `utf8`. PR will enable them to use this. 

resolves #532
