### PR TITLE
fix(product-json-to-csv): use multivaluedelimiter and remove dimensions

### DIFF
--- a/packages/product-json-to-csv/src/map-product-data.js
+++ b/packages/product-json-to-csv/src/map-product-data.js
@@ -142,10 +142,8 @@ export default class ProductMapping {
             if (!isEmpty(value.images))
               images = value.images
                 .map((image: Image): string => {
-                  const { url, dimensions, label } = image
-                  let imageString = `${url}|${dimensions.w}|${dimensions.h}`
-                  imageString += label ? `|${label}` : ''
-                  return imageString
+                  const { url, label } = image
+                  return label ? `${url}${this.multiValDel}${label}` : url
                 })
                 .join(';')
 

--- a/packages/product-json-to-csv/src/map-product-data.js
+++ b/packages/product-json-to-csv/src/map-product-data.js
@@ -143,9 +143,9 @@ export default class ProductMapping {
               images = value.images
                 .map((image: Image): string => {
                   const { url, label } = image
-                  return label ? `${url}${this.multiValDel}${label}` : url
+                  return label ? `${url}|${label}` : url
                 })
-                .join(';')
+                .join(this.multiValDel)
 
             const { id, sku, key } = value
             acc[property] = pickBy({ id, sku, key, images }, Boolean)

--- a/packages/product-json-to-csv/test/__snapshots__/map-product-data.spec.js.snap
+++ b/packages/product-json-to-csv/test/__snapshots__/map-product-data.spec.js.snap
@@ -8,7 +8,7 @@ Object {
   "state": "my-resolved-state",
   "variant": Object {
     "id": 1,
-    "images": "https://example.com/foobar/commer.jpg;https://example-2.com/demo/tools.jpg;image-label",
+    "images": "https://example.com/foobar/commer.jpg;https://example-2.com/demo/tools.jpg|image-label",
     "sku": "A0E200000001YKI",
   },
 }
@@ -39,7 +39,7 @@ Array [
     "slug.en": "michaelkors-phonecover",
     "taxCategory": "resolved-tax-name",
     "variant.id": 1,
-    "variant.images": "https://example.com/foobar/commer.jpg;https://example-2.com/demo/tools.jpg;image-label",
+    "variant.images": "https://example.com/foobar/commer.jpg;https://example-2.com/demo/tools.jpg|image-label",
     "variant.sku": "A0E200000001YKI",
   },
   Object {

--- a/packages/product-json-to-csv/test/__snapshots__/map-product-data.spec.js.snap
+++ b/packages/product-json-to-csv/test/__snapshots__/map-product-data.spec.js.snap
@@ -1,0 +1,56 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`::ProductMapping ::mapProperties converts variant image array to strings 1`] = `
+Object {
+  "hasStagedChanges": false,
+  "id": "12345ab-id",
+  "key": "product-key",
+  "state": "my-resolved-state",
+  "variant": Object {
+    "id": 1,
+    "images": "https://example.com/foobar/commer.jpg;https://example-2.com/demo/tools.jpg;image-label",
+    "sku": "A0E200000001YKI",
+  },
+}
+`;
+
+exports[`::ProductMapping ::run should accept a product and return a formatted csv string 1`] = `
+Array [
+  Object {
+    "addedAttr": "",
+    "anotherAddedAttr": "",
+    "article": "sample 089 WHT",
+    "categories": "res-cat-name-1;res-cat-name-2",
+    "categoryOrderHints": "res-cat-name-1:0.015;res-cat-name-2:0.987",
+    "color": "white",
+    "colorFreeDefinition.de": "schwarz-weiß",
+    "colorFreeDefinition.en": "black-white",
+    "createdAt": "2017-01-06T10:54:51.395Z",
+    "designer": "michaelkors",
+    "hasStagedChanges": false,
+    "id": "12345ab-id",
+    "key": "product-key",
+    "lastModifiedAt": "2017-01-06T10:54:51.395Z",
+    "name.de": "Handyhülle",
+    "name.en": "Phone cover",
+    "productType": "resolved-product-type",
+    "published": false,
+    "slug.de": "michaelkors-handyhuelle",
+    "slug.en": "michaelkors-phonecover",
+    "taxCategory": "resolved-tax-name",
+    "variant.id": 1,
+    "variant.images": "https://example.com/foobar/commer.jpg;https://example-2.com/demo/tools.jpg;image-label",
+    "variant.sku": "A0E200000001YKI",
+  },
+  Object {
+    "article": "sample 089 WHT",
+    "color": "white",
+    "colorFreeDefinition.de": "schwarz-weiß",
+    "colorFreeDefinition.en": "black-white",
+    "designer": "michaelkors",
+    "variant.id": 2,
+    "variant.images": "https://example.com/foobar/commer234.jpg;https://example-2.com/demo/tools67.jpg",
+    "variant.sku": "A0E200001YKI123",
+  },
+]
+`;

--- a/packages/product-json-to-csv/test/map-product-data.spec.js
+++ b/packages/product-json-to-csv/test/map-product-data.spec.js
@@ -181,51 +181,7 @@ describe('::ProductMapping', () => {
         createdAt: '2017-01-06T10:54:51.395Z',
         lastModifiedAt: '2017-01-06T10:54:51.395Z',
       }
-
-      const expected = [
-        {
-          id: '12345ab-id',
-          key: 'product-key',
-          productType: 'resolved-product-type',
-          'name.en': 'Phone cover',
-          'name.de': 'Handyhülle',
-          categories: 'res-cat-name-1;res-cat-name-2',
-          categoryOrderHints: 'res-cat-name-1:0.015;res-cat-name-2:0.987',
-          'slug.en': 'michaelkors-phonecover',
-          'slug.de': 'michaelkors-handyhuelle',
-          taxCategory: 'resolved-tax-name',
-          published: false,
-          hasStagedChanges: false,
-          createdAt: '2017-01-06T10:54:51.395Z',
-          lastModifiedAt: '2017-01-06T10:54:51.395Z',
-          'variant.id': 1,
-          'variant.sku': 'A0E200000001YKI',
-          'variant.images': oneLineTrim`
-          https://example.com/foobar/commer.jpg|3|4;
-          https://example-2.com/demo/tools.jpg|1|5|image-label`,
-          addedAttr: '',
-          anotherAddedAttr: '',
-          article: 'sample 089 WHT',
-          color: 'white',
-          'colorFreeDefinition.en': 'black-white',
-          'colorFreeDefinition.de': 'schwarz-weiß',
-          designer: 'michaelkors',
-        },
-        {
-          'variant.id': 2,
-          'variant.sku': 'A0E200001YKI123',
-          'variant.images': oneLineTrim`
-          https://example.com/foobar/commer234.jpg|3|3;
-          https://example-2.com/demo/tools67.jpg|1|1`,
-          article: 'sample 089 WHT',
-          color: 'white',
-          'colorFreeDefinition.en': 'black-white',
-          'colorFreeDefinition.de': 'schwarz-weiß',
-          designer: 'michaelkors',
-        },
-      ]
-
-      expect(productMapping.run(sample)).toEqual(expected)
+      expect(productMapping.run(sample)).toMatchSnapshot()
     })
   })
 
@@ -491,20 +447,7 @@ describe('::ProductMapping', () => {
         },
         hasStagedChanges: false,
       }
-      const expected = {
-        id: '12345ab-id',
-        key: 'product-key',
-        variant: {
-          id: 1,
-          sku: 'A0E200000001YKI',
-          images: oneLineTrim`
-            https://example.com/foobar/commer.jpg|3|4;
-            https://example-2.com/demo/tools.jpg|1|5|image-label`,
-        },
-        state: 'my-resolved-state',
-        hasStagedChanges: false,
-      }
-      expect(productMapping._mapProperties(sample)).toEqual(expected)
+      expect(productMapping._mapProperties(sample)).toMatchSnapshot()
     })
   })
 


### PR DESCRIPTION
affects: @commercetools/product-json-to-csv

#### Summary

Fixes a bug where `multiValueDelimiter` was not used in images. Also removes `dimensions` attributes as they are not needed.

#### Todo

* Tests
  * [x] Unit
  * [x] Integration

closes #565
closes #566