### PR TITLE
refactor(sdk-auth): use promises instead of async-await

### DIFF
--- a/packages/sdk-auth/test/password-flow.spec.js
+++ b/packages/sdk-auth/test/password-flow.spec.js
@@ -48,14 +48,14 @@ describe('Password flow', () => {
     expect(res).toEqual(response)
   })
 
-  test('should throw an error when credentials are not provided', async () => {
-    await expect(auth.passwordFlow()).rejects.toThrow(
+  test('should throw an error when credentials are not provided', () => {
+    expect(() => auth.passwordFlow()).toThrow(
       'Missing required user credentials (username, password)'
     )
-    await expect(auth.passwordFlow({ username: 'user' })).rejects.toThrow(
+    expect(() => auth.passwordFlow({ username: 'user' })).toThrow(
       'Missing required user credentials (username, password)'
     )
-    await expect(auth.passwordFlow({ password: 'password' })).rejects.toThrow(
+    expect(() => auth.passwordFlow({ password: 'password' })).toThrow(
       'Missing required user credentials (username, password)'
     )
   })

--- a/packages/sdk-auth/test/refresh-token-flow.spec.js
+++ b/packages/sdk-auth/test/refresh-token-flow.spec.js
@@ -23,7 +23,7 @@ describe('Refresh Token flow', () => {
   })
 
   test('should throw an error when token is not provided', async () => {
-    await expect(auth.refreshTokenFlow()).rejects.toThrow(
+    expect(() => auth.refreshTokenFlow()).toThrow(
       'Missing required token value'
     )
   })

--- a/packages/sdk-auth/test/token-introspection.spec.js
+++ b/packages/sdk-auth/test/token-introspection.spec.js
@@ -25,9 +25,7 @@ describe('Token Introspection', () => {
     expect(res).toEqual(response)
   })
 
-  test('should throw an error when token is not provided', async () => {
-    await expect(auth.introspectToken()).rejects.toThrow(
-      'Missing required token value'
-    )
+  test('should throw an error when token is not provided', () => {
+    expect(() => auth.introspectToken()).toThrow('Missing required token value')
   })
 })


### PR DESCRIPTION
#### Summary

Refactor for easier use with `.cjs`

#### Todo

- Tests
  - [x] Unit
  - [x] Integration
