### PR TITLE
feat(sdk-auth): add a possibility to specify custom headers

### DIFF
--- a/docs/sdk/api/sdkAuth.md
+++ b/docs/sdk/api/sdkAuth.md
@@ -199,6 +199,7 @@ Runs a custom request based on given configuration.
 4.  `body` _(String)_: request body formatted as `application/x-www-form-urlencoded` content type, see example [here](https://developer.mozilla.org/en-US/docs/Web/HTTP/Methods/POST#Example).
 5.  `authType` _(String)_: Auth type performed in the auth request (default `Basic`).
 6.  `token` _(String)_: A `token` which will be sent in `Authorization` header. If not provided, we calculate it from credentials.
+7.  `headers` _(Object)_: Optional object containing headers which should be sent in auth request.
 
 #### Usage example
 
@@ -206,7 +207,13 @@ Runs a custom request based on given configuration.
 await authClient.customFlow({
   host: 'https://custom.url',
   uri: '/login',
-  body: 'user=username&password=password',
+  body: JSON.stringify({
+    username: 'username',
+    password: 'password',
+  }),
+  headers: {
+    'Content-Type': 'application/json',
+  },
 })
 // {
 // 	 ...API response

--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
     "eslint-plugin-jsx-a11y": "6.1.2",
     "eslint-plugin-prettier": "3.0.0",
     "eslint-plugin-react": "7.11.1",
-    "flow-bin": "^0.85.0",
+    "flow-bin": "0.85.0",
     "gitbook-cli": "daern91/gitbook-cli",
     "gitbook-plugin-anchorjs": "2.0.1",
     "gitbook-plugin-edit-link": "2.0.2",

--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
     "eslint-plugin-jsx-a11y": "6.1.2",
     "eslint-plugin-prettier": "3.0.0",
     "eslint-plugin-react": "7.11.1",
-    "flow-bin": "0.85.0",
+    "flow-bin": "^0.85.0",
     "gitbook-cli": "daern91/gitbook-cli",
     "gitbook-plugin-anchorjs": "2.0.1",
     "gitbook-plugin-edit-link": "2.0.2",

--- a/packages/sdk-auth/test/custom-flow.spec.js
+++ b/packages/sdk-auth/test/custom-flow.spec.js
@@ -55,4 +55,34 @@ describe('Custom flow', () => {
     expect(scope.isDone()).toBe(true)
     expect(res).toEqual(response)
   })
+
+  test('should set custom headers', async () => {
+    const scope = nock(customHost, {
+      reqheaders: {
+        'Content-Type': 'application/json',
+      },
+    })
+      .post(
+        '/custom-endpoint',
+        JSON.stringify({
+          a: 'b',
+        })
+      )
+      .reply(200, JSON.stringify(response))
+
+    expect(scope.isDone()).toBe(false)
+    const res = await auth.customFlow({
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      uri: '/custom-endpoint',
+      host: customHost,
+      body: JSON.stringify({
+        a: 'b',
+      }),
+    })
+
+    expect(scope.isDone()).toBe(true)
+    expect(res).toEqual(response)
+  })
 })

--- a/types/sdk.js
+++ b/types/sdk.js
@@ -25,6 +25,7 @@ export type AuthRequest = {
   body: string,
   basicAuth: string,
   authType: string,
+  headers?: Object,
 }
 export type HttpErrorType = {
   name: string,

--- a/types/sdk.js
+++ b/types/sdk.js
@@ -112,6 +112,7 @@ export type AuthOptions = {
     clientId: string,
     clientSecret: string,
   },
+  headers?: Object,
   scopes?: Array<string>,
   // For internal usage only
   fetch?: ConfigFetch,
@@ -127,6 +128,7 @@ export type CustomAuthOptions = {
     clientId: string,
     clientSecret: string,
   },
+  headers?: Object,
   scopes?: Array<string>,
   // For internal usage only
   fetch?: ConfigFetch,


### PR DESCRIPTION
#### Summary
This PR adds a possibility to specify custom headers when doing a customFlow auth request.

#### Todo

- Tests
  - [x] Unit
  - [ ] Integration
  - [ ] Acceptance
- [ ] Documentation
  <!-- Two persons should review a PR, don't forget to assign them. -->
