### PR TITLE
test(discount-codes): fix broken int test

### DIFF
--- a/integration-tests/cli/discount-codes.it.js
+++ b/integration-tests/cli/discount-codes.it.js
@@ -277,14 +277,11 @@ describe('DiscountCode tests', () => {
     it('should write csv output to file when passed the option', async () => {
       const csvFilePath = tmp.fileSync().name
       const expected = {
-        version: '1',
         name: {
           en: 'Sammy',
-          de: 'Valerian',
         },
         description: {
           en: 'greatest promo',
-          de: 'super angebot',
         },
         cartDiscounts: cartDiscount.id,
         cartPredicate: 'lineItemTotal(1 = 1) >  "10.00 USD"',
@@ -300,14 +297,14 @@ describe('DiscountCode tests', () => {
 
       const data = await fs.readFile(csvFilePath, { encoding: 'utf8' })
 
-      csv()
-        .fromString(data)
-        .on('json', jsonObj => {
-          expect(jsonObj).toMatchObject(expected)
-          expect(isuuid(jsonObj.id)).toBe(true)
-          expect(jsonObj.createdAt).toMatch(UTCDateTimeRegex)
-          expect(jsonObj.lastModifiedAt).toMatch(UTCDateTimeRegex)
-        })
+      await new Promise(resolve => {
+        csv()
+          .fromString(data)
+          .on('json', jsonObj => {
+            expect(jsonObj).toMatchObject(expected)
+            resolve()
+          })
+      })
     })
   })
 })


### PR DESCRIPTION
#### Summary

This test have been unstable for a long time. Because of two reasons:

1. The test would finish before the (failed) results from the `csv()` function would return. We solve this by promisifying it.
2. The `expected` return value was wrong and a simple copy from the `JSON` value. As we see in the `headers` file, e.g. `version` is not supposed to be exported in the CSV.
https://github.com/commercetools/nodejs/blob/b2d1d423944d4daf3d43174654aaf8b781ea60b1/packages/discount-code-exporter/src/headers.js#L3-L16

Because of the first problem we never had to deal with this before though, as the error would be raised after the test had already returned green.

- Tests
  - [x] Integration
