### PR TITLE
feat(sdk-auth): add invalidateTokenInfo fn, lock fetching

### DIFF
--- a/docs/sdk/api/sdkAuth.md
+++ b/docs/sdk/api/sdkAuth.md
@@ -284,7 +284,10 @@ const tokenProvider = new TokenProvider({
 const accessToken = await tokenProvider.getAccessToken()
 
 // get whole tokenInfo object
-const accessToken = await tokenProvider.getTokenInfo()
+const tokenInfo = await tokenProvider.getTokenInfo()
+
+// invalidate current tokenInfo so the tokenProvider will use fetchTokenInfo fn to fetch new one
+tokenProvider.invalidateTokenInfo()
 ```
 
 Another example:

--- a/packages/sdk-auth/test/token-provider.spec.js
+++ b/packages/sdk-auth/test/token-provider.spec.js
@@ -200,6 +200,23 @@ describe('Token Provider', () => {
       const resToken = await _tokenProvider.getAccessToken()
       expect(resToken).toEqual('new-access-token')
     })
+
+    test('should call fetchTokenInfo method only once', async () => {
+      const _tokenProvider = new TokenProvider({
+        sdkAuth,
+        fetchTokenInfo: jest
+          .fn()
+          .mockImplementation(() => Promise.resolve(tokenInfo)),
+      })
+
+      const tokenInfos = await Promise.all([
+        _tokenProvider.getTokenInfo(),
+        _tokenProvider.getTokenInfo(),
+      ])
+
+      expect(_tokenProvider.fetchTokenInfo).toHaveBeenCalledTimes(1)
+      expect(tokenInfos).toEqual([tokenInfo, tokenInfo])
+    })
   })
 
   describe('Valid token', () => {
@@ -265,6 +282,35 @@ describe('Token Provider', () => {
         'refreshToken'
       )
       expect(refreshedInfo).toEqual('refreshedInfo')
+    })
+
+    test('should call sdkAuth refreshToken flow only once', async () => {
+      const _tokenProvider = new TokenProvider({ sdkAuth }, tokenInfo)
+      _tokenProvider.sdkAuth.refreshTokenFlow = jest
+        .fn()
+        .mockImplementation(() => Promise.resolve('refreshedInfo'))
+
+      const refreshedInfo = await Promise.all([
+        _tokenProvider._performRefreshTokenFlow('refreshToken'),
+        _tokenProvider._performRefreshTokenFlow('refreshToken'),
+      ])
+
+      expect(_tokenProvider.sdkAuth.refreshTokenFlow).toHaveBeenCalledTimes(1)
+      expect(_tokenProvider.sdkAuth.refreshTokenFlow).toHaveBeenCalledWith(
+        'refreshToken'
+      )
+
+      expect(refreshedInfo).toEqual(['refreshedInfo', 'refreshedInfo'])
+    })
+  })
+
+  describe('invalidateTokenInfo', () => {
+    test('should invalidate stored tokenInfo', async () => {
+      const _tokenProvider = new TokenProvider({ sdkAuth }, tokenInfo)
+      expect(_tokenProvider.tokenInfo).not.toEqual(null)
+
+      _tokenProvider.invalidateTokenInfo()
+      expect(_tokenProvider.tokenInfo).toEqual(null)
     })
   })
 })


### PR DESCRIPTION
#### Summary
Resolves #1006 

#### Description
This PR brings following changes:
 - add `invalidateTokenInfo()` method
 - locks fetching so we send only one request to api
 - fix issue with missing `refresh_token` property

#### Todo

- Tests
  - [x] Unit
  - [ ] Integration
  - [ ] Acceptance
- [x] Documentation
  <!-- Two persons should review a PR, don't forget to assign them. -->
