### PR TITLE
chore(renovate): remove limitation of concurrent pull requests

### DIFF
--- a/.renovaterc.json
+++ b/.renovaterc.json
@@ -3,6 +3,7 @@
     "config:base",
     ":pinAllExceptPeerDependencies",
     ":prHourlyLimitNone",
+    ":prConcurrentLimitNone",
     "schedule:weekly"
   ]
 }


### PR DESCRIPTION
#### Summary

We are currently extending Renovate's [base config](https://github.com/renovatebot/presets/blob/master/packages/renovate-config-config/package.json#L16-L34) which sets the concurrent PR limit to 20. This causes some trouble right now as we have more updates that needs to get done throughout all the packages and should not wait until next week to have them done.

So, this PR removes the limitation through adding the `prConcurrentLimitNone` option that got introduced in this PR: https://github.com/renovatebot/presets/pull/77 