### PR TITLE
chore(babel): compile production and cli to node 6 instead of 4

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -51,7 +51,7 @@
           {
             "targets": {
               "browsers": ["last 2 versions"],
-              "node": "4"
+              "node": "6"
             },
             "modules": false
           }
@@ -73,7 +73,7 @@
           "env",
           {
             "targets": {
-              "node": "4"
+              "node": "6"
             },
             "modules": "commonjs"
           }


### PR DESCRIPTION
#### Summary

Update .babelrc settings for production and cli environment

resolves #561