### PR TITLE
Add set valid from and until action for discounts

### DIFF
--- a/packages/sync-actions/src/cart-discounts.js
+++ b/packages/sync-actions/src/cart-discounts.js
@@ -3,6 +3,7 @@ import createBuildActions from './utils/create-build-actions'
 import createMapActionGroup from './utils/create-map-action-group'
 import actionsMapCustom from './utils/action-map-custom'
 import { actionsMapBase } from './cart-discounts-actions'
+import combineValidityActions from './utils/combine-validity-actions'
 import * as diffpatcher from './utils/diffpatcher'
 
 export const actionGroups = ['base', 'custom']
@@ -21,7 +22,7 @@ function createCartDiscountsMapActions(mapActionGroup, syncActionConfig) {
       mapActionGroup('custom', () => actionsMapCustom(diff, newObj, oldObj))
     )
 
-    return flatten(allActions)
+    return combineValidityActions(flatten(allActions))
   }
 }
 

--- a/packages/sync-actions/src/discount-codes.js
+++ b/packages/sync-actions/src/discount-codes.js
@@ -3,6 +3,7 @@ import createBuildActions from './utils/create-build-actions'
 import createMapActionGroup from './utils/create-map-action-group'
 import actionsMapCustom from './utils/action-map-custom'
 import { actionsMapBase } from './discount-codes-actions'
+import combineValidityActions from './utils/combine-validity-actions'
 import * as diffpatcher from './utils/diffpatcher'
 
 export const actionGroups = ['base', 'custom']
@@ -18,7 +19,7 @@ function createDiscountCodesMapActions(mapActionGroup, syncActionConfig) {
     allActions.push(
       mapActionGroup('custom', () => actionsMapCustom(diff, newObj, oldObj))
     )
-    return flatten(allActions)
+    return combineValidityActions(flatten(allActions))
   }
 }
 

--- a/packages/sync-actions/src/product-discounts.js
+++ b/packages/sync-actions/src/product-discounts.js
@@ -2,6 +2,7 @@ import flatten from 'lodash.flatten'
 import createBuildActions from './utils/create-build-actions'
 import createMapActionGroup from './utils/create-map-action-group'
 import { actionsMapBase } from './product-discounts-actions'
+import combineValidityActions from './utils/combine-validity-actions'
 import * as diffpatcher from './utils/diffpatcher'
 
 export const actionGroups = ['base']
@@ -15,8 +16,7 @@ function createProductDiscountsMapActions(mapActionGroup, syncActionConfig) {
         actionsMapBase(diff, oldObj, newObj, syncActionConfig)
       )
     )
-
-    return flatten(allActions)
+    return combineValidityActions(flatten(allActions))
   }
 }
 

--- a/packages/sync-actions/src/utils/combine-validity-actions.js
+++ b/packages/sync-actions/src/utils/combine-validity-actions.js
@@ -1,0 +1,19 @@
+export default function combineValidityActions(actions = []) {
+  const [setValidFromAction, setValidUntilAction] = actions.filter(
+    item => item.action === 'setValidFrom' || item.action === 'setValidUntil'
+  )
+  if (setValidFromAction && setValidUntilAction) {
+    return [
+      ...actions.filter(
+        item =>
+          !(item.action === 'setValidFrom' || item.action === 'setValidUntil')
+      ),
+      {
+        action: 'setValidFromAndUntil',
+        validFrom: setValidFromAction.validFrom,
+        validUntil: setValidUntilAction.validUntil,
+      },
+    ]
+  }
+  return actions
+}

