### PR TITLE
refactor: use tc39 optional chaining

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -57,6 +57,7 @@ packages/*/src
 module.name_mapper='^types/\(.*\)$' -> '<PROJECT_ROOT>/types/\1.js'
 include_warnings=true
 emoji=true
+esproposal.optional_chaining=enable
 
 [version]
 0.80.0

--- a/babel.config.js
+++ b/babel.config.js
@@ -43,5 +43,6 @@ module.exports = {
     '@babel/plugin-proposal-export-default-from',
     '@babel/plugin-proposal-export-namespace-from',
     '@babel/plugin-proposal-object-rest-spread',
+    '@babel/plugin-proposal-optional-chaining',
   ],
 }

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "@babel/plugin-proposal-export-default-from": "7.0.0",
     "@babel/plugin-proposal-export-namespace-from": "7.0.0",
     "@babel/plugin-proposal-object-rest-spread": "7.0.0",
-    "@babel/plugin-proposal-optional-chaining": "^7.0.0",
+    "@babel/plugin-proposal-optional-chaining": "7.0.0",
     "@babel/preset-env": "7.0.0",
     "@babel/preset-flow": "7.0.0",
     "@commitlint/cli": "7.1.2",

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "@babel/plugin-proposal-export-default-from": "7.0.0",
     "@babel/plugin-proposal-export-namespace-from": "7.0.0",
     "@babel/plugin-proposal-object-rest-spread": "7.0.0",
+    "@babel/plugin-proposal-optional-chaining": "^7.0.0",
     "@babel/preset-env": "7.0.0",
     "@babel/preset-flow": "7.0.0",
     "@commitlint/cli": "7.1.2",

--- a/packages/api-request-builder/src/build-query-string.js
+++ b/packages/api-request-builder/src/build-query-string.js
@@ -48,7 +48,7 @@ export default function buildQueryString(
 
   if (priceChannel) queryString.push(`priceChannel=${priceChannel}`)
 
-  if (expand && expand.length)
+  if (expand?.length)
     queryString = queryString.concat(
       expand.map((e: string): string => `expand=${e}`)
     )
@@ -74,7 +74,7 @@ export default function buildQueryString(
       const offsetParam = limitParam * (page - 1)
       queryString.push(`offset=${offsetParam}`)
     }
-    if (sort && sort.length)
+    if (sort?.length)
       queryString = queryString.concat(
         sort.map((s: string): string => `sort=${s}`)
       )

--- a/packages/csv-parser-price/src/main.js
+++ b/packages/csv-parser-price/src/main.js
@@ -132,12 +132,12 @@ export default class CsvParserPrice {
   renameHeaders(price) {
     const newPrice = { ...price }
 
-    if (newPrice.customerGroup && newPrice.customerGroup.groupName) {
+    if (newPrice.customerGroup?.groupName) {
       newPrice.customerGroup.id = newPrice.customerGroup.groupName
       delete newPrice.customerGroup.groupName
     }
 
-    if (newPrice.channel && newPrice.channel.key) {
+    if (newPrice.channel?.key) {
       newPrice.channel.id = newPrice.channel.key
       delete newPrice.channel.key
     }
@@ -149,7 +149,7 @@ export default class CsvParserPrice {
   mergeBySku(data, currentPrice) {
     const previousPrice = data.prices[data.prices.length - 1]
     const sku = CONSTANTS.header.sku
-    if (previousPrice && previousPrice.sku === currentPrice[sku])
+    if (previousPrice?.sku === currentPrice[sku])
       previousPrice.prices.push(currentPrice)
     else
       data.prices.push({

--- a/packages/discount-code-importer/src/main.js
+++ b/packages/discount-code-importer/src/main.js
@@ -171,8 +171,7 @@ export default class DiscountCodeImport {
             return this._update(newCode, existingCode)
               .then(
                 (response: Object): Promise<void> => {
-                  if (response && response.statusCode === 304)
-                    this._summary.unchanged += 1
+                  if (response?.statusCode === 304) this._summary.unchanged += 1
                   else this._summary.updated += 1
                   return Promise.resolve()
                 }

--- a/packages/http-user-agent/src/create-user-agent.js
+++ b/packages/http-user-agent/src/create-user-agent.js
@@ -12,9 +12,7 @@ import type { HttpUserAgentOptions } from 'types/sdk'
 */
 
 const isBrowser = (): boolean =>
