### PR TITLE
feat(sync-actions): configure empty string as not-a-value

### DIFF
--- a/packages/sync-actions/src/product-types-actions.js
+++ b/packages/sync-actions/src/product-types-actions.js
@@ -21,7 +21,7 @@ export const baseActionsList = [
   { action: 'changeDescription', key: 'description' },
 ]
 
-export function actionsMapBase(diff, previous, next, config) {
+export function actionsMapBase(diff, previous, next, config = {}) {
   return buildBaseAttributesActions({
     diff,
     actions: baseActionsList,

--- a/packages/sync-actions/src/product-types-actions.js
+++ b/packages/sync-actions/src/product-types-actions.js
@@ -28,7 +28,6 @@ export function actionsMapBase(diff, previous, next, config) {
     oldObj: previous,
     newObj: next,
     shouldOmitEmptyString: config.shouldOmitEmptyString,
-    // omitUnecessaryUpdates: config.shouldOmitEmptyString,
   })
 }
 

--- a/packages/sync-actions/src/product-types-actions.js
+++ b/packages/sync-actions/src/product-types-actions.js
@@ -21,12 +21,14 @@ export const baseActionsList = [
   { action: 'changeDescription', key: 'description' },
 ]
 
-export function actionsMapBase(diff, previous, next) {
+export function actionsMapBase(diff, previous, next, config) {
   return buildBaseAttributesActions({
     diff,
     actions: baseActionsList,
     oldObj: previous,
     newObj: next,
+    shouldOmitEmptyString: config.shouldOmitEmptyString,
+    // omitUnecessaryUpdates: config.shouldOmitEmptyString,
   })
 }
 

--- a/packages/sync-actions/src/product-types.js
+++ b/packages/sync-actions/src/product-types.js
@@ -46,7 +46,7 @@ function createProductTypeMapActions(
 
 export default (
   actionGroupConfig: Array<ActionGroup>,
-  config: Object
+  config: Object = {}
 ): SyncAction => {
   const mapActionGroup = createMapActionGroup(actionGroupConfig)
   const doMapActions = createProductTypeMapActions(mapActionGroup, config)

--- a/packages/sync-actions/src/product-types.js
+++ b/packages/sync-actions/src/product-types.js
@@ -13,7 +13,8 @@ function createProductTypeMapActions(
   mapActionGroup: (
     type: string,
     fn: () => Array<UpdateAction>
-  ) => Array<UpdateAction>
+  ) => Array<UpdateAction>,
+  config: Object
 ): (diff: Object, next: Object, previous: Object) => Array<UpdateAction> {
   return function doMapActions(
     diff: Object,
@@ -23,7 +24,7 @@ function createProductTypeMapActions(
     const allActions = []
     allActions.push(
       mapActionGroup('base', (): Array<UpdateAction> =>
-        productTypeActions.actionsMapBase(diff, previous, next)
+        productTypeActions.actionsMapBase(diff, previous, next, config)
       ),
       mapActionGroup('attributes', (): Array<UpdateAction> =>
         productTypeActions.actionsMapAttributes(
@@ -43,9 +44,12 @@ function createProductTypeMapActions(
   }
 }
 
-export default (config: Array<ActionGroup>): SyncAction => {
-  const mapActionGroup = createMapActionGroup(config)
-  const doMapActions = createProductTypeMapActions(mapActionGroup)
+export default (
+  actionGroupConfig: Array<ActionGroup>,
+  config: Object
+): SyncAction => {
+  const mapActionGroup = createMapActionGroup(actionGroupConfig)
+  const doMapActions = createProductTypeMapActions(mapActionGroup, config)
   const buildActions = createBuildActions(diffpatcher.diff, doMapActions)
   return { buildActions }
 }

--- a/packages/sync-actions/src/product-types.js
+++ b/packages/sync-actions/src/product-types.js
@@ -1,6 +1,11 @@
 /* @flow */
 import flatten from 'lodash.flatten'
-import type { SyncAction, UpdateAction, ActionGroup } from 'types/sdk'
+import type {
+  SyncAction,
+  UpdateAction,
+  ActionGroup,
+  SyncActionConfig,
+} from 'types/sdk'
 import createBuildActions from './utils/create-build-actions'
 import createMapActionGroup from './utils/create-map-action-group'
 import * as productTypeActions from './product-types-actions'
@@ -14,7 +19,7 @@ function createProductTypeMapActions(
     type: string,
     fn: () => Array<UpdateAction>
   ) => Array<UpdateAction>,
-  config: Object
+  config: SyncActionConfig
 ): (diff: Object, next: Object, previous: Object) => Array<UpdateAction> {
   return function doMapActions(
     diff: Object,
@@ -46,7 +51,7 @@ function createProductTypeMapActions(
 
 export default (
   actionGroupConfig: Array<ActionGroup>,
-  config: Object = {}
+  config: SyncActionConfig
 ): SyncAction => {
   const mapActionGroup = createMapActionGroup(actionGroupConfig)
   const doMapActions = createProductTypeMapActions(mapActionGroup, config)

--- a/packages/sync-actions/test/product-types-sync-base.spec.js
+++ b/packages/sync-actions/test/product-types-sync-base.spec.js
@@ -1,5 +1,5 @@
 import clone from '../src/utils/clone'
-import productTypesSyncFn, { actionGroups } from '../src/product-types'
+import createSyncProductTypes, { actionGroups } from '../src/product-types'
 import { baseActionsList } from '../src/product-types-actions'
 
 describe('Exports', () => {
@@ -23,7 +23,7 @@ describe('Actions', () => {
   let before
   let now
   beforeEach(() => {
-    productTypesSync = productTypesSyncFn()
+    productTypesSync = createSyncProductTypes()
   })
   describe('mutation', () => {
     test('should ensure given objects are not mutated', () => {
@@ -95,6 +95,153 @@ describe('Actions', () => {
           description: 'kicks-description',
         },
       ])
+    })
+  })
+
+  describe('with `shouldOmitEmptyString`', () => {
+    beforeEach(() => {
+      productTypesSync = createSyncProductTypes([], {
+        shouldOmitEmptyString: true,
+      })
+    })
+    describe('with key change', () => {
+      describe('when previous value is an empty string', () => {
+        describe('when there is a next value', () => {
+          beforeEach(() => {
+            before = {
+              key: '',
+            }
+            now = {
+              key: 'hello world',
+            }
+            updateActions = productTypesSync.buildActions(now, before)
+          })
+          it('should return `setKey` update-action', () => {
+            expect(updateActions).toEqual([
+              {
+                action: 'setKey',
+                key: 'hello world',
+              },
+            ])
+          })
+        })
+        describe('when next value is `undefined`', () => {
+          beforeEach(() => {
+            before = {
+              key: '',
+            }
+            now = {
+              key: undefined,
+            }
+            updateActions = productTypesSync.buildActions(now, before)
+          })
+          it('should not return `setKey` update-action', () => {
+            expect(updateActions).toEqual([])
+          })
+        })
+        describe('when next value is `null`', () => {
+          beforeEach(() => {
+            before = {
+              key: '',
+            }
+            now = {
+              key: null,
+            }
+            updateActions = productTypesSync.buildActions(now, before)
+          })
+          it('should not return `setKey` update-action', () => {
+            expect(updateActions).toEqual([])
+          })
+        })
+      })
+      describe('when previous value is `null`', () => {
+        describe('when there is a next value', () => {
+          beforeEach(() => {
+            before = {
+              key: null,
+            }
+            now = {
+              key: 'kicks-key',
+            }
+            updateActions = productTypesSync.buildActions(now, before)
+          })
+          it('should return `setKey` update-action', () => {
+            expect(updateActions).toEqual([
+              {
+                action: 'setKey',
+                key: 'kicks-key',
+              },
+            ])
+          })
+        })
+        describe('when next value is `undefined`', () => {
+          beforeEach(() => {
+            before = {
+              key: null,
+            }
+            now = {
+              key: undefined,
+            }
+            updateActions = productTypesSync.buildActions(now, before)
+          })
+          it('should not return `setKey` update-action', () => {
+            expect(updateActions).toEqual([])
+          })
+        })
+        describe('when next value is an empty string', () => {
+          beforeEach(() => {
+            before = {
+              key: null,
+            }
+            now = {
+              key: '',
+            }
+            updateActions = productTypesSync.buildActions(now, before)
+          })
+          it('should not return `setKey` update-action', () => {
+            expect(updateActions).toEqual([])
+          })
+        })
+      })
+      describe('when previous value is `undefined`', () => {
+        describe('when there is a next value', () => {
+          beforeEach(() => {
+            before = {}
+            now = {
+              key: 'hello world',
+            }
+            updateActions = productTypesSync.buildActions(now, before)
+          })
+          it('should return `setKey` update-action', () => {
+            expect(updateActions).toEqual([
+              {
+                action: 'setKey',
+                key: 'hello world',
+              },
+            ])
+          })
+        })
+        describe('when next value is `null`', () => {
+          beforeEach(() => {
+            before = {}
+            now = { key: null }
+            updateActions = productTypesSync.buildActions(now, before)
+          })
+          it('should not return `setKey` update-action', () => {
+            expect(updateActions).toEqual([])
+          })
+        })
+        describe('when next value is `undefined`', () => {
+          beforeEach(() => {
+            before = {}
+            now = {}
+            updateActions = productTypesSync.buildActions(now, before)
+          })
+          it('should not return `setKey` update-action', () => {
+            expect(updateActions).toEqual([])
+          })
+        })
+      })
     })
   })
 })

--- a/types/sdk.js
+++ b/types/sdk.js
@@ -310,6 +310,9 @@ export type UpdateAction = {
 export type SyncAction = {
   buildActions: (now: Object, before: Object) => Array<UpdateAction>,
 }
+export type SyncActionConfig = {
+  shouldOmitEmptyString: boolean,
+}
 export type ActionGroup = {
   type: string,
   group: 'black' | 'white',


### PR DESCRIPTION
#### Summary

- add configuration to `createSyncProductTypes` to treat empty string as not a value
- follow up to https://github.com/commercetools/nodejs/pull/541

#### Description

So at the project I work on, we still use work-arounds to treat empty string, `undefined` and `null` as not a value in our forms. This is something that we wish is already supported on the `nodejs/sync-actions`.

Unfortunately, on #541 we learned that the changes in that PR is a breaking change across all sync-action types and can potentially break clients using the `nodejs/sync-actions` and still has the use case of __empty string being a value__

This time I suggest it to be an __opt-in__

For now, I added support only on product-types. We can add support to other types as a separate step essentially when it is needed. There won't be much repetition/redundancy, except on the entry point and on the call of `buildBaseAttributesActions`

#### Todo

* [ ] Figure out a better name to `shouldOmitEmptyString`
* Tests
  * [x] Unit

  <!-- Two persons should review a PR, don't forget to assign them. -->
