### PR TITLE
docs(docs): fix typo's in docs

### DIFF
--- a/docs/sdk/api/README.md
+++ b/docs/sdk/api/README.md
@@ -39,7 +39,7 @@ It's up to you to pick whatever middleware fits your needs: you can compose them
 
 ### `sdk-middleware-auth`
 
-Middelware to authenticate the [request](/sdk/Glossary.md#clientrequest) using one of the supported _auth flows_.
+Middleware to authenticate the [request](/sdk/Glossary.md#clientrequest) using one of the supported _auth flows_.
 
 * [createAuthMiddlewareForClientCredentialsFlow(options)](/sdk/api/sdkMiddlewareAuth.md#createauthmiddlewareforclientcredentialsflowoptions)
 * [createAuthMiddlewareForPasswordFlow(options)](/sdk/api/sdkMiddlewareAuth.md#createauthmiddlewareforpasswordflow)
@@ -49,14 +49,14 @@ Middelware to authenticate the [request](/sdk/Glossary.md#clientrequest) using o
 
 ### `sdk-middleware-http`
 
-Middelware to send the actual HTTP [request](/sdk/Glossary.md#clientrequest).
+Middleware to send the actual HTTP [request](/sdk/Glossary.md#clientrequest).
 
 * [createHttpMiddleware(options)](/sdk/api/sdkMiddlewareHttp.md#createhttpmiddlewareoptions)
 * [getErrorByCode(code)](/sdk/api/sdkMiddlewareHttp.md#geterrorbycode)
 
 ### `sdk-middleware-queue`
 
-Middelware to throttle concurrent [request](/sdk/Glossary.md#clientrequest) to a certain limit. Useful to reduce concurrent HTTP requests.
+Middleware to throttle concurrent [request](/sdk/Glossary.md#clientrequest) to a certain limit. Useful to reduce concurrent HTTP requests.
 
 * [createQueueMiddleware(options)](/sdk/api/sdkMiddlewareQueue.md#createqueuemiddlewareoptions)
 

--- a/docs/sdk/api/sdkMiddlewareAuth.md
+++ b/docs/sdk/api/sdkMiddlewareAuth.md
@@ -1,6 +1,6 @@
 # `sdk-middleware-auth`
 
-Middelware to authenticate the [request](/sdk/Glossary.md#clientrequest) using one of the supported _auth flows_.
+Middleware to authenticate the [request](/sdk/Glossary.md#clientrequest) using one of the supported _auth flows_.
 
 ## Install
 

--- a/docs/sdk/api/sdkMiddlewareHttp.md
+++ b/docs/sdk/api/sdkMiddlewareHttp.md
@@ -1,6 +1,6 @@
 # `sdk-middleware-http`
 
-Middelware to send the actual HTTP [request](/sdk/Glossary.md#clientrequest).
+Middleware to send the actual HTTP [request](/sdk/Glossary.md#clientrequest).
 
 ## Install
 

--- a/docs/sdk/api/sdkMiddlewareLogger.md
+++ b/docs/sdk/api/sdkMiddlewareLogger.md
@@ -1,6 +1,6 @@
 # `sdk-middleware-logger`
 
-Middelware to log incoming [request](/sdk/Glossary.md#clientrequest) and [response](/sdk/Glossary.md#clientrequest) objects.
+Middleware to log incoming [request](/sdk/Glossary.md#clientrequest) and [response](/sdk/Glossary.md#clientrequest) objects.
 
 ## Install
 

--- a/docs/sdk/api/sdkMiddlewareQueue.md
+++ b/docs/sdk/api/sdkMiddlewareQueue.md
@@ -1,6 +1,6 @@
 # `sdk-middleware-queue`
 
-Middelware to throttle concurrent [request](/sdk/Glossary.md#clientrequest) to a certain limit. Useful to reduce concurrent HTTP requests.
+Middleware to throttle concurrent [request](/sdk/Glossary.md#clientrequest) to a certain limit. Useful to reduce concurrent HTTP requests.
 
 ## Install
 

--- a/docs/sdk/api/sdkMiddlewareUserAgent.md
+++ b/docs/sdk/api/sdkMiddlewareUserAgent.md
@@ -1,6 +1,6 @@
 # `sdk-middleware-user-agent`
 
-Middelware to automatically set the `User-Agent` to the [request](/sdk/Glossary.md#clientrequest).
+Middleware to automatically set the `User-Agent` to the [request](/sdk/Glossary.md#clientrequest).
 
 ## Install
 


### PR DESCRIPTION
Summary
Fix typo's in docs

Description
Small typos in docs where Middleware is misspelled as Middelware.

closes #616 