### PR TITLE
fix(product-json-to-csv): use default quotes value(")

### DIFF
--- a/packages/product-json-to-csv/src/writer.js
+++ b/packages/product-json-to-csv/src/writer.js
@@ -24,7 +24,6 @@ export function writeToSingleCsvFile(
         data: product,
         fields: columnNames,
         hasCSVColumnTitle: false,
-        quotes: '',
         del,
       })
       output.write(`${csvData}\n`)
@@ -77,7 +76,6 @@ export function writeToZipFile(productStream, output, logger, del) {
         data: product,
         fields: columnNames,
         hasCSVColumnTitle,
-        quotes: '',
         del,
       })
       fileStream.write(`${csvData}\n`)

--- a/packages/product-json-to-csv/test/__snapshots__/writer.spec.js.snap
+++ b/packages/product-json-to-csv/test/__snapshots__/writer.spec.js.snap
@@ -1,0 +1,39 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Writer ::writeToSingleCsvFile write products to a single file with specified delimiter 1`] = `
+"id;key;productType;variantId;sku;images;anotherAddedAttr;article;designer;color
+\\"12345ab-id\\";\\"product-key\\";\\"product-type-1\\";1;\\"A0E200000001YKI\\";\\"image-url1\\";\\"\\";\\"sample 089 WHT\\";;\\"white\\"
+;;;6;\\"A0E200001YKI123\\";\\"https://image1.de;myImage.com\\";;\\"sample 089 WHT\\";;\\"white\\"
+\\"75345ab-id\\";\\"product-key-2\\";\\"product-type-2\\";1;\\"A0E200000001YKI\\";\\"https://example.com/foobar/commer.jpg|3|4\\";\\"\\";\\"sample 089 WHT\\";\\"michaelkors\\";\\"white\\"
+;;;3;\\"A0E200001YKI123\\";\\"https://example.com/foobar/commer234.jpg|3|3\\";;;\\"michaelkors\\";
+\\"another5ab-id\\";\\"product-key\\";\\"product-type-1\\";1;\\"A0E200001YKI\\";;\\"\\";\\"sample 777 WHT\\";;\\"grune\\"
+;;;21;\\"PPP0001YKI123\\";\\"https://eg993\\";;;;\\"blau\\"
+"
+`;
+
+exports[`Writer ::writeToSingleCsvFile write products to a single file with specified headers 1`] = `
+"id,key,productType,variantId,sku,images,anotherAddedAttr,article,designer,color
+\\"12345ab-id\\",\\"product-key\\",\\"product-type-1\\",1,\\"A0E200000001YKI\\",\\"image-url1\\",\\"\\",\\"sample 089 WHT\\",,\\"white\\"
+,,,6,\\"A0E200001YKI123\\",\\"https://image1.de;myImage.com\\",,\\"sample 089 WHT\\",,\\"white\\"
+\\"75345ab-id\\",\\"product-key-2\\",\\"product-type-2\\",1,\\"A0E200000001YKI\\",\\"https://example.com/foobar/commer.jpg|3|4\\",\\"\\",\\"sample 089 WHT\\",\\"michaelkors\\",\\"white\\"
+,,,3,\\"A0E200001YKI123\\",\\"https://example.com/foobar/commer234.jpg|3|3\\",,,\\"michaelkors\\",
+\\"another5ab-id\\",\\"product-key\\",\\"product-type-1\\",1,\\"A0E200001YKI\\",,\\"\\",\\"sample 777 WHT\\",,\\"grune\\"
+,,,21,\\"PPP0001YKI123\\",\\"https://eg993\\",,,,\\"blau\\"
+"
+`;
+
+exports[`Writer ::writeToZipFile log success info on completion 1`] = `
+"\\"id\\",\\"key\\",\\"productType\\",\\"variantId\\",\\"sku\\",\\"images\\",\\"addedAttr\\",\\"anotherAddedAttr\\",\\"article\\",\\"color\\",\\"colorFreeDefinition.en\\"
+\\"12345ab-id\\",\\"product-key\\",\\"product-type-1\\",1,\\"A0E200000001YKI\\",\\"image-url1\\",\\"\\",\\"\\",\\"sample 089 WHT\\",\\"white\\",\\"black-white\\"
+,,,6,\\"A0E200001YKI123\\",\\"https://image1.de;myImage.com\\",,,\\"sample 089 WHT\\",\\"white\\",\\"black-white\\"
+\\"another5ab-id\\",\\"product-key\\",\\"product-type-1\\",1,\\"A0E200001YKI\\",,\\"\\",\\"\\",\\"sample 777 WHT\\",\\"grune\\",\\"grey-white\\"
+,,,21,\\"PPP0001YKI123\\",\\"https://eg993\\",,,,\\"blau\\",\\"schwarz-weiß\\"
+"
+`;
+
+exports[`Writer ::writeToZipFile log success info on completion 2`] = `
+"\\"id\\",\\"key\\",\\"productType\\",\\"variantId\\",\\"sku\\",\\"images\\",\\"addedAttr\\",\\"anotherAddedAttr\\",\\"article\\",\\"color\\",\\"colorFreeDefinition.en\\",\\"colorFreeDefinition.de\\",\\"designer\\"
+\\"75345ab-id\\",\\"product-key-2\\",\\"product-type-2\\",1,\\"A0E200000001YKI\\",\\"https://example.com/foobar/commer.jpg|3|4\\",\\"\\",\\"\\",\\"sample 089 WHT\\",\\"white\\",\\"black-white\\",\\"schwarz-weiß\\",\\"michaelkors\\"
+,,,3,\\"A0E200001YKI123\\",\\"https://example.com/foobar/commer234.jpg|3|3\\",,,,,,\\"schwarz-weiß\\",\\"michaelkors\\"
+"
+`;

--- a/packages/product-json-to-csv/test/helpers/csvFileWithDelimiter.csv
+++ b/packages/product-json-to-csv/test/helpers/csvFileWithDelimiter.csv
@@ -1,7 +1,0 @@
-id;key;productType;variantId;sku;images;anotherAddedAttr;article;designer;color
-12345ab-id;product-key;product-type-1;1;A0E200000001YKI;image-url1;;sample 089 WHT;;white
-;;;6;A0E200001YKI123;https://image1.de;myImage.com;;sample 089 WHT;;white
-75345ab-id;product-key-2;product-type-2;1;A0E200000001YKI;https://example.com/foobar/commer.jpg|3|4;;sample 089 WHT;michaelkors;white
-;;;3;A0E200001YKI123;https://example.com/foobar/commer234.jpg|3|3;;;michaelkors;
-another5ab-id;product-key;product-type-1;1;A0E200001YKI;;;sample 777 WHT;;grune
-;;;21;PPP0001YKI123;https://eg993;;;;blau

--- a/packages/product-json-to-csv/test/helpers/csvFileWithHeaders.csv
+++ b/packages/product-json-to-csv/test/helpers/csvFileWithHeaders.csv
@@ -1,7 +1,0 @@
-id,key,productType,variantId,sku,images,anotherAddedAttr,article,designer,color
-12345ab-id,product-key,product-type-1,1,A0E200000001YKI,image-url1,,sample 089 WHT,,white
-,,,6,A0E200001YKI123,https://image1.de;myImage.com,,sample 089 WHT,,white
-75345ab-id,product-key-2,product-type-2,1,A0E200000001YKI,https://example.com/foobar/commer.jpg|3|4,,sample 089 WHT,michaelkors,white
-,,,3,A0E200001YKI123,https://example.com/foobar/commer234.jpg|3|3,,,michaelkors,
-another5ab-id,product-key,product-type-1,1,A0E200001YKI,,,sample 777 WHT,,grune
-,,,21,PPP0001YKI123,https://eg993,,,,blau

--- a/packages/product-json-to-csv/test/helpers/productType1Sample.csv
+++ b/packages/product-json-to-csv/test/helpers/productType1Sample.csv
@@ -1,5 +1,0 @@
-id,key,productType,variantId,sku,images,addedAttr,anotherAddedAttr,article,color,colorFreeDefinition.en
-12345ab-id,product-key,product-type-1,1,A0E200000001YKI,image-url1,,,sample 089 WHT,white,black-white
-,,,6,A0E200001YKI123,https://image1.de;myImage.com,,,sample 089 WHT,white,black-white
-another5ab-id,product-key,product-type-1,1,A0E200001YKI,,,,sample 777 WHT,grune,grey-white
-,,,21,PPP0001YKI123,https://eg993,,,,blau,schwarz-weiß

--- a/packages/product-json-to-csv/test/helpers/productType2Sample.csv
+++ b/packages/product-json-to-csv/test/helpers/productType2Sample.csv
@@ -1,3 +1,0 @@
-id,key,productType,variantId,sku,images,addedAttr,anotherAddedAttr,article,color,colorFreeDefinition.en,colorFreeDefinition.de,designer
-75345ab-id,product-key-2,product-type-2,1,A0E200000001YKI,https://example.com/foobar/commer.jpg|3|4,,,sample 089 WHT,white,black-white,schwarz-weiß,michaelkors
-,,,3,A0E200001YKI123,https://example.com/foobar/commer234.jpg|3|3,,,,,,schwarz-weiß,michaelkors

--- a/packages/product-json-to-csv/test/writer.spec.js
+++ b/packages/product-json-to-csv/test/writer.spec.js
@@ -95,9 +95,7 @@ describe('Writer', () => {
       ]
       const outputStream = streamTest.toText((error, actual) => {
         expect(error).toBeFalsy()
-        const expectedCsvFile = `${__dirname}/helpers/csvFileWithHeaders.csv`
-        const expectedCsv = fs.readFileSync(expectedCsvFile, 'utf8')
-        expect(actual).toMatch(expectedCsv)
+        expect(actual).toMatchSnapshot()
         done()
       })
 
@@ -121,9 +119,7 @@ describe('Writer', () => {
       const delimiter = ';'
       const outputStream = streamTest.toText((error, actual) => {
         expect(error).toBeFalsy()
-        const expectedCsvFile = `${__dirname}/helpers/csvFileWithDelimiter.csv`
-        const expectedCsv = fs.readFileSync(expectedCsvFile, 'utf8')
-        expect(actual).toMatch(expectedCsv)
+        expect(actual).toMatchSnapshot()
         done()
       })
 
@@ -156,15 +152,11 @@ describe('Writer', () => {
       const sampleStream = highland(sampleProducts)
       const verifyCsv1 = streamTest.toText((error, actual) => {
         expect(error).toBeFalsy()
-        const type1 = `${__dirname}/helpers/productType1Sample.csv`
-        const expectedCsv = fs.readFileSync(type1, 'utf8')
-        expect(expectedCsv).toMatch(actual)
+        expect(actual).toMatchSnapshot()
       })
       const verifyCsv2 = streamTest.toText((error, actual) => {
         expect(error).toBeFalsy()
-        const type2 = `${__dirname}/helpers/productType2Sample.csv`
-        const expectedCsv = fs.readFileSync(type2, 'utf8')
-        expect(expectedCsv).toMatch(actual)
+        expect(actual).toMatchSnapshot()
       })
 
       const tempFile = tmp.fileSync({ postfix: '.zip', keep: true })


### PR DESCRIPTION
#### Summary

PR sets quotes option when using [json2csv](https://www.npmjs.com/package/json2csv) package to default (")

#### Description

We had problems were a client was using commas(,) in their description of the products. Without encapsulating the cell values in quotes the CSV parser would push data to the next cell. This also happened when client chose to use pipes(|) as their delimiter since images return both the file path as well as pixel dimensions within pipes. Such as `<file/Path.jpg>|120|120|`

PR also refactors tests to use snapshots which, also, includes the new quotes.

#### Todo

* Tests
  * [x] Unit
  * [x] Integration

resolves #557