### PR TITLE
fix(documentation): add missing link to documentation

### DIFF
--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -9,6 +9,7 @@
   - [Glossary](/sdk/Glossary.md)
   - [API Reference](/sdk/api/README.md)
     - [core](/sdk/api/README.md#core)
+      - [sdk-auth](/sdk/api/sdkAuth.md)
       - [sdk-client](/sdk/api/sdkClient.md)
     - [middlewares](/sdk/api/README.md#middlewares)
       - [sdk-middleware-auth](/sdk/api/sdkMiddlewareAuth.md)

--- a/integration-tests/cli/discount-codes.it.js
+++ b/integration-tests/cli/discount-codes.it.js
@@ -13,7 +13,6 @@ let projectKey
 if (process.env.CI === 'true') projectKey = 'discount-codes-integration-test'
 else projectKey = process.env.npm_config_projectkey
 
-
 describe('DiscountCode tests', () => {
   let apiConfig
   let cartDiscount


### PR DESCRIPTION
#### Summary
This PR completes documentation summary page with a new link to `sdkAuth` docs page.