### PR TITLE
fix(personal-data-erasure): fix failing int tests

### DIFF
--- a/integration-tests/cli/personal-data-erasure.it.js
+++ b/integration-tests/cli/personal-data-erasure.it.js
@@ -17,7 +17,6 @@ import {
 let projectKey
 if (process.env.CI === 'true') projectKey = 'custom-objects-import-int-tests'
 else projectKey = process.env.npm_config_projectkey
-projectKey = 'custom-objects-import-int-tests'
 
 describe('personal data erasure', () => {
   jest.setTimeout(15000) // 15 second timeout

--- a/integration-tests/cli/personal-data-erasure.it.js
+++ b/integration-tests/cli/personal-data-erasure.it.js
@@ -20,6 +20,8 @@ else projectKey = process.env.npm_config_projectkey
 projectKey = 'custom-objects-import-int-tests'
 
 describe('personal data erasure', () => {
+  jest.setTimeout(15000) // 15 second timeout
+
   const bin = './integration-tests/node_modules/.bin/personal-data-erasure'
 
   describe('CLI basic functionality', () => {
@@ -49,7 +51,7 @@ describe('personal data erasure', () => {
       debug: () => {},
     }
 
-    beforeAll(async () => {
+    const setupProject = async () => {
       const credentials = await getCredentials(projectKey)
       apiConfig = {
         host: 'https://auth.sphere.io',
@@ -89,63 +91,77 @@ describe('personal data erasure', () => {
           { ...review[0], customer: { id: customerId, typeId: 'customer' } },
         ]),
       ])
-    })
-
-    afterAll(async () => {
-      await Promise.all([
-        clearData(apiConfig, 'customers'),
-        clearData(apiConfig, 'orders'),
-        clearData(apiConfig, 'carts'),
-        clearData(apiConfig, 'payments'),
-        clearData(apiConfig, 'shoppingLists'),
-        clearData(apiConfig, 'reviews'),
-      ])
-    })
+    }
 
     beforeEach(() => {
       personalDataErasure = new PersonalDataErasure({ apiConfig }, logger)
     })
 
-    describe('export function', () => {
-      it('should get data on the CTP', async () => {
-        const data = await personalDataErasure.getCustomerData(customerId)
+    describe('functional usage', () => {
+      beforeAll(async () => {
+        await setupProject()
+      }, 30000) // 30 second timeout as this might take a while
 
-        expect(data).toHaveLength(10)
+      describe('::getCustomerData', () => {
+        it('should get data on the CTP', async () => {
+          const data = await personalDataErasure.getCustomerData(customerId)
+
+          expect(data).toHaveLength(10)
+        })
       })
 
-      it('should log success messages', async () => {
-        const filePath = tmp.fileSync().name
-        const [stdout, stderr] = await exec(
-          `${bin} -o ${filePath} -p ${projectKey} -c ${customerId}`
-        )
-        expect(stderr).toBeFalsy()
-        expect(stdout).toMatch(/Starting to fetch data/)
-        expect(stdout).toMatch(/Export operation completed successfully/)
-        expect(stdout).toMatch(/entities has been successfully written to file/)
+      describe('::deleteAll', () => {
+        it('should delete data on the CTP', async () => {
+          let data
+          const fetchDataAfterTimeout = ms =>
+            new Promise(resolve =>
+              setTimeout(async () => {
+                data = await personalDataErasure.getCustomerData(customerId)
+                resolve()
+              }, ms)
+            )
+
+          await personalDataErasure.deleteAll(customerId)
+
+          // wait 3s for DB to finish deletion
+          await fetchDataAfterTimeout(3000)
+          expect(data).toHaveLength(0)
+        })
       })
     })
 
-    describe('delete function', () => {
-      it('should delete data on the CTP', async () => {
-        await personalDataErasure.deleteAll(customerId)
+    describe('child process usage', () => {
+      beforeAll(async () => {
+        await setupProject()
+      }, 30000) // 30 second timeout as this might take a while
 
-        // wait 1s for DB to finish deletion
-        setTimeout(async () => {
-          const data = await personalDataErasure.getCustomerData(customerId)
-          expect(data).toHaveLength(0)
-        }, 1000)
+      describe('get data', () => {
+        it('should log success messages', async () => {
+          const filePath = tmp.fileSync().name
+          const [stdout, stderr] = await exec(
+            `${bin} -o ${filePath} -p ${projectKey} -c ${customerId}`
+          )
+          expect(stderr).toBeFalsy()
+          expect(stdout).toMatch(/Starting to fetch data/)
+          expect(stdout).toMatch(/Export operation completed successfully/)
+          expect(stdout).toMatch(
+            /entities has been successfully written to file/
+          )
+        })
       })
 
-      it('should log success messages', async () => {
-        const filePath = tmp.fileSync().name
-        const [stdout, stderr] = await exec(
-          `${bin} -o ${filePath} -p ${projectKey} -c ${customerId} -D  --force`
-        )
-        expect(stderr).toBeFalsy()
-        expect(stdout).toMatch(/Starting deletion/)
-        expect(stdout).toMatch(
-          `All data related to customer with id '${customerId}' has successfully been deleted.`
-        )
+      describe('delete data', () => {
+        it('should log success messages', async () => {
+          const filePath = tmp.fileSync().name
+          const [stdout, stderr] = await exec(
+            `${bin} -o ${filePath} -p ${projectKey} -c ${customerId} -D  --force`
+          )
+          expect(stderr).toBeFalsy()
+          expect(stdout).toMatch(/Starting deletion/)
+          expect(stdout).toMatch(
+            `All data related to customer with id '${customerId}' has successfully been deleted.`
+          )
+        })
       })
     })
   })

--- a/packages/personal-data-erasure/src/main.js
+++ b/packages/personal-data-erasure/src/main.js
@@ -177,10 +177,6 @@ export default class PersonalDataErasure {
       uri: requestBuilder.orders.where(`customerId = "${customerId}"`).build(),
       builder: requestBuilder.orders,
     }
-    const cartsResource = {
-      uri: requestBuilder.carts.where(`customerId = "${customerId}"`).build(),
-      builder: requestBuilder.carts,
-    }
     const paymentsResource = {
       uri: requestBuilder.payments
         .where(`customer(id = "${customerId}")`)
@@ -203,7 +199,6 @@ export default class PersonalDataErasure {
     const resourcesToDelete = [
       customersResource,
       ordersResource,
-      cartsResource,
       paymentsResource,
       shoppingListsResource,
       reviewsResource,


### PR DESCRIPTION
#### Summary

Tests were flaky because we bizarrely tried to delete all data twice from the same project. This would most of the time, weirdly enough, work since we are running the tests in parallel. However, sometimes it would fail since we can not delete what doesn't exist. Duh!

#### Description

PR restructures test file to set up and tear down the project correctly so we have new, fresh, data for each deletion. PR also removes carts from `resourcesToDelete` as it belongs to `customer` and gets deleted that way. (Hence, the tests are still passing).
https://docs.commercetools.com/http-api-projects-carts.html#carts

#### Todo

* Tests
  * [x] Unit
  * [x] Integration