### PR TITLE
docs(product-json-to-csv): Set correct link in readme

### DIFF
--- a/packages/product-json-to-csv/readme.md
+++ b/packages/product-json-to-csv/readme.md
@@ -2,7 +2,7 @@
 
 Convert [commercetools products](http://dev.commercetools.com/http-api-projects-products.html#product) JSON data to CSV
 
-More info here: https://commercetools.github.io/nodejs/cli/json-parser-products.html
+More info here: https://commercetools.github.io/nodejs/cli/product-json-to-csv.html
 
 ## Install
 


### PR DESCRIPTION

### Summary
Wrong link in product-json-to-csv package readme

#### Description
We have a wrong link to a documentation in README.md file in product-json-to-csv package:

https://commercetools.github.io/nodejs/cli/json-parser-products.html
Correct link is:

https://commercetools.github.io/nodejs/cli/product-json-to-csv.html

Closes #623 