### PR TITLE
fix(product-export): throw error when no products are found

### DIFF
--- a/integration-tests/cli/product-export.it.js
+++ b/integration-tests/cli/product-export.it.js
@@ -19,50 +19,6 @@ describe('Product Exporter', () => {
   let apiConfig
   const bin = './integration-tests/node_modules/.bin/product-exporter'
 
-  beforeAll(async () => {
-    const credentials = await getCredentials(projectKey)
-    apiConfig = {
-      host: 'https://auth.sphere.io',
-      apiUrl: 'https://api.sphere.io',
-      projectKey,
-      credentials,
-    }
-    await clearData(apiConfig, 'products')
-
-    await Promise.all([
-      clearData(apiConfig, 'productTypes'),
-      clearData(apiConfig, 'taxCategories'),
-    ])
-
-    const createdProductType = await createData(apiConfig, 'productTypes', [
-      sampleProductType,
-    ])
-    const createdTaxCategory = await createData(apiConfig, 'taxCategories', [
-      sampleTaxCategory,
-    ])
-
-    const productType = {
-      typeId: 'product-type',
-      id: createdProductType[0].body.id,
-    }
-    const taxCategory = {
-      typeId: 'tax-category',
-      id: createdTaxCategory[0].body.id,
-    }
-
-    const sampleProducts = createProducts(productType, taxCategory)
-
-    await createData(apiConfig, 'products', sampleProducts)
-  }, 30000)
-
-  afterAll(async () => {
-    await clearData(apiConfig, 'products')
-    await Promise.all([
-      clearData(apiConfig, 'productTypes'),
-      clearData(apiConfig, 'taxCategories'),
-    ])
-  })
-
   describe('CLI basic functionality', () => {
     it('should print usage information given the help flag', async () => {
       const [stdout, stderr] = await exec(`${bin} --help`)
@@ -77,7 +33,60 @@ describe('Product Exporter', () => {
     })
   })
 
-  describe('export function', () => {
+  describe('When no products exist', () => {
+    it('should throw error', async () => {
+      const filePath = tmp.fileSync().name
+
+      await expect(
+        exec(`${bin} -o ${filePath} -p ${projectKey} --staged`)
+      ).rejects.toThrowError('No products found')
+    })
+  })
+
+  describe('Export function', () => {
+    beforeAll(async () => {
+      const credentials = await getCredentials(projectKey)
+      apiConfig = {
+        host: 'https://auth.sphere.io',
+        apiUrl: 'https://api.sphere.io',
+        projectKey,
+        credentials,
+      }
+      await clearData(apiConfig, 'products')
+
+      await Promise.all([
+        clearData(apiConfig, 'productTypes'),
+        clearData(apiConfig, 'taxCategories'),
+      ])
+
+      const createdProductType = await createData(apiConfig, 'productTypes', [
+        sampleProductType,
+      ])
+      const createdTaxCategory = await createData(apiConfig, 'taxCategories', [
+        sampleTaxCategory,
+      ])
+
+      const productType = {
+        typeId: 'product-type',
+        id: createdProductType[0].body.id,
+      }
+      const taxCategory = {
+        typeId: 'tax-category',
+        id: createdTaxCategory[0].body.id,
+      }
+
+      const sampleProducts = createProducts(productType, taxCategory)
+
+      await createData(apiConfig, 'products', sampleProducts)
+    }, 30000)
+
+    afterAll(async () => {
+      await clearData(apiConfig, 'products')
+      await Promise.all([
+        clearData(apiConfig, 'productTypes'),
+        clearData(apiConfig, 'taxCategories'),
+      ])
+    })
     it(
       'should export products from the CTP',
       async () => {

--- a/integration-tests/cli/product-export.it.js
+++ b/integration-tests/cli/product-export.it.js
@@ -33,7 +33,7 @@ describe('Product Exporter', () => {
     })
   })
 
-  describe('When no products exist', () => {
+  describe('when no products exist', () => {
     it('should throw error', async () => {
       const filePath = tmp.fileSync().name
 
@@ -43,7 +43,7 @@ describe('Product Exporter', () => {
     })
   })
 
-  describe('Export function', () => {
+  describe('export function', () => {
     beforeAll(async () => {
       const credentials = await getCredentials(projectKey)
       apiConfig = {

--- a/packages/product-exporter/src/main.js
+++ b/packages/product-exporter/src/main.js
@@ -90,6 +90,9 @@ export default class ProductExporter {
       .process(
         request,
         ({ body: { results: products } }: ProcessFnResponse): Promise<*> => {
+          if (products.length < 1) {
+            return Promise.reject(Error('No products found'))
+          }
           this.logger.debug(`Fetched ${products.length} products`)
           ProductExporter._writeEachProduct(outputStream, products)
           this.logger.debug(

--- a/packages/product-exporter/src/main.js
+++ b/packages/product-exporter/src/main.js
@@ -90,14 +90,14 @@ export default class ProductExporter {
       .process(
         request,
         ({ body: { results: products } }: ProcessFnResponse): Promise<*> => {
-          if (products.length < 1) {
-            return Promise.reject(Error('No products found'))
-          }
           this.logger.debug(`Fetched ${products.length} products`)
           ProductExporter._writeEachProduct(outputStream, products)
           this.logger.debug(
             `${products.length} products written to outputStream`
           )
+          if (products.length < 1) {
+            return Promise.reject(Error('No products found'))
+          }
           return Promise.resolve()
         },
         processConfig


### PR DESCRIPTION
#### Summary

PR makes product-export throw error `No products found` when predicate is too strict or there simply isn't any products.

#### Description

We used to export empty JSON files which 
a) Doesn't make sense to clients as they would prefer to get an error instead of downloading an empty file.
b) Caused `json-to-csv` parser package to break since it is not built to handle empty JSON files.

Note that this is a breaking change so we need to make sure everyone is aware of the new behaviour.

resolves #553