### PR TITLE
fix(sync-actions/product-types): product types doesn't generate update actions for enum changes

### DIFF
--- a/packages/sync-actions/src/product-types-actions.js
+++ b/packages/sync-actions/src/product-types-actions.js
@@ -50,21 +50,20 @@ const getIsAnAttributeDefinitionBaseFieldChange = diff =>
   diff.isSearchable
 
 function actionsMapEnums(attributeType, attributeDiff, previous, next) {
-  const getAddActionName = type =>
-    type === 'enum' ? 'addPlainEnumValue' : 'addLocalizedEnumValue'
-  const getChangeEnumOrderActionName = type =>
-    type === 'enum'
+  const addEnumActionName =
+    attributeType === 'enum' ? 'addPlainEnumValue' : 'addLocalizedEnumValue'
+  const changeEnumOrderActionName =
+    attributeType === 'enum'
       ? 'changePlainEnumValueOrder'
       : 'changeLocalizedEnumValueOrder'
-  const getChangeEnumLabelActionName = type =>
-    type === 'enum'
+  const changeEnumLabelActionName =
+    attributeType === 'enum'
       ? 'changePlainEnumValueLabel'
       : 'changeLocalizedEnumValueLabel'
-
   const buildArrayActions = createBuildArrayActions('values', {
     [ADD_ACTIONS]: newEnum => ({
       attributeName: next.name,
-      action: getAddActionName(attributeType),
+      action: addEnumActionName,
       value: newEnum,
     }),
     [CHANGE_ACTIONS]: (oldEnum, newEnum) => {
@@ -81,13 +80,13 @@ function actionsMapEnums(attributeType, attributeDiff, previous, next) {
         if (!deepEqual(oldEnum.label, oldEnumInNext.label)) {
           changeActions.push({
             attributeName: next.name,
-            action: getChangeEnumLabelActionName(attributeType),
+            action: changeEnumLabelActionName,
             newValue: newEnum,
           })
         } else {
           changeActions.push({
             attributeName: next.name,
-            action: getChangeEnumOrderActionName(attributeType),
+            action: changeEnumOrderActionName,
             value: newEnum,
           })
         }
@@ -99,7 +98,7 @@ function actionsMapEnums(attributeType, attributeDiff, previous, next) {
         })
         changeActions.push({
           attributeName: next.name,
-          action: getAddActionName(attributeType),
+          action: addEnumActionName,
           value: newEnum,
         })
       }
@@ -122,9 +121,7 @@ function actionsMapEnums(attributeType, attributeDiff, previous, next) {
     updateAction => {
       if (updateAction.action === 'removeEnumValue')
         removedKeys.push(updateAction.value.key)
-      else if (
-        updateAction.action === getChangeEnumOrderActionName(attributeType)
-      ) {
+      else if (updateAction.action === changeEnumOrderActionName) {
         newEnumValuesOrder.push(updateAction.value)
       } else actions.push(updateAction)
     }
@@ -136,7 +133,7 @@ function actionsMapEnums(attributeType, attributeDiff, previous, next) {
       ? [
           {
             attributeName: next.name,
-            action: getChangeEnumOrderActionName(attributeType),
+            action: changeEnumOrderActionName,
             values: newEnumValuesOrder,
           },
         ]

--- a/packages/sync-actions/src/product-types-actions.js
+++ b/packages/sync-actions/src/product-types-actions.js
@@ -167,6 +167,7 @@ export function actionsMapAttributes(
       previous,
       next
     )
+
     if (getIsChangedOperation(diffKey)) {
       if (Array.isArray(diffValue)) {
         const deltaValue = diffpatcher.getDeltaValue(diffValue)
@@ -188,13 +189,13 @@ export function actionsMapAttributes(
             attributeName: extractedPairs.oldObj.name,
           }))
         )
-      } else if (diffValue.values) {
+      } else if (diffValue.type.values) {
         actions.push(
           ...actionsMapEnums(
             extractedPairs.oldObj.type.name,
-            diffValue,
-            extractedPairs.oldObj,
-            extractedPairs.newObj
+            diffValue.type,
+            extractedPairs.oldObj.type,
+            extractedPairs.newObj.type
           )
         )
       }

--- a/packages/sync-actions/test/product-types-sync-enums.spec.js
+++ b/packages/sync-actions/test/product-types-sync-enums.spec.js
@@ -6,11 +6,8 @@ const createTestProductType = custom => ({
   ...custom,
 })
 
-const createAttributeDefinition = custom => ({
-  type: {
-    name: custom.name,
-  },
-  ...custom,
+const createAttributeDefinition = type => ({
+  type,
 })
 
 describe('Actions', () => {

--- a/packages/sync-actions/test/product-types-sync-enums.spec.js
+++ b/packages/sync-actions/test/product-types-sync-enums.spec.js
@@ -6,10 +6,6 @@ const createTestProductType = custom => ({
   ...custom,
 })
 
-const createAttributeDefinition = type => ({
-  type,
-})
-
 describe('Actions', () => {
   let before
   let now
@@ -23,23 +19,27 @@ describe('Actions', () => {
       beforeEach(() => {
         before = createTestProductType({
           attributes: [
-            createAttributeDefinition({
-              name: 'enum',
-              values: [],
-            }),
+            {
+              type: {
+                name: 'enum',
+                values: [],
+              },
+            },
           ],
         })
         now = createTestProductType({
           attributes: [
-            createAttributeDefinition({
-              name: 'enum',
-              values: [
-                {
-                  key: 'enum_1',
-                  label: 'enum-1',
-                },
-              ],
-            }),
+            {
+              type: {
+                name: 'enum',
+                values: [
+                  {
+                    key: 'enum_1',
+                    label: 'enum-1',
+                  },
+                ],
+              },
+            },
           ],
         })
         // we get a change operation only here.
@@ -62,31 +62,35 @@ describe('Actions', () => {
       beforeEach(() => {
         before = createTestProductType({
           attributes: [
-            createAttributeDefinition({
-              name: 'enum',
-              values: [
-                {
-                  key: 'enum_1',
-                  label: 'enum-1',
-                },
-                {
-                  key: 'enum_2',
-                  label: 'enum-2',
-                },
-                {
-                  key: 'enum_4',
-                  label: 'enum-4',
-                },
-              ],
-            }),
+            {
+              type: {
+                name: 'enum',
+                values: [
+                  {
+                    key: 'enum_1',
+                    label: 'enum-1',
+                  },
+                  {
+                    key: 'enum_2',
+                    label: 'enum-2',
+                  },
+                  {
+                    key: 'enum_4',
+                    label: 'enum-4',
+                  },
+                ],
+              },
+            },
           ],
         })
         now = createTestProductType({
           attributes: [
-            createAttributeDefinition({
-              name: 'enum',
-              values: [],
-            }),
+            {
+              type: {
+                name: 'enum',
+                values: [],
+              },
+            },
           ],
         })
         updateActions = productTypesSync.buildActions(now, before)
@@ -105,26 +109,30 @@ describe('Actions', () => {
       beforeEach(() => {
         before = createTestProductType({
           attributes: [
-            createAttributeDefinition({
-              name: 'enum',
-              values: [
-                { key: 'enum_0', label: 'enum-0' },
-                { key: 'enum_2', label: 'enum-2' },
-                { key: 'enum_4', label: 'enum-4' },
-              ],
-            }),
+            {
+              type: {
+                name: 'enum',
+                values: [
+                  { key: 'enum_0', label: 'enum-0' },
+                  { key: 'enum_2', label: 'enum-2' },
+                  { key: 'enum_4', label: 'enum-4' },
+                ],
+              },
+            },
           ],
         })
         now = createTestProductType({
           attributes: [
-            createAttributeDefinition({
-              name: 'enum',
-              values: [
-                { key: 'enum_1', label: 'enum-1' },
-                { key: 'enum_3', label: 'enum-3' },
-                { key: 'enum_5', label: 'enum-5' },
-              ],
-            }),
+            {
+              type: {
+                name: 'enum',
+                values: [
+                  { key: 'enum_1', label: 'enum-1' },
+                  { key: 'enum_3', label: 'enum-3' },
+                  { key: 'enum_5', label: 'enum-5' },
+                ],
+              },
+            },
           ],
         })
         updateActions = productTypesSync.buildActions(now, before)
@@ -158,25 +166,29 @@ describe('Actions', () => {
       beforeEach(() => {
         before = createTestProductType({
           attributes: [
-            createAttributeDefinition({
-              name: 'enum',
-              values: [
-                { key: 'enum_0', label: 'enum-0' },
-                { key: 'enum_2', label: 'enum-2' },
-                { key: 'enum_4', label: 'enum-4' },
-              ],
-            }),
+            {
+              type: {
+                name: 'enum',
+                values: [
+                  { key: 'enum_0', label: 'enum-0' },
+                  { key: 'enum_2', label: 'enum-2' },
+                  { key: 'enum_4', label: 'enum-4' },
+                ],
+              },
+            },
           ],
         })
         now = createTestProductType({
           attributes: [
-            createAttributeDefinition({
-              name: 'enum',
-              values: [
-                { key: 'enum_0', label: 'enum-0' },
-                { key: 'enum_3', label: 'enum-3' },
-              ],
-            }),
+            {
+              type: {
+                name: 'enum',
+                values: [
+                  { key: 'enum_0', label: 'enum-0' },
+                  { key: 'enum_3', label: 'enum-3' },
+                ],
+              },
+            },
           ],
         })
 
@@ -204,26 +216,30 @@ describe('Actions', () => {
       beforeEach(() => {
         before = createTestProductType({
           attributes: [
-            createAttributeDefinition({
-              name: 'enum',
-              values: [
-                { key: 'enum_1', label: 'enum-1' },
-                { key: 'enum_2', label: 'enum-2' },
-                { key: 'enum_4', label: 'enum-4' },
-              ],
-            }),
+            {
+              type: {
+                name: 'enum',
+                values: [
+                  { key: 'enum_1', label: 'enum-1' },
+                  { key: 'enum_2', label: 'enum-2' },
+                  { key: 'enum_4', label: 'enum-4' },
+                ],
+              },
+            },
           ],
         })
         now = createTestProductType({
           attributes: [
-            createAttributeDefinition({
-              name: 'enum',
-              values: [
-                { key: 'enum_4', label: 'enum-4' },
-                { key: 'enum_1', label: 'enum-1' },
-                { key: 'enum_2', label: 'enum-2' },
-              ],
-            }),
+            {
+              type: {
+                name: 'enum',
+                values: [
+                  { key: 'enum_4', label: 'enum-4' },
+                  { key: 'enum_1', label: 'enum-1' },
+                  { key: 'enum_2', label: 'enum-2' },
+                ],
+              },
+            },
           ],
         })
         updateActions = productTypesSync.buildActions(now, before)
@@ -246,18 +262,22 @@ describe('Actions', () => {
       beforeEach(() => {
         before = createTestProductType({
           attributes: [
-            createAttributeDefinition({
-              name: 'enum',
-              values: [{ key: 'enum_1', label: 'enum-1' }],
-            }),
+            {
+              type: {
+                name: 'enum',
+                values: [{ key: 'enum_1', label: 'enum-1' }],
+              },
+            },
           ],
         })
         now = createTestProductType({
           attributes: [
-            createAttributeDefinition({
-              name: 'enum',
-              values: [{ key: 'enum_1', label: 'enum-4' }],
-            }),
+            {
+              type: {
+                name: 'enum',
+                values: [{ key: 'enum_1', label: 'enum-4' }],
+              },
+            },
           ],
         })
         updateActions = productTypesSync.buildActions(now, before)
@@ -278,26 +298,30 @@ describe('Actions', () => {
       beforeEach(() => {
         before = createTestProductType({
           attributes: [
-            createAttributeDefinition({
-              name: 'lenum',
-              values: [],
-            }),
+            {
+              type: {
+                name: 'lenum',
+                values: [],
+              },
+            },
           ],
         })
         now = createTestProductType({
           attributes: [
-            createAttributeDefinition({
-              name: 'lenum',
-              values: [
-                {
-                  key: 'lenum_1',
-                  label: {
-                    en: 'lenum-en',
-                    de: 'lenum-de',
+            {
+              type: {
+                name: 'lenum',
+                values: [
+                  {
+                    key: 'lenum_1',
+                    label: {
+                      en: 'lenum-en',
+                      de: 'lenum-de',
+                    },
                   },
-                },
-              ],
-            }),
+                ],
+              },
+            },
           ],
         })
         // we get a change operation only here.
@@ -323,37 +347,41 @@ describe('Actions', () => {
       beforeEach(() => {
         before = createTestProductType({
           attributes: [
-            createAttributeDefinition({
-              name: 'lenum',
-              values: [
-                {
-                  key: 'lenum_1',
-                  label: {
-                    en: 'lenum-1',
+            {
+              type: {
+                name: 'lenum',
+                values: [
+                  {
+                    key: 'lenum_1',
+                    label: {
+                      en: 'lenum-1',
+                    },
                   },
-                },
-                {
-                  key: 'lenum_2',
-                  label: {
-                    en: 'lenum-2',
+                  {
+                    key: 'lenum_2',
+                    label: {
+                      en: 'lenum-2',
+                    },
                   },
-                },
-                {
-                  key: 'lenum_4',
-                  label: {
-                    en: 'lenum-4',
+                  {
+                    key: 'lenum_4',
+                    label: {
+                      en: 'lenum-4',
+                    },
                   },
-                },
-              ],
-            }),
+                ],
+              },
+            },
           ],
         })
         now = createTestProductType({
           attributes: [
-            createAttributeDefinition({
-              name: 'lenum',
-              values: [],
-            }),
+            {
+              type: {
+                name: 'lenum',
+                values: [],
+              },
+            },
           ],
         })
         updateActions = productTypesSync.buildActions(now, before)
@@ -372,26 +400,30 @@ describe('Actions', () => {
       beforeEach(() => {
         before = createTestProductType({
           attributes: [
-            createAttributeDefinition({
-              name: 'lenum',
-              values: [
-                { key: 'enum_0', label: { en: 'enum-0' } },
-                { key: 'enum_2', label: { en: 'enum-2' } },
-                { key: 'enum_4', label: { en: 'enum-4' } },
-              ],
-            }),
+            {
+              type: {
+                name: 'lenum',
+                values: [
+                  { key: 'enum_0', label: { en: 'enum-0' } },
+                  { key: 'enum_2', label: { en: 'enum-2' } },
+                  { key: 'enum_4', label: { en: 'enum-4' } },
+                ],
+              },
+            },
           ],
         })
         now = createTestProductType({
           attributes: [
-            createAttributeDefinition({
-              name: 'lenum',
-              values: [
-                { key: 'enum_1', label: { en: 'enum-1' } },
-                { key: 'enum_3', label: { en: 'enum-3' } },
-                { key: 'enum_5', label: { en: 'enum-5' } },
-              ],
-            }),
+            {
+              type: {
+                name: 'lenum',
+                values: [
+                  { key: 'enum_1', label: { en: 'enum-1' } },
+                  { key: 'enum_3', label: { en: 'enum-3' } },
+                  { key: 'enum_5', label: { en: 'enum-5' } },
+                ],
+              },
+            },
           ],
         })
         updateActions = productTypesSync.buildActions(now, before)
@@ -425,25 +457,29 @@ describe('Actions', () => {
       beforeEach(() => {
         before = createTestProductType({
           attributes: [
-            createAttributeDefinition({
-              name: 'lenum',
-              values: [
-                { key: 'enum_0', label: { en: 'enum-0' } },
-                { key: 'enum_2', label: { en: 'enum-2' } },
-                { key: 'enum_4', label: { en: 'enum-4' } },
-              ],
-            }),
+            {
+              type: {
+                name: 'lenum',
+                values: [
+                  { key: 'enum_0', label: { en: 'enum-0' } },
+                  { key: 'enum_2', label: { en: 'enum-2' } },
+                  { key: 'enum_4', label: { en: 'enum-4' } },
+                ],
+              },
+            },
           ],
         })
         now = createTestProductType({
           attributes: [
-            createAttributeDefinition({
-              name: 'lenum',
-              values: [
-                { key: 'enum_0', label: { en: 'enum-0' } },
-                { key: 'enum_3', label: { en: 'enum-3' } },
-              ],
-            }),
+            {
+              type: {
+                name: 'lenum',
+                values: [
+                  { key: 'enum_0', label: { en: 'enum-0' } },
+                  { key: 'enum_3', label: { en: 'enum-3' } },
+                ],
+              },
+            },
           ],
         })
 
@@ -471,26 +507,30 @@ describe('Actions', () => {
       beforeEach(() => {
         before = createTestProductType({
           attributes: [
-            createAttributeDefinition({
-              name: 'lenum',
-              values: [
-                { key: 'enum_1', label: { en: 'enum-1' } },
-                { key: 'enum_2', label: { en: 'enum-2' } },
-                { key: 'enum_4', label: { en: 'enum-4' } },
-              ],
-            }),
+            {
+              type: {
+                name: 'lenum',
+                values: [
+                  { key: 'enum_1', label: { en: 'enum-1' } },
+                  { key: 'enum_2', label: { en: 'enum-2' } },
+                  { key: 'enum_4', label: { en: 'enum-4' } },
+                ],
+              },
+            },
           ],
         })
         now = createTestProductType({
           attributes: [
-            createAttributeDefinition({
-              name: 'lenum',
-              values: [
-                { key: 'enum_4', label: { en: 'enum-4' } },
-                { key: 'enum_1', label: { en: 'enum-1' } },
-                { key: 'enum_2', label: { en: 'enum-2' } },
-              ],
-            }),
+            {
+              type: {
+                name: 'lenum',
+                values: [
+                  { key: 'enum_4', label: { en: 'enum-4' } },
+                  { key: 'enum_1', label: { en: 'enum-1' } },
+                  { key: 'enum_2', label: { en: 'enum-2' } },
+                ],
+              },
+            },
           ],
         })
         updateActions = productTypesSync.buildActions(now, before)
@@ -513,18 +553,22 @@ describe('Actions', () => {
       beforeEach(() => {
         before = createTestProductType({
           attributes: [
-            createAttributeDefinition({
-              name: 'lenum',
-              values: [{ key: 'enum_1', label: { en: 'enum-1' } }],
-            }),
+            {
+              type: {
+                name: 'lenum',
+                values: [{ key: 'enum_1', label: { en: 'enum-1' } }],
+              },
+            },
           ],
         })
         now = createTestProductType({
           attributes: [
-            createAttributeDefinition({
-              name: 'lenum',
-              values: [{ key: 'enum_1', label: { en: 'enum-4' } }],
-            }),
+            {
+              type: {
+                name: 'lenum',
+                values: [{ key: 'enum_1', label: { en: 'enum-4' } }],
+              },
+            },
           ],
         })
         updateActions = productTypesSync.buildActions(now, before)


### PR DESCRIPTION
#### Summary

- generates update-actions for changes in enum
- removes `get*` and use simpler assignment

#### Description

for the moment, the `sync-actions/products` assumes the following shape of the attribute when the type is enum;

```
{
  type: {
    name: 'enum'
  }
  values: []
}
```

which results `sync-actions` not generating appropriate update actions when there is a change in `values` of enums.

##### Correct shape

```js
{
  type: {
    name: 'enum'
    values: []
  }
}
```


#### Todo

* Tests
  * [x] Unit
