### PR TITLE
fix(sync-actions): re-order product update actions build sequence

### DIFF
--- a/packages/sync-actions/src/products.js
+++ b/packages/sync-actions/src/products.js
@@ -31,6 +31,24 @@ function createProductMapActions(mapActionGroup) {
     )
 
     allActions.push(
+      mapActionGroup('attributes', () =>
+        productActions.actionsMapAttributes(
+          diff,
+          oldObj,
+          newObj,
+          sameForAllAttributeNames || [],
+          variantHashMap
+        )
+      )
+    )
+
+    allActions.push(
+      mapActionGroup('variants', () =>
+        productActions.actionsMapVariants(diff, oldObj, newObj)
+      )
+    )
+
+    allActions.push(
       mapActionGroup('base', () =>
         productActions.actionsMapBase(diff, oldObj, newObj)
       )
@@ -48,25 +66,7 @@ function createProductMapActions(mapActionGroup) {
       )
     )
 
-    allActions.push(
-      mapActionGroup('variants', () =>
-        productActions.actionsMapVariants(diff, oldObj, newObj)
-      )
-    )
-
     allActions.push(productActions.actionsMapMasterVariant(oldObj, newObj))
-
-    allActions.push(
-      mapActionGroup('attributes', () =>
-        productActions.actionsMapAttributes(
-          diff,
-          oldObj,
-          newObj,
-          sameForAllAttributeNames || [],
-          variantHashMap
-        )
-      )
-    )
 
     allActions.push(
       mapActionGroup('images', () =>

--- a/packages/sync-actions/test/product-sync-variants.spec.js
+++ b/packages/sync-actions/test/product-sync-variants.spec.js
@@ -330,12 +330,6 @@ describe('Actions', () => {
 
     const actions = productsSync.buildActions(now, before)
     expect(actions).toEqual([
-      {
-        action: 'addVariant',
-        sku: 'v3',
-        key: 'v3',
-        attributes: [{ name: 'foo', value: 'yet another' }],
-      },
       { action: 'setProductVariantKey', key: 'v2', variantId: 1 },
       { action: 'setAttribute', variantId: 1, name: 'foo', value: 'new value' },
       { action: 'setSku', sku: 'v4', variantId: 3 },
@@ -351,6 +345,12 @@ describe('Actions', () => {
         variantId: 2,
         name: 'foo',
         value: 'another value',
+      },
+      {
+        action: 'addVariant',
+        sku: 'v3',
+        key: 'v3',
+        attributes: [{ name: 'foo', value: 'yet another' }],
       },
     ])
   })
@@ -431,12 +431,6 @@ describe('Actions', () => {
 
         expect(actions).toEqual([
           {
-            action: 'addVariant',
-            sku: 'v4',
-            key: 'v4',
-            attributes: [{ name: 'foo', value: 'yet another' }],
-          },
-          {
             action: 'setAttribute',
             variantId: 2,
             name: 'foo',
@@ -447,6 +441,12 @@ describe('Actions', () => {
             variantId: 3,
             name: 'foo',
             value: 'i dont care',
+          },
+          {
+            action: 'addVariant',
+            sku: 'v4',
+            key: 'v4',
+            attributes: [{ name: 'foo', value: 'yet another' }],
           },
         ])
       })
@@ -620,13 +620,13 @@ describe('Actions', () => {
             const actions = productsSync.buildActions(now, before)
 
             expect(actions).toEqual([
-              { action: 'changeMasterVariant', variantId: 1 },
               {
                 action: 'setAttribute',
                 name: 'foo-2',
                 value: 'bar-3',
                 variantId: 1,
               },
+              { action: 'changeMasterVariant', variantId: 1 },
             ])
           })
         })

--- a/yarn.lock
+++ b/yarn.lock
@@ -1205,9 +1205,9 @@ babel-polyfill@6.26.0, babel-polyfill@^6.26.0:
     core-js "^2.5.0"
     regenerator-runtime "^0.10.5"
 
-babel-preset-env@1.6.1:
-  version "1.6.1"
-  resolved "https://registry.yarnpkg.com/babel-preset-env/-/babel-preset-env-1.6.1.tgz#a18b564cc9b9afdf4aae57ae3c1b0d99188e6f48"
+babel-preset-env@1.7.0:
+  version "1.7.0"
+  resolved "https://registry.yarnpkg.com/babel-preset-env/-/babel-preset-env-1.7.0.tgz#dea79fa4ebeb883cd35dab07e260c1c9c04df77a"
   dependencies:
     babel-plugin-check-es2015-constants "^6.22.0"
     babel-plugin-syntax-trailing-function-commas "^6.22.0"
@@ -1236,7 +1236,7 @@ babel-preset-env@1.6.1:
     babel-plugin-transform-es2015-unicode-regex "^6.22.0"
     babel-plugin-transform-exponentiation-operator "^6.22.0"
     babel-plugin-transform-regenerator "^6.22.0"
-    browserslist "^2.1.2"
+    browserslist "^3.2.6"
     invariant "^2.2.2"
     semver "^5.3.0"
 
@@ -1484,12 +1484,12 @@ browser-stdout@1.3.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/browser-stdout/-/browser-stdout-1.3.0.tgz#f351d32969d32fa5d7a5567154263d928ae3bd1f"
 
-browserslist@^2.1.2:
-  version "2.11.3"
-  resolved "https://registry.yarnpkg.com/browserslist/-/browserslist-2.11.3.tgz#fe36167aed1bbcde4827ebfe71347a2cc70b99b2"
+browserslist@^3.2.6:
+  version "3.2.7"
+  resolved "https://registry.yarnpkg.com/browserslist/-/browserslist-3.2.7.tgz#aa488634d320b55e88bab0256184dbbcca1e6de9"
   dependencies:
-    caniuse-lite "^1.0.30000792"
-    electron-to-chromium "^1.3.30"
+    caniuse-lite "^1.0.30000835"
+    electron-to-chromium "^1.3.45"
 
 bser@^2.0.0:
   version "2.0.0"
@@ -1644,9 +1644,9 @@ camelcase@^4.0.0, camelcase@^4.1.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-4.1.0.tgz#d545635be1e33c542649c69173e5de6acfae34dd"
 
-caniuse-lite@^1.0.30000792:
-  version "1.0.30000830"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30000830.tgz#cb96b8a2dd3cbfe04acea2af3c4e894249095328"
+caniuse-lite@^1.0.30000835:
+  version "1.0.30000840"
+  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30000840.tgz#344513f8f843536cf99694964c09811277eee395"
 
 capture-stack-trace@^1.0.0:
   version "1.0.0"
@@ -1883,9 +1883,9 @@ code-point-at@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/code-point-at/-/code-point-at-1.1.0.tgz#0d070b4d043a5bea33a2f1a40e2edb3d9a4ccf77"
 
-codecov@3.0.1:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/codecov/-/codecov-3.0.1.tgz#cc4c5cd1955c6be47f6dda2f8c55bcc43c732dca"
+codecov@3.0.2:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/codecov/-/codecov-3.0.2.tgz#aea43843a5cd2fb6b7e488b2eff25d367ab70b12"
   dependencies:
     argv "0.0.2"
     request "^2.81.0"
@@ -2274,9 +2274,9 @@ create-jest-runner@^0.1.1:
     throat "4.1.0"
     worker-farm "1.5.0"
 
-cross-env@5.1.4:
-  version "5.1.4"
-  resolved "https://registry.yarnpkg.com/cross-env/-/cross-env-5.1.4.tgz#f61c14291f7cc653bb86457002ea80a04699d022"
+cross-env@5.1.5:
+  version "5.1.5"
+  resolved "https://registry.yarnpkg.com/cross-env/-/cross-env-5.1.5.tgz#31daf7f3a52ef337c8ddda585f08175cce5d1fa5"
   dependencies:
     cross-spawn "^5.1.0"
     is-windows "^1.0.0"
@@ -2678,9 +2678,9 @@ editor@1.0.0, editor@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/editor/-/editor-1.0.0.tgz#60c7f87bd62bcc6a894fa8ccd6afb7823a24f742"
 
-electron-to-chromium@^1.3.30:
-  version "1.3.42"
-  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.42.tgz#95c33bf01d0cc405556aec899fe61fd4d76ea0f9"
+electron-to-chromium@^1.3.45:
+  version "1.3.45"
+  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.45.tgz#458ac1b1c5c760ce8811a16d2bfbd97ec30bafb8"
 
 elegant-spinner@^1.0.1:
   version "1.0.1"
@@ -2882,9 +2882,9 @@ eslint-plugin-prettier@2.6.0:
     fast-diff "^1.1.1"
     jest-docblock "^21.0.0"
 
-eslint-plugin-react@7.7.0:
-  version "7.7.0"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-react/-/eslint-plugin-react-7.7.0.tgz#f606c719dbd8a1a2b3d25c16299813878cca0160"
+eslint-plugin-react@7.8.2:
+  version "7.8.2"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-react/-/eslint-plugin-react-7.8.2.tgz#e95c9c47fece55d2303d1a67c9d01b930b88a51d"
   dependencies:
     doctrine "^2.0.2"
     has "^1.0.1"


### PR DESCRIPTION
affects: @commercetools/sync-actions

move attribute actions above variant actions

resolves #589 

See #589 for more context on this issue