--- a/packages/sync-actions/src/utils/combine-validity-actions.js
+++ b/packages/sync-actions/src/utils/combine-validity-actions.js
@@ -1,13 +1,14 @@
+const validityActions = ['setValidFrom', 'setValidUntil']
+
+const isValidityActions = actionName => validityActions.includes(actionName)
+
 export default function combineValidityActions(actions = []) {
-  const [setValidFromAction, setValidUntilAction] = actions.filter(
-    item => item.action === 'setValidFrom' || item.action === 'setValidUntil'
+  const [setValidFromAction, setValidUntilAction] = actions.filter(item =>
+    isValidityActions(item.action)
   )
   if (setValidFromAction && setValidUntilAction) {
     return [
-      ...actions.filter(
-        item =>
-          !(item.action === 'setValidFrom' || item.action === 'setValidUntil')
-      ),
+      ...actions.filter(item => !isValidityActions(item.action)),
       {
         action: 'setValidFromAndUntil',
         validFrom: setValidFromAction.validFrom,

--- a/packages/sync-actions/test/cart-discounts-sync.spec.js
+++ b/packages/sync-actions/test/cart-discounts-sync.spec.js
@@ -313,7 +313,27 @@ describe('Cart Discounts Actions', () => {
     const actual = cartDiscountsSync.buildActions(now, before)
     expect(actual).toEqual(expected)
   })
+  test('should build the `setValidFromAndUntil` action when both `validFrom` and `validUntil` exist', () => {
+    const before = {
+      validFrom: 'date-1-From',
+      validUntil: 'date-1-Until',
+    }
 
+    const now = {
+      validFrom: 'date-2-From',
+      validUntil: 'date-2-Until',
+    }
+
+    const expected = [
+      {
+        action: 'setValidFromAndUntil',
+        validFrom: 'date-2-From',
+        validUntil: 'date-2-Until',
+      },
+    ]
+    const actual = cartDiscountsSync.buildActions(now, before)
+    expect(actual).toEqual(expected)
+  })
   test('should build the `changeStackingMode` action', () => {
     const before = {
       stackingMode: 'Stacking',

--- a/packages/sync-actions/test/discount-codes-sync.spec.js
+++ b/packages/sync-actions/test/discount-codes-sync.spec.js
@@ -276,6 +276,28 @@ describe('Actions', () => {
     expect(actual).toEqual(expected)
   })
 
+  test('should build the `setValidFromAndUntil` action when both `validFrom` and `validUntil` exist', () => {
+    const before = {
+      validFrom: 'date-1-From',
+      validUntil: 'date-1-Until',
+    }
+
+    const now = {
+      validFrom: 'date-2-From',
+      validUntil: 'date-2-Until',
+    }
+
+    const expected = [
+      {
+        action: 'setValidFromAndUntil',
+        validFrom: 'date-2-From',
+        validUntil: 'date-2-Until',
+      },
+    ]
+    const actual = discountCodesSync.buildActions(now, before)
+    expect(actual).toEqual(expected)
+  })
+
   test('should build the `changeGroups` action', () => {
     const before = {
       groups: ['A'],

--- a/packages/sync-actions/test/product-discounts-sync.spec.js
+++ b/packages/sync-actions/test/product-discounts-sync.spec.js
@@ -235,4 +235,25 @@ describe('Actions', () => {
     const actual = productDiscountsSync.buildActions(now, before)
     expect(actual).toEqual(expected)
   })
+  test('should build the `setValidFromAndUntil` action when both `validFrom` and `validUntil` exist', () => {
+    const before = {
+      validFrom: 'date-1-From',
+      validUntil: 'date-1-Until',
+    }
+
+    const now = {
+      validFrom: 'date-2-From',
+      validUntil: 'date-2-Until',
+    }
+
+    const expected = [
+      {
+        action: 'setValidFromAndUntil',
+        validFrom: 'date-2-From',
+        validUntil: 'date-2-Until',
+      },
+    ]
+    const actual = productDiscountsSync.buildActions(now, before)
+    expect(actual).toEqual(expected)
+  })
 })

--- a/packages/sync-actions/test/utils/combine-validity-actions.spec.js
+++ b/packages/sync-actions/test/utils/combine-validity-actions.spec.js
@@ -42,7 +42,7 @@ describe('combineValidityActions', () => {
     beforeEach(() => {
       combinedActions = combineValidityActions([otherAction, validFromAction])
     })
-    it('should not compine into `setValidFromAndUntil` and keep `validFromAction`', () => {
+    it('should not combine into `setValidFromAndUntil` and keep `validFromAction`', () => {
       expect(combinedActions).toMatchObject([otherAction, validFromAction])
     })
   })
@@ -50,7 +50,7 @@ describe('combineValidityActions', () => {
     beforeEach(() => {
       combinedActions = combineValidityActions([otherAction, validUntilAction])
     })
-    it('should not compine into `setValidFromAndUntil` and keep `validUntilAction`', () => {
+    it('should not combine into `setValidFromAndUntil` and keep `validUntilAction`', () => {
       expect(combinedActions).toMatchObject([otherAction, validUntilAction])
     })
   })

--- a/packages/sync-actions/test/utils/combine-validity-actions.spec.js
+++ b/packages/sync-actions/test/utils/combine-validity-actions.spec.js
@@ -1,0 +1,65 @@
+import combineValidityActions from '../../src/utils/combine-validity-actions'
+
+describe('combineValidityActions', () => {
+  let combinedActions
+  let validFromAction
+  let validUntilAction
+  let otherAction
+  beforeEach(() => {
+    validFromAction = {
+      action: 'setValidFrom',
+      validFrom: 'date-from-1',
+    }
+    validUntilAction = {
+      action: 'setValidUntil',
+      validUntil: 'date-until-1',
+    }
+    otherAction = {
+      action: 'changeRequiresDiscountCode',
+      requiresDiscountCode: true,
+    }
+  })
+  describe('when both `setValidFrom` and `setValidUntil` available', () => {
+    beforeEach(() => {
+      combinedActions = combineValidityActions([
+        otherAction,
+        validFromAction,
+        validUntilAction,
+      ])
+    })
+    it('should combine both actions into `setValidFromAndUntil` action', () => {
+      expect(combinedActions).toMatchObject([
+        otherAction,
+        {
+          action: 'setValidFromAndUntil',
+          validFrom: validFromAction.validFrom,
+          validUntil: validUntilAction.validUntil,
+        },
+      ])
+    })
+  })
+  describe('when only `setValidFrom` is available', () => {
+    beforeEach(() => {
+      combinedActions = combineValidityActions([otherAction, validFromAction])
+    })
+    it('should not compine into `setValidFromAndUntil` and keep `validFromAction`', () => {
+      expect(combinedActions).toMatchObject([otherAction, validFromAction])
+    })
+  })
+  describe('when only `setValidUntil` is available', () => {
+    beforeEach(() => {
+      combinedActions = combineValidityActions([otherAction, validUntilAction])
+    })
+    it('should not compine into `setValidFromAndUntil` and keep `validUntilAction`', () => {
+      expect(combinedActions).toMatchObject([otherAction, validUntilAction])
+    })
+  })
+  describe('when neither `setValidFrom` nor `setValidUntil` are available', () => {
+    beforeEach(() => {
+      combinedActions = combineValidityActions([otherAction])
+    })
+    it('should return same actions without any change', () => {
+      expect(combinedActions).toMatchObject([otherAction])
+    })
+  })
+})


### PR DESCRIPTION
#### Summary
In this PR we add support we combine both  `setValidFrom` and `setValidUntil` to `setValidFromAndUntil` when appropriate 

- Add utility function that combines `validFromAction` and `validUntilAction` if both exist
- Apply `combineValidityActions` to discounts

#### Description

When we apply list of actions, and one of them fails, all fail, which is great.
But in some situation like the following example
**Draft**
```js
{
  validFrom: '01.01.2019',
  validUntil: '10.01.2019'
}
```
**Updated values**
```js
{
  validFrom: '15.01.2019',
  validUntil: '20.01.2019'
}
```
this will generate two update actions
```
[
  {setValidFrom: '15.01.2019'},
  {setValidUntil: '20.01.2019'}
]
```
And when applying the first action _setValidFrom_ we'll have this middle state 
```js
{
  validFrom: '15.01.2019',
  validUntil: '10.01.2019'
}
```
which will fail because `validFrom` should not exede `validUntil`
and this was the motivation for adding `setValidFromAndUntil` action
https://docs.commercetools.com/http-api-projects-productDiscounts.html#set-valid-from-and-until
Which allows us to update `validFrom` and `validUntil` in one step


<!-- Describe the changes in this PR here and provide some context -->

#### Todo

* Tests
  * [*] Unit
  * [ ] Integration
  * [ ] Acceptance
* [ ] Documentation
  <!-- Two persons should review a PR, don't forget to assign them. -->
