### PR TITLE
Add support of withTotal to api-request-builder

### DIFF
--- a/docs/sdk/api/apiRequestBuilder.md
+++ b/docs/sdk/api/apiRequestBuilder.md
@@ -95,6 +95,17 @@ const deleteUri = service.payments
   .build()
 ```
 
+#### withTotal
+
+You can also append the `withTotal` option to the uri when making a get request if you want to do not need tht total when for instance fetching orders. [More info here](https://docs.commercetools.com/release-notes#releases-2018-05-24-data-erasure)
+
+This can be done by using the `.withTotal(false)` method.
+
+```js
+const service = createRequestBuilder(options)
+const getUri = service.orders.withTotal(false).build()
+```
+
 #### Usage example
 
 ```js

--- a/docs/sdk/api/apiRequestBuilder.md
+++ b/docs/sdk/api/apiRequestBuilder.md
@@ -97,7 +97,7 @@ const deleteUri = service.payments
 
 #### withTotal
 
-You can also append the `withTotal` option to the uri when making a get request if you want to do not need tht total when for instance fetching orders. [More info here](https://docs.commercetools.com/release-notes#releases-2018-05-24-data-erasure)
+You can also append the `withTotal` option to the uri when making a query. [More info here](https://docs.commercetools.com/http-api#pagedqueryresult).
 
 This can be done by using the `.withTotal(false)` method.
 

--- a/packages/api-request-builder/src/build-query-string.js
+++ b/packages/api-request-builder/src/build-query-string.js
@@ -67,7 +67,7 @@ export default function buildQueryString(
   }
 
   if (pagination) {
-    const { page, perPage, sort } = pagination
+    const { page, perPage, sort, withTotal } = pagination
     if (typeof perPage === 'number') queryString.push(`limit=${perPage}`)
     if (page) {
       const limitParam = perPage || 20
@@ -78,6 +78,9 @@ export default function buildQueryString(
       queryString = queryString.concat(
         sort.map((s: string): string => `sort=${s}`)
       )
+
+    if (typeof withTotal === 'boolean')
+      queryString.push(`withTotal=${String(withTotal)}`)
   }
 
   if (search) {

--- a/packages/api-request-builder/src/default-params.js
+++ b/packages/api-request-builder/src/default-params.js
@@ -18,6 +18,7 @@ export function getDefaultQueryParams(): ServiceBuilderDefaultParams {
       page: null,
       perPage: null,
       sort: [],
+      withTotal: null,
     },
     location: {
       currency: '',
@@ -45,6 +46,7 @@ export function getDefaultSearchParams(): ServiceBuilderDefaultParams {
       page: null,
       perPage: null,
       sort: [],
+      withTotal: null,
     },
     search: {
       facet: [],
@@ -126,6 +128,7 @@ export function setParams(params: ServiceBuilderParams) {
     'currency',
     'state',
     'dataErasure',
+    'withTotal',
   ]
   Object.keys(params).forEach((key: string) => {
     if (!knownKeys.includes(key)) throw new Error(`Unknown key "${key}"`)
@@ -208,4 +211,7 @@ export function setParams(params: ServiceBuilderParams) {
 
   // dataErasure
   if (hasKey(params, 'dataErasure')) this.withFullDataErasure()
+
+  // withTotal
+  if (hasKey(params, 'withTotal')) this.withTotal(params.withTotal)
 }

--- a/packages/api-request-builder/src/query-page.js
+++ b/packages/api-request-builder/src/query-page.js
@@ -59,3 +59,11 @@ export function perPage(value: number): Object {
   this.params.pagination.perPage = value
   return this
 }
+
+export function withTotal(value: boolean = true): Object {
+  if (typeof value !== 'boolean' && !value)
+    throw new Error('Required argument for `withTotal` is missing or invalid')
+
+  this.params.pagination.withTotal = value
+  return this
+}

--- a/packages/api-request-builder/src/query-page.js
+++ b/packages/api-request-builder/src/query-page.js
@@ -67,7 +67,7 @@ export function perPage(value: number): Object {
  * @param {boolean} value - indicating if the total should be included or not
  */
 export function withTotal(value: boolean = true): Object {
-  if (typeof value !== 'boolean' && !value)
+  if (typeof value !== 'boolean')
     throw new Error('Required argument for `withTotal` is missing or invalid')
 
   this.params.pagination.withTotal = value

--- a/packages/api-request-builder/src/query-page.js
+++ b/packages/api-request-builder/src/query-page.js
@@ -60,6 +60,12 @@ export function perPage(value: number): Object {
   return this
 }
 
+/**
+ * Set whether or not the total should be calculated (and included) in the result
+ * of a paginated query result.
+ *
+ * @param {boolean} value - indicating if the total should be included or not
+ */
 export function withTotal(value: boolean = true): Object {
   if (typeof value !== 'boolean' && !value)
     throw new Error('Required argument for `withTotal` is missing or invalid')

--- a/packages/api-request-builder/test/build-query-string.spec.js
+++ b/packages/api-request-builder/test/build-query-string.spec.js
@@ -23,6 +23,7 @@ describe('buildQueryString', () => {
           encodeURIComponent('name.en desc'),
           encodeURIComponent('createdAt asc'),
         ],
+        withTotal: false,
       },
       query: {
         operator: 'or',
@@ -74,6 +75,7 @@ describe('buildQueryString', () => {
       'limit=10&offset=20&' +
       `sort=${encodeURIComponent('name.en desc')}&` +
       `sort=${encodeURIComponent('createdAt asc')}&` +
+      `withTotal=false&` +
       `text.en=${encodeURIComponent('Foo')}&` +
       'fuzzy=true&' +
       'fuzzyLevel=2&' +

--- a/packages/api-request-builder/test/default-params.spec.js
+++ b/packages/api-request-builder/test/default-params.spec.js
@@ -13,6 +13,7 @@ describe('defaultParams', () => {
         page: null,
         perPage: null,
         sort: [],
+        withTotal: null,
       },
       query: {
         operator: 'and',
@@ -36,6 +37,7 @@ describe('defaultParams', () => {
         page: null,
         perPage: null,
         sort: [],
+        withTotal: null,
       },
       query: {
         operator: 'and',
@@ -60,6 +62,7 @@ describe('defaultParams', () => {
         page: null,
         perPage: null,
         sort: [],
+        withTotal: null,
       },
       query: {
         operator: 'and',
@@ -79,6 +82,7 @@ describe('defaultParams', () => {
         page: null,
         perPage: null,
         sort: [],
+        withTotal: null,
       },
       search: {
         facet: [],

--- a/packages/api-request-builder/test/query-page.spec.js
+++ b/packages/api-request-builder/test/query-page.spec.js
@@ -64,4 +64,15 @@ describe('queryPage', () => {
       /Required argument for `perPage` must be a number >= 0/
     )
   })
+
+  test('should set the withTotal param', () => {
+    service.withTotal(false)
+    expect(service.params.pagination.withTotal).toBe(false)
+  })
+
+  test('should throw if withTotal is not a boolean', () => {
+    expect(() => service.withTotal('foo')).toThrowError(
+      /Required argument for `withTotal` is missing or invalid/
+    )
+  })
 })

--- a/types/sdk.js
+++ b/types/sdk.js
@@ -242,6 +242,7 @@ export type ServiceBuilderDefaultParams = {
     page: ?number,
     perPage: ?number,
     sort: Array<string>,
+    withTotal: ?boolean,
   },
   id?: ?string,
   staged?: boolean,
@@ -290,6 +291,7 @@ export type ServiceBuilderParams = {
   sort: Array<{ by: string, direction: 'asc' | 'desc' }>,
   page: ?number,
   perPage: ?number,
+  withTotal: ?boolean,
 
   // query-projection
   staged?: boolean,
@@ -348,6 +350,7 @@ export type ServiceBuilderInstance = {
   sort: (option: string) => Object,
   page: (page: number) => Object,
   perPage: (amount: number) => Object,
+  withTotal(shouldIncludeTotal: boolean): Object,
   byId: (id: string) => Object,
   byKey: (key: string) => Object,
   byCustomerId: (id: string) => Object,

--- a/types/sdk.js
+++ b/types/sdk.js
@@ -350,7 +350,7 @@ export type ServiceBuilderInstance = {
   sort: (option: string) => Object,
   page: (page: number) => Object,
   perPage: (amount: number) => Object,
-  withTotal(shouldIncludeTotal: boolean): Object,
+  withTotal(value: boolean): Object,
   byId: (id: string) => Object,
   byKey: (key: string) => Object,
   byCustomerId: (id: string) => Object,


### PR DESCRIPTION
#### Summary

The api request builder should support withTotal of the API. This is needed for performance improvements within the MC.

Reference: https://docs.commercetools.com/http-api#pagedqueryresult