### PR TITLE
fix(sync-actions): fix misspelled moveImageToPosition action

### DIFF
--- a/packages/sync-actions/src/product-actions.js
+++ b/packages/sync-actions/src/product-actions.js
@@ -210,7 +210,7 @@ function _buildVariantImagesAction(
         if (Number(image[2]) === 3)
           // image position changed
           actions.push({
-            action: 'moveImagetoPosition',
+            action: 'moveImageToPosition',
             variantId: oldVariant.id,
             imageUrl: oldObj.url,
             position: Number(image[1]),

--- a/packages/sync-actions/test/product-sync-images.spec.js
+++ b/packages/sync-actions/test/product-sync-images.spec.js
@@ -148,7 +148,7 @@ describe('Actions', () => {
           },
         },
         {
-          action: 'moveImagetoPosition',
+          action: 'moveImageToPosition',
           variantId: 3,
           imageUrl: '//example.com/image4.png',
           position: 0,
@@ -313,7 +313,7 @@ describe('Actions', () => {
           variantId: 1,
         },
         {
-          action: 'moveImagetoPosition',
+          action: 'moveImageToPosition',
           variantId: 1,
           imageUrl:
             'https://95bc80c3c245100a18cc-04fc5bec7ec901344d7cbd57f9a2fab3.ssl.cf3.rackcdn.com/cactus-with-surfboar-BmOeVZEZ.jpg',


### PR DESCRIPTION
affects: @commercetools/sync-actions

#### Summary

Fixes spelling error for `moveImageToPosition` action.

Correct spelling is [here](https://docs.commercetools.com/http-api-projects-products#move-image-to-position) in the docs.

resolves #638