### PR TITLE
fix(product-sync-actions): merge meta actions into base actions

### DIFF
--- a/packages/sync-actions/src/product-actions.js
+++ b/packages/sync-actions/src/product-actions.js
@@ -22,9 +22,6 @@ export const baseActionsList = [
   { action: 'setDescription', key: 'description' },
   { action: 'setSearchKeywords', key: 'searchKeywords' },
   { action: 'setKey', key: 'key' },
-]
-
-export const metaActionsList = [
   { action: 'setMetaTitle', key: 'metaTitle' },
   { action: 'setMetaDescription', key: 'metaDescription' },
   { action: 'setMetaKeywords', key: 'metaKeywords' },
@@ -370,15 +367,6 @@ function _buildVariantAttributesActions(
 export function actionsMapBase(diff, oldObj, newObj) {
   return buildBaseAttributesActions({
     actions: baseActionsList,
-    diff,
-    oldObj,
-    newObj,
-  })
-}
-
-export function actionsMapMeta(diff, oldObj, newObj) {
-  return buildBaseAttributesActions({
-    actions: metaActionsList,
     diff,
     oldObj,
     newObj,

--- a/packages/sync-actions/src/products.js
+++ b/packages/sync-actions/src/products.js
@@ -9,7 +9,6 @@ import findMatchingPairs from './utils/find-matching-pairs'
 
 const actionGroups = [
   'base',
-  'meta',
   'references',
   'prices',
   'attributes',
@@ -33,12 +32,6 @@ function createProductMapActions(mapActionGroup) {
     allActions.push(
       mapActionGroup('base', () =>
         productActions.actionsMapBase(diff, oldObj, newObj)
-      )
-    )
-
-    allActions.push(
-      mapActionGroup('meta', () =>
-        productActions.actionsMapMeta(diff, oldObj, newObj)
       )
     )
 

--- a/packages/sync-actions/test/product-sync-base.spec.js
+++ b/packages/sync-actions/test/product-sync-base.spec.js
@@ -1,16 +1,11 @@
 import clone from '../src/utils/clone'
 import productsSyncFn, { actionGroups } from '../src/products'
-import {
-  baseActionsList,
-  metaActionsList,
-  referenceActionsList,
-} from '../src/product-actions'
+import { baseActionsList, referenceActionsList } from '../src/product-actions'
 
 describe('Exports', () => {
   test('action group list', () => {
     expect(actionGroups).toEqual([
       'base',
-      'meta',
       'references',
       'prices',
       'attributes',
@@ -28,11 +23,6 @@ describe('Exports', () => {
       { action: 'setDescription', key: 'description' },
       { action: 'setSearchKeywords', key: 'searchKeywords' },
       { action: 'setKey', key: 'key' },
-    ])
-  })
-
-  test('correctly define meta actions list', () => {
-    expect(metaActionsList).toEqual([
       { action: 'setMetaTitle', key: 'metaTitle' },
       { action: 'setMetaDescription', key: 'metaDescription' },
       { action: 'setMetaKeywords', key: 'metaKeywords' },


### PR DESCRIPTION
#### Summary
<!-- Provide a short summary of your changes -->
This PR merges product update actions related to the `meta` fields (`metaTitle`, `metaDescription`, `metaKeywords`) into base actions.

#### Description
<!-- Describe the changes in this PR here and provide some context -->
While working on migrating the [sphere-node-csv-sync to the JS-SDK](https://github.com/sphereio/sphere-node-product-csv-sync/tree/200-js-sdk), I realised that the meta updates were not working at all. Moving them to the base actions solved it.
Also, seeing how the update actions work, and the shape of the meta fields (basic objects), I think it makes a lot of sense to have them in the base actions as well :-)


resolves #564 