### PR TITLE
fix(product-json-to-csv): fix prefixing of conflicting attribute names

### DIFF
--- a/packages/product-json-to-csv/src/map-product-data.js
+++ b/packages/product-json-to-csv/src/map-product-data.js
@@ -52,6 +52,8 @@ export default class ProductMapping {
     this.multiValDel = multiValueDelimiter
     this.createShortcuts = createShortcuts
 
+    // this list was created from a list of productProjection properties:
+    // https://docs.commercetools.com/http-api-projects-productProjections.html#productprojection
     this.productLevelProperties = [
       'id',
       'key',

--- a/packages/product-json-to-csv/test/__snapshots__/map-product-data.spec.js.snap
+++ b/packages/product-json-to-csv/test/__snapshots__/map-product-data.spec.js.snap
@@ -14,6 +14,26 @@ Object {
 }
 `;
 
+exports[`::ProductMapping ::_mapProduct handle conflicting attribute names which are missing in main product info: conflictingDescriptionAttributeName 1`] = `
+Object {
+  "attribute.categories": "1;2;3",
+  "attribute.description.de": "descAttrDe",
+  "attribute.description.en": "descAttrEn",
+  "attribute.id": 1,
+  "attribute.name": "nameAttr",
+  "attribute.published": "false",
+  "attribute.slug": 1234,
+  "booleanAttribute": "false",
+  "id": "12345ab-id",
+  "key": "product-key",
+  "productType": "resolved-product-type",
+  "published": "true",
+  "variant.id": 1,
+  "variant.images": "",
+  "variant.sku": "A0E200000001YKI",
+}
+`;
+
 exports[`::ProductMapping ::_mapProduct handle conflicting productType names: conflictingPropertyNames 1`] = `
 Object {
   "attribute.productType": "prodTypeattributeValue",

--- a/packages/product-json-to-csv/test/map-product-data.spec.js
+++ b/packages/product-json-to-csv/test/map-product-data.spec.js
@@ -772,6 +772,68 @@ describe('::ProductMapping', () => {
       expect(mappedVariant).toMatchSnapshot('conflictingPropertyNames')
     })
 
+    test('handle conflicting attribute names which are missing in main product info', () => {
+      const sample = {
+        id: '12345ab-id',
+        key: 'product-key',
+        // missing description
+        productType: {
+          name: 'resolved-product-type',
+          attributes: [],
+        },
+        published: true,
+        masterVariant: {
+          id: 1,
+          sku: 'A0E200000001YKI',
+          images: [],
+          attributes: [
+            {
+              name: 'description',
+              value: {
+                en: 'descAttrEn',
+                de: 'descAttrDe',
+              },
+            },
+            {
+              name: 'id',
+              value: 1,
+            },
+            {
+              name: 'name',
+              value: 'nameAttr',
+            },
+            {
+              name: 'slug',
+              value: 1234,
+            },
+            {
+              // set of numbers
+              name: 'categories',
+              value: [1, 2, 3],
+            },
+            {
+              name: 'published',
+              value: false,
+            },
+            {
+              name: 'booleanAttribute',
+              value: false,
+            },
+          ],
+        },
+        variants: [],
+      }
+
+      const [mappedVariant] = productMapping.run(sample)
+      expect(mappedVariant.booleanAttribute).toEqual('false')
+      expect(mappedVariant.description).toEqual(undefined)
+      expect(mappedVariant['attribute.description.en']).toEqual('descAttrEn')
+      expect(mappedVariant['attribute.description.de']).toEqual('descAttrDe')
+      expect(mappedVariant).toMatchSnapshot(
+        'conflictingDescriptionAttributeName'
+      )
+    })
+
     test('converts variant image array to strings', () => {
       const sample = {
         id: '12345ab-id',

--- a/yarn.lock
+++ b/yarn.lock
@@ -1586,11 +1586,6 @@ ansi-escapes@^3.0.0:
   resolved "https://registry.yarnpkg.com/ansi-escapes/-/ansi-escapes-3.1.0.tgz#f73207bb81207d75fd6c83f125af26eea378ca30"
   integrity sha512-UgAb8H9D41AQnu/PbWlCofQVcnV4Gs2bBJi9eZPxfU/hgglFh3SMDMENRIqdr7H6XFnXdoknctFByVsCOotTVw==
 
-ansi-regex@*, ansi-regex@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-4.0.0.tgz#70de791edf021404c3fd615aa89118ae0432e5a9"
-  integrity sha512-iB5Dda8t/UqpPI/IjsejXu5jOGDrzn41wJyljwPH65VCIbk6+1BzFIMJGFwTNrYXT1CrD+B4l19U7awiQ8rk7w==
-
 ansi-regex@^2.0.0:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-2.1.1.tgz#c3b33ab5ee360d86e0e628f0468ae7ef27d654df"
@@ -1600,6 +1595,11 @@ ansi-regex@^3.0.0, ansi-regex@~3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-3.0.0.tgz#ed0317c322064f79466c02966bddb605ab37d998"
   integrity sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=
+
+ansi-regex@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-4.0.0.tgz#70de791edf021404c3fd615aa89118ae0432e5a9"
+  integrity sha512-iB5Dda8t/UqpPI/IjsejXu5jOGDrzn41wJyljwPH65VCIbk6+1BzFIMJGFwTNrYXT1CrD+B4l19U7awiQ8rk7w==
 
 ansi-styles@^2.2.1:
   version "2.2.1"
@@ -3326,7 +3326,7 @@ debug@^3.1.0:
   dependencies:
     ms "^2.1.1"
 
-debuglog@*, debuglog@^1.0.1:
+debuglog@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/debuglog/-/debuglog-1.0.1.tgz#aa24ffb9ac3df9a2351837cfb2d279360cd78492"
   integrity sha1-qiT/uaw9+aI1GDfPstJ5NgzXhJI=
@@ -5316,7 +5316,7 @@ import-local@^1.0.0:
     pkg-dir "^2.0.0"
     resolve-cwd "^2.0.0"
 
-imurmurhash@*, imurmurhash@^0.1.4:
+imurmurhash@^0.1.4:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/imurmurhash/-/imurmurhash-0.1.4.tgz#9218b9b2b928a238b13dc4fb6b6d576f231453ea"
   integrity sha1-khi5srkoojixPcT7a21XbyMUU+o=
@@ -6803,11 +6803,6 @@ lodash._basecreate@^3.0.0:
   resolved "https://registry.yarnpkg.com/lodash._basecreate/-/lodash._basecreate-3.0.3.tgz#1bc661614daa7fc311b7d03bf16806a0213cf821"
   integrity sha1-G8ZhYU2qf8MRt9A78WgGoCE8+CE=
 
-lodash._baseindexof@*:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/lodash._baseindexof/-/lodash._baseindexof-3.1.0.tgz#fe52b53a1c6761e42618d654e4a25789ed61822c"
-  integrity sha1-/lK1OhxnYeQmGNZU5KJXie1hgiw=
-
 lodash._baseuniq@~4.6.0:
   version "4.6.0"
   resolved "https://registry.yarnpkg.com/lodash._baseuniq/-/lodash._baseuniq-4.6.0.tgz#0ebb44e456814af7905c6212fa2c9b2d51b841e8"
@@ -6816,29 +6811,12 @@ lodash._baseuniq@~4.6.0:
     lodash._createset "~4.0.0"
     lodash._root "~3.0.0"
 
-lodash._bindcallback@*:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/lodash._bindcallback/-/lodash._bindcallback-3.0.1.tgz#e531c27644cf8b57a99e17ed95b35c748789392e"
-  integrity sha1-5THCdkTPi1epnhftlbNcdIeJOS4=
-
-lodash._cacheindexof@*:
-  version "3.0.2"
-  resolved "https://registry.yarnpkg.com/lodash._cacheindexof/-/lodash._cacheindexof-3.0.2.tgz#3dc69ac82498d2ee5e3ce56091bafd2adc7bde92"
-  integrity sha1-PcaayCSY0u5ePOVgkbr9Ktx73pI=
-
-lodash._createcache@*:
-  version "3.1.2"
-  resolved "https://registry.yarnpkg.com/lodash._createcache/-/lodash._createcache-3.1.2.tgz#56d6a064017625e79ebca6b8018e17440bdcf093"
-  integrity sha1-VtagZAF2JeeevKa4AY4XRAvc8JM=
-  dependencies:
-    lodash._getnative "^3.0.0"
-
 lodash._createset@~4.0.0:
   version "4.0.3"
   resolved "https://registry.yarnpkg.com/lodash._createset/-/lodash._createset-4.0.3.tgz#0f4659fbb09d75194fa9e2b88a6644d363c9fe26"
   integrity sha1-D0ZZ+7CddRlPqeK4imZE02PJ/iY=
 
-lodash._getnative@*, lodash._getnative@^3.0.0:
+lodash._getnative@^3.0.0:
   version "3.9.1"
   resolved "https://registry.yarnpkg.com/lodash._getnative/-/lodash._getnative-3.9.1.tgz#570bc7dede46d61cdcde687d65d3eecbaa3aaff5"
   integrity sha1-VwvH3t5G1hzc3mh9ZdPuy6o6r/U=
@@ -6985,11 +6963,6 @@ lodash.reject@^4.4.0:
   version "4.6.0"
   resolved "https://registry.yarnpkg.com/lodash.reject/-/lodash.reject-4.6.0.tgz#80d6492dc1470864bbf583533b651f42a9f52415"
   integrity sha1-gNZJLcFHCGS79YNTO2UfQqn1JBU=
-
-lodash.restparam@*:
-  version "3.6.1"
-  resolved "https://registry.yarnpkg.com/lodash.restparam/-/lodash.restparam-3.6.1.tgz#936a4e309ef330a7645ed4145986c85ae5b20805"
-  integrity sha1-k2pOMJ7zMKdkXtQUWYbIWuWyCAU=
 
 lodash.snakecase@4.1.1:
   version "4.1.1"
@@ -9392,7 +9365,7 @@ readable-stream@~2.1.5:
     string_decoder "~0.10.x"
     util-deprecate "~1.0.1"
 
-readdir-scoped-modules@*, readdir-scoped-modules@^1.0.0:
+readdir-scoped-modules@^1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/readdir-scoped-modules/-/readdir-scoped-modules-1.0.2.tgz#9fafa37d286be5d92cbaebdee030dc9b5f406747"
   integrity sha1-n6+jfShr5dksuuve4DDcm19AZ0c=
@@ -11112,7 +11085,7 @@ uuid@^3.0.0, uuid@^3.0.1, uuid@^3.2.1, uuid@^3.3.2:
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.3.2.tgz#1b4af4955eb3077c501c23872fc6513811587131"
   integrity sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA==
 
-validate-npm-package-license@*, validate-npm-package-license@^3.0.1, validate-npm-package-license@^3.0.3, validate-npm-package-license@~3.0.1:
+validate-npm-package-license@^3.0.1, validate-npm-package-license@^3.0.3, validate-npm-package-license@~3.0.1:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz#fc91f6b9c7ba15c857f4cb2c5defeec39d4f410a"
   integrity sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==


### PR DESCRIPTION
#### Summary
Fixes #970 

#### Description
When exporting a product with no product description field but an attribute named as description, we save incorrectly the attribute to `description` column instead of prefixing it with an `attribute.` string.

This PR adds a list of conflicting names which should be prefixed.
#### Todo

- Tests
  - [x] Unit
  - [ ] Integration
  - [ ] Acceptance
- [ ] Documentation
  <!-- Two persons should review a PR, don't forget to assign them. -->
