### PR TITLE
fix(renovate): disable auto update of node engines

### DIFF
--- a/.renovaterc.json
+++ b/.renovaterc.json
@@ -1,8 +1,20 @@
 {
   "extends": [
     "config:base",
-    ":pinVersions",
-    "group:monorepos",
     "schedule:weekly"
+  ],
+  "packageRules": [
+    {
+      "packagePatterns": [
+        "*"
+      ],
+      "rangeStrategy": "pin"
+    },
+    {
+      "depTypeList": [
+        "engines"
+      ],
+      "rangeStrategy": "auto"
+    }
   ]
 }


### PR DESCRIPTION
Using [:pinVersions preset](https://renovatebot.com/docs/presets-default/#pinversions) makes renovate bot pin the node engine, like seen in this PR #674

This PR changes the config to pin everything except engines. Verified working in this PR in forked repo.
https://github.com/daern91/nodejs/pull/4/files

This also removes `group:monorepos` as it is already included in `config:base
`, [more info here](https://renovatebot.com/docs/presets-config/#configbase).

closes #674
