### PR TITLE
(sync-actions): support custom fields updates in orders

### DIFF
--- a/packages/sync-actions/src/orders.js
+++ b/packages/sync-actions/src/orders.js
@@ -8,6 +8,7 @@ import type {
 } from 'types/sdk'
 import createBuildActions from './utils/create-build-actions'
 import createMapActionGroup from './utils/create-map-action-group'
+import actionsMapCustom from './utils/action-map-custom'
 import * as orderActions from './order-actions'
 import * as diffpatcher from './utils/diffpatcher'
 
@@ -48,6 +49,10 @@ function createOrderMapActions(
             orderActions.actionsMapReturnsInfo(diff, oldObj, newObj)
         )
       )
+    )
+
+    allActions.push(
+      mapActionGroup('custom', () => actionsMapCustom(diff, newObj, oldObj))
     )
 
     return flatten(allActions)

--- a/packages/sync-actions/test/order-sync.spec.js
+++ b/packages/sync-actions/test/order-sync.spec.js
@@ -343,3 +343,70 @@ describe('Actions', () => {
     })
   })
 })
+
+describe('custom fields', () => {
+  let orderSync
+  beforeEach(() => {
+    orderSync = orderSyncFn()
+  })
+  test('should build `setCustomType` action', () => {
+    const before = {
+      custom: {
+        type: {
+          typeId: 'type',
+          id: 'customType1',
+        },
+        fields: {
+          customField1: true,
+        },
+      },
+    }
+    const now = {
+      custom: {
+        type: {
+          typeId: 'type',
+          id: 'customType2',
+        },
+        fields: {
+          customField1: true,
+        },
+      },
+    }
+    const actual = orderSync.buildActions(now, before)
+    const expected = [{ action: 'setCustomType', ...now.custom }]
+    expect(actual).toEqual(expected)
+  })
+  test('should build `setCustomField` action', () => {
+    const before = {
+      custom: {
+        type: {
+          typeId: 'type',
+          id: 'customType1',
+        },
+        fields: {
+          customField1: false,
+        },
+      },
+    }
+    const now = {
+      custom: {
+        type: {
+          typeId: 'type',
+          id: 'customType1',
+        },
+        fields: {
+          customField1: true,
+        },
+      },
+    }
+    const actual = orderSync.buildActions(now, before)
+    const expected = [
+      {
+        action: 'setCustomField',
+        name: 'customField1',
+        value: true,
+      },
+    ]
+    expect(actual).toEqual(expected)
+  })
+})


### PR DESCRIPTION
#### Summary

Adds support for order custom fields.

#### Description

We are improving how we handle custom fields in the MC and when developing this for orders, I've realized that we didn't add the support for the `custom` attribute in orders 👍 

I've based the solution on what we have in `channels` and `customers` since is working like a charm there 😋 . Hope it make sense!

- Tests
  - [X] Unit
  - [X] Integration
  - [ ] Acceptance
- [ ] Documentation
