### PR TITLE
feat(api-req-builder): add \`fullDataErasure\` option

### DIFF
--- a/docs/sdk/api/apiRequestBuilder.md
+++ b/docs/sdk/api/apiRequestBuilder.md
@@ -75,14 +75,14 @@ const uri = service.channels.withVersion(2).build()
 
 You can also append the `dataErasure` option to the uri when making a delete request if you want to make sure all related data is deleted. For example, regarding the GDPR, this means that all personal data related to the particular object, including invisible data, is erased. [More info here](https://docs.commercetools.com/release-notes#releases-2018-05-24-data-erasure)
 
-This can be done by passing the required `boolean` to the `.fullDataErasure()` method.
+This can be done by using the `.withFullDataErasure()` method.
 
 ```js
 const service = createRequestBuilder(options)
 const deleteUri = service.payments
   .byId(12345)
   .withVersion(3)
-  .fullDataErasure(true)
+  .withFullDataErasure()
   .build()
 ```
 

--- a/packages/api-request-builder/src/build-query-string.js
+++ b/packages/api-request-builder/src/build-query-string.js
@@ -106,7 +106,7 @@ export default function buildQueryString(
 
   if (version) queryString.push(`version=${version}`)
 
-  if (dataErasure) queryString.push(`dataErasure=${String(dataErasure)}`)
+  if (dataErasure) queryString.push(dataErasure)
 
   return queryString.join('&')
 }

--- a/packages/api-request-builder/src/create-service.js
+++ b/packages/api-request-builder/src/create-service.js
@@ -14,7 +14,7 @@ import {
 import classify from './classify'
 import buildQueryString from './build-query-string'
 import withVersion from './version'
-import fullDataErasure from './data-erasure'
+import withFullDataErasure from './data-erasure'
 import * as defaultFeatures from './features'
 import * as query from './query'
 import * as queryId from './query-id'
@@ -62,7 +62,7 @@ export default function createService(
     features,
     params: getDefaultQueryParams(),
     withVersion,
-    fullDataErasure,
+    withFullDataErasure,
 
     ...features.reduce((acc, feature) => {
       if (feature === defaultFeatures.query)

--- a/packages/api-request-builder/src/data-erasure.js
+++ b/packages/api-request-builder/src/data-erasure.js
@@ -8,14 +8,10 @@
  *
  * More info here: https://docs.commercetools.com/release-notes#releases-2018-05-24-data-erasure
  *
- * @param  {boolean} dataErasure - The dataErasure boolean option
- * @throws if `dataErasure` is missing or not a boolean.
  * @return {Object} The instance of the service, can be chained.
  */
 
-export default function fullDataErasure(dataErasure: boolean): Object {
-  if (typeof dataErasure !== 'boolean')
-    throw new Error('Required argument for `fullDataErasure` is missing')
-  this.params.dataErasure = dataErasure
+export default function withFullDataErasure(): Object {
+  this.params.dataErasure = 'dataErasure=true'
   return this
 }

--- a/packages/api-request-builder/src/default-params.js
+++ b/packages/api-request-builder/src/default-params.js
@@ -211,5 +211,5 @@ export function setParams(params: ServiceBuilderParams) {
   if (hasKey(params, 'version')) this.withVersion(params.version)
 
   // dataErasure
-  if (hasKey(params, 'dataErasure')) this.fullDataErasure(params.dataErasure)
+  if (hasKey(params, 'dataErasure')) this.withFullDataErasure()
 }

--- a/packages/api-request-builder/test/__snapshots__/data-erasure.spec.js.snap
+++ b/packages/api-request-builder/test/__snapshots__/data-erasure.spec.js.snap
@@ -1,5 +1,3 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`fullDataErasure should throw if not passed a number 1`] = `"Required argument for \`fullDataErasure\` is missing"`;
-
-exports[`fullDataErasure should throw if not passed any value 1`] = `"Required argument for \`fullDataErasure\` is missing"`;
+exports[`withFullDataErasure should set the dataErasure option to true 1`] = `"dataErasure=true"`;

--- a/packages/api-request-builder/test/create-service.spec.js
+++ b/packages/api-request-builder/test/create-service.spec.js
@@ -412,7 +412,7 @@ describe('createService', () => {
         expect(
           service
             .byCustomerId('foo')
-            .fullDataErasure(true)
+            .withFullDataErasure()
             .build()
         ).toBe('/my-project1/test?customerId=foo&dataErasure=true')
       })
@@ -440,7 +440,7 @@ describe('createService', () => {
           service
             .byCartId('foo')
             .withVersion(3)
-            .fullDataErasure(true)
+            .withFullDataErasure()
             .build()
         ).toBe('/my-project1/test?cartId=foo&version=3&dataErasure=true')
       })

--- a/packages/api-request-builder/test/data-erasure.spec.js
+++ b/packages/api-request-builder/test/data-erasure.spec.js
@@ -1,22 +1,14 @@
-import fullDataErasure from '../src/data-erasure'
+import withFullDataErasure from '../src/data-erasure'
 
-describe('fullDataErasure', () => {
+describe('withFullDataErasure', () => {
   let service
 
   beforeEach(() => {
-    service = { params: {}, fullDataErasure }
+    service = { params: {}, withFullDataErasure }
   })
 
-  test('should set the version number of an item', () => {
-    service.fullDataErasure(true)
-    expect(service.params.dataErasure).toBe(true)
-  })
-
-  test('should throw if not passed any value', () => {
-    expect(() => service.fullDataErasure()).toThrowErrorMatchingSnapshot()
-  })
-
-  test('should throw if not passed a number', () => {
-    expect(() => service.fullDataErasure('foo')).toThrowErrorMatchingSnapshot()
+  test('should set the dataErasure option to true', () => {
+    service.withFullDataErasure()
+    expect(service.params.dataErasure).toMatchSnapshot()
   })
 })

--- a/types/sdk.js
+++ b/types/sdk.js
@@ -226,7 +226,7 @@ export type ServiceBuilderDefaultParams = {
   version?: number,
   customerId?: string,
   cartId?: string,
-  dataErasure?: boolean,
+  dataErasure?: string,
 }
 export type ServiceBuilderParams = {
   // query-expand
@@ -277,6 +277,8 @@ export type ServiceBuilderParams = {
 
   // version
   version?: string,
+
+  // data-erasure
   dataErasure?: string,
 }
 export type ServiceBuilder = {


### PR DESCRIPTION
affects: @commercetools/api-request-builder

### Description

We now have the [dataErasure option](https://deploy-preview-963--commercetools-documentation.netlify.com/release-notes.html#releases-2018-05-24-data-erasure) in the API and we need to add it to the `api-request-builder` in order to not have to write code like [this](https://github.com/commercetools/nodejs/blob/master/packages/personal-data-erasure/src/main.js#L211)

```
let deleteUri = builder
  .byId(result.id)
  .withVersion(result.version)
  .build()

deleteUri += '&dataErasure=true'
```

PR adds a `fullDataErasure()` function that adds this option to the uri.

```
let deleteUri = builder
  .byId(result.id)
  .withVersion(result.version)
  .fullDataErasure(true)
  .build()
```

#### Todo

* Tests
  * [x] Unit
* [x] Documentation
  
closes #611 
