### PR TITLE
chore(renovate): pin all dependencies

### DIFF
--- a/.renovaterc.json
+++ b/.renovaterc.json
@@ -1,7 +1,7 @@
 {
   "extends": [
     "config:base",
-    ":pinOnlyDevDependencies",
+    ":pinVersions",
     "group:monorepos",
     "schedule:weekly"
   ]


### PR DESCRIPTION
Since we use semver ranges instead of pinning the dependencies our [readme](https://github.com/commercetools/nodejs/blob/master/README.md) hurts people's eyes by saying our packages are **insecure** or **out of date**.

PR proposes to pin all dependencies and not only the `dev dependencies`