### PR TITLE
chore(tooling): pin deps when publishing instead of using ranges

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -1,6 +1,7 @@
 {
   "lerna": "2.7.1",
   "version": "independent",
+  "exact": true,
   "changelog": {
     "rootPath": ".",
     "repo": "commercetools/nodejs",


### PR DESCRIPTION
#### Summary

PR makes sure we pin all dependencies upon publish.

#### Description

After recent changes to pin all dependencies instead of using ranges, we found that lerna publishes with added carets to the package.json. This makes renovate directly respond with a new PR that pins the dependencies again. Which in-turn makes lerna think the packages have changes and are ready to be published again. This could keep going forever...

PR adds `"exact": true` to `lerna.json` to fix this. This functionality was added to lerna [in this commit](https://github.com/lerna/lerna/pull/661/files#diff-7f56aae935ac7120955d2dc2fbf62eb8).

For more reading, please see lerna docs [here](https://github.com/lerna/lerna/tree/master/commands/version#--exact).

resolves #722