-  typeof window !== 'undefined' &&
-  window.document &&
-  window.document.nodeType === 9
+  typeof window !== 'undefined' && window.document?.nodeType === 9
 
 function getSystemInfo(): string {
   if (isBrowser()) return window.navigator.userAgent

--- a/packages/inventories-exporter/src/main.js
+++ b/packages/inventories-exporter/src/main.js
@@ -155,7 +155,7 @@ export default class InventoryExporter {
       }
     return this.client.execute(request).then(
       (result: Object): Promise<any> => {
-        if (result.body && result.body.results.length)
+        if (result.body?.results.length)
           return Promise.resolve(result.body.results[0].id)
         return Promise.reject(
           new Error('No data with channel key in CTP Platform')
@@ -177,8 +177,7 @@ export default class InventoryExporter {
       sku: row.sku,
       quantityOnStock: row.quantityOnStock,
     }
-    if (row.supplyChannel && row.supplyChannel.obj)
-      result.supplyChannel = row.supplyChannel.obj.key
+    if (row.supplyChannel?.obj) result.supplyChannel = row.supplyChannel.obj.key
     if (row.restockableInDays) result.restockableInDays = row.restockableInDays
     if (row.expectedDelivery) result.expectedDelivery = row.expectedDelivery
     if (row.custom && Object.keys(row.custom).length !== 0) {

--- a/packages/product-exporter/src/main.js
+++ b/packages/product-exporter/src/main.js
@@ -127,7 +127,7 @@ export default class ProductExporter {
     if (exportConfig.batch) service.perPage(exportConfig.batch)
     if (exportConfig.predicate) service.where(exportConfig.predicate)
     // Handle `expand` separately because it's an array
-    if (exportConfig.expand && exportConfig.expand.length)
+    if (exportConfig.expand?.length)
       exportConfig.expand.forEach((reference: string) => {
         service.expand(reference)
       })

--- a/packages/sdk-middleware-auth/src/anonymous-session-flow.js
+++ b/packages/sdk-middleware-auth/src/anonymous-session-flow.js
@@ -25,10 +25,7 @@ export default function createAuthMiddlewareForAnonymousSessionFlow(
   ) => {
     // Check if there is already a `Authorization` header in the request.
     // If so, then go directly to the next middleware.
-    if (
-      (request.headers && request.headers.authorization) ||
-      (request.headers && request.headers.Authorization)
-    ) {
+    if (request.headers?.authorization || request.headers?.Authorization) {
       next(request, response)
       return
     }

--- a/packages/sdk-middleware-auth/src/base-auth-flow.js
+++ b/packages/sdk-middleware-auth/src/base-auth-flow.js
@@ -130,17 +130,14 @@ export default function authMiddlewareBase(
     fetcher = fetch
   // Check if there is already a `Authorization` header in the request.
   // If so, then go directly to the next middleware.
-  if (
-    (request.headers && request.headers.authorization) ||
-    (request.headers && request.headers.Authorization)
-  ) {
+  if (request.headers?.authorization || request.headers?.Authorization) {
     next(request, response)
     return
   }
   // If there was a token in the tokenCache, and it's not expired, append
   // the token in the `Authorization` header.
   const tokenObj = tokenCache.get()
-  if (tokenObj && tokenObj.token && Date.now() < tokenObj.expirationTime) {
+  if (tokenObj?.token && Date.now() < tokenObj.expirationTime) {
     const requestWithAuth = mergeAuthHeader(tokenObj.token, request)
     next(requestWithAuth, response)
     return
@@ -160,8 +157,7 @@ export default function authMiddlewareBase(
   // If there was a refreshToken in the tokenCache, and there was an expired
   // token or no token in the tokenCache, use the refreshToken flow
   if (
-    tokenObj &&
-    tokenObj.refreshToken &&
+    tokenObj?.refreshToken &&
     (!tokenObj.token ||
       (tokenObj.token && Date.now() > tokenObj.expirationTime))
   ) {

--- a/packages/sdk-middleware-auth/src/client-credentials-flow.js
+++ b/packages/sdk-middleware-auth/src/client-credentials-flow.js
@@ -25,10 +25,7 @@ export default function createAuthMiddlewareForClientCredentialsFlow(
   ) => {
     // Check if there is already a `Authorization` header in the request.
     // If so, then go directly to the next middleware.
-    if (
-      (request.headers && request.headers.authorization) ||
-      (request.headers && request.headers.Authorization)
-    ) {
+    if (request.headers?.authorization || request.headers?.Authorization) {
       next(request, response)
       return
     }

--- a/packages/sdk-middleware-auth/src/existing-token.js
+++ b/packages/sdk-middleware-auth/src/existing-token.js
@@ -25,8 +25,7 @@ export default function createAuthMiddlewareWithExistingToken(
      */
     if (
       !authorization ||
-      (((request.headers && request.headers.authorization) ||
-        (request.headers && request.headers.Authorization)) &&
+      ((request.headers?.authorization || request.headers?.Authorization) &&
         force === false)
     ) {
       return next(request, response)

--- a/packages/sdk-middleware-auth/src/password-flow.js
+++ b/packages/sdk-middleware-auth/src/password-flow.js
@@ -25,10 +25,7 @@ export default function createAuthMiddlewareForPasswordFlow(
   ) => {
     // Check if there is already a `Authorization` header in the request.
     // If so, then go directly to the next middleware.
-    if (
-      (request.headers && request.headers.authorization) ||
-      (request.headers && request.headers.Authorization)
-    ) {
+    if (request.headers?.authorization || request.headers?.Authorization) {
       next(request, response)
       return
     }

--- a/packages/sdk-middleware-auth/src/refresh-token-flow.js
+++ b/packages/sdk-middleware-auth/src/refresh-token-flow.js
@@ -25,10 +25,7 @@ export default function createAuthMiddlewareForRefreshTokenFlow(
   ) => {
     // Check if there is already a `Authorization` header in the request.
     // If so, then go directly to the next middleware.
-    if (
-      (request.headers && request.headers.authorization) ||
-      (request.headers && request.headers.Authorization)
-    ) {
+    if (request.headers?.authorization || request.headers?.Authorization) {
       next(request, response)
       return
     }

--- a/packages/state-importer/src/main.js
+++ b/packages/state-importer/src/main.js
@@ -159,8 +159,7 @@ export default class StateImport {
             return this._update(newState, existingState)
               .then(
                 (response: Object): Promise<void> => {
-                  if (response && response.statusCode === 304)
-                    this._summary.unchanged += 1
+                  if (response?.statusCode === 304) this._summary.unchanged += 1
                   else this._summary.updated += 1
                   return Promise.resolve()
                 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -252,6 +252,13 @@
     "@babel/helper-plugin-utils" "^7.0.0"
     "@babel/plugin-syntax-optional-catch-binding" "^7.0.0"
 
+"@babel/plugin-proposal-optional-chaining@^7.0.0":
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-optional-chaining/-/plugin-proposal-optional-chaining-7.0.0.tgz#3d344d4152253379b8758e7d041148e8787c4a9d"
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.0.0"
+    "@babel/plugin-syntax-optional-chaining" "^7.0.0"
+
 "@babel/plugin-proposal-unicode-property-regex@^7.0.0":
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-unicode-property-regex/-/plugin-proposal-unicode-property-regex-7.0.0.tgz#498b39cd72536cd7c4b26177d030226eba08cd33"
@@ -299,6 +306,12 @@
 "@babel/plugin-syntax-optional-catch-binding@^7.0.0":
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-optional-catch-binding/-/plugin-syntax-optional-catch-binding-7.0.0.tgz#886f72008b3a8b185977f7cb70713b45e51ee475"
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.0.0"
+
+"@babel/plugin-syntax-optional-chaining@^7.0.0":
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-optional-chaining/-/plugin-syntax-optional-chaining-7.0.0.tgz#1e6ecba124310b5d3a8fc1e00d50b1c4c2e05e68"
   dependencies:
     "@babel/helper-plugin-utils" "^7.0.0"
 


### PR DESCRIPTION
#### Summary

After the babel 7 migration finished we also have the option to use a bunch of new proposals. PR introduces support for [optional chaining](https://github.com/tc39/proposal-optional-chaining) which is moving into `stage-3` as of now.

To give a few examples of where this can be useful PR also refactors a couple lines as an example.

#### Todo

- Tests
  - [x] Unit
  - [x] Integration
