### PR TITLE
Fixed typo in API Request Builder doc

### DIFF
--- a/docs/sdk/api/apiRequestBuilder.md
+++ b/docs/sdk/api/apiRequestBuilder.md
@@ -86,7 +86,7 @@ const channelsUri = requestBuilder.channels
   .withVersion(3)
   .build()
 const channelsRequest = {
-  url: channelsUri,
+  uri: channelsUri,
   method: 'GET',
 }
 


### PR DESCRIPTION
#### Summary
Fixed typo in API Request Builder doc

#### Description
There is a typo in the API Request Builder doc. It has `url` in the request object and that fails. Correct key is `uri`.
