### PR TITLE
chore(deps): update deps

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,6 @@
 node6Environment: &node6Environment
   docker:
-    - image: circleci/node:6@sha256:18e9fc218fc34f4a340cdbefb2f88694d8b97751bd49fb5c81d95853bf4290ba
+    - image: circleci/node:6@sha256:cdb5d5997a7ff4fb2978932786038fa95c1fab46d5a081784c25887d7ac7cb3d
   working_directory: ~/nodejs
 node8Environment: &node8Environment
   docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ node6Environment: &node6Environment
   working_directory: ~/nodejs
 node8Environment: &node8Environment
   docker:
-    - image: circleci/node:8@sha256:cea848e3a36f9b4c8e5cb78150ec842c3b6abd236aed8a5c2a38c14a74872407
+    - image: circleci/node:8@sha256:fa335a5e6518c937e4e261e79158a69c9a4c855fbc38bea89e6da720f63a3177
   working_directory: ~/nodejs
 
 aliases:

--- a/package.json
+++ b/package.json
@@ -93,7 +93,7 @@
     "prettier": "1.15.3",
     "resolve": "1.9.0",
     "rimraf": "2.6.3",
-    "rollup": "1.0.0",
+    "rollup": "1.0.2",
     "rollup-plugin-babel": "4.2.0",
     "rollup-plugin-commonjs": "9.2.0",
     "rollup-plugin-filesize": "5.0.1",

--- a/package.json
+++ b/package.json
@@ -92,7 +92,7 @@
     "npm-check-updates": "2.15.0",
     "prettier": "1.15.3",
     "resolve": "1.9.0",
-    "rimraf": "2.6.2",
+    "rimraf": "2.6.3",
     "rollup": "1.0.0",
     "rollup-plugin-babel": "4.2.0",
     "rollup-plugin-commonjs": "9.2.0",

--- a/package.json
+++ b/package.json
@@ -96,7 +96,7 @@
     "rollup": "1.0.2",
     "rollup-plugin-babel": "4.2.0",
     "rollup-plugin-commonjs": "9.2.0",
-    "rollup-plugin-filesize": "5.0.1",
+    "rollup-plugin-filesize": "6.0.0",
     "rollup-plugin-includepaths": "0.2.3",
     "rollup-plugin-json": "3.1.0",
     "rollup-plugin-node-resolve": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     "eslint-plugin-jest": "22.1.2",
     "eslint-plugin-jsx-a11y": "6.1.2",
     "eslint-plugin-prettier": "3.0.1",
-    "eslint-plugin-react": "7.12.1",
+    "eslint-plugin-react": "7.12.3",
     "flow-bin": "0.89.0",
     "gitbook-cli": "daern91/gitbook-cli",
     "gitbook-plugin-anchorjs": "2.1.0",

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "cross-env": "5.2.0",
     "cz-lerna-changelog": "2.0.0",
     "debug": "4.1.1",
-    "eslint": "5.11.1",
+    "eslint": "5.12.0",
     "eslint-config-airbnb": "17.1.0",
     "eslint-config-airbnb-base": "13.1.0",
     "eslint-config-prettier": "3.3.0",

--- a/packages/category-exporter/package.json
+++ b/packages/category-exporter/package.json
@@ -38,7 +38,7 @@
         "@commercetools/sdk-middleware-http": "4.0.10",
         "@commercetools/sdk-middleware-user-agent": "1.2.11",
         "node-fetch": "2.3.0",
-        "pino": "5.10.5",
+        "pino": "5.10.6",
         "pino-pretty": "2.5.0",
         "pretty-error": "2.1.1",
         "yargs": "12.0.5"

--- a/packages/csv-parser-state/package.json
+++ b/packages/csv-parser-state/package.json
@@ -47,7 +47,7 @@
     "highland": "2.13.0",
     "lodash.memoize": "4.1.2",
     "node-fetch": "2.3.0",
-    "pino": "5.10.5",
+    "pino": "5.10.6",
     "pretty-error": "2.1.1",
     "yargs": "12.0.5"
   }

--- a/packages/custom-objects-exporter/package.json
+++ b/packages/custom-objects-exporter/package.json
@@ -37,7 +37,7 @@
         "@commercetools/sdk-middleware-user-agent": "1.2.11",
         "JSONStream": "1.3.5",
         "node-fetch": "2.3.0",
-        "pino": "5.10.5",
+        "pino": "5.10.6",
         "pretty-error": "2.1.1",
         "yargs": "12.0.5"
     },

--- a/packages/customer-groups-exporter/package.json
+++ b/packages/customer-groups-exporter/package.json
@@ -38,7 +38,7 @@
         "@commercetools/sdk-middleware-user-agent": "1.2.11",
         "JSONStream": "1.3.5",
         "node-fetch": "2.3.0",
-        "pino": "5.10.5",
+        "pino": "5.10.6",
         "pretty-error": "2.1.1",
         "yargs": "12.0.5"
     },

--- a/packages/personal-data-erasure/package.json
+++ b/packages/personal-data-erasure/package.json
@@ -37,7 +37,7 @@
         "@commercetools/sdk-middleware-user-agent": "1.2.11",
         "lodash.flatten": "4.4.0",
         "node-fetch": "2.3.0",
-        "pino": "5.10.5",
+        "pino": "5.10.6",
         "pretty-error": "2.1.1",
         "prompt-confirm": "2.0.4",
         "yargs": "12.0.5"

--- a/packages/product-exporter/package.json
+++ b/packages/product-exporter/package.json
@@ -39,7 +39,7 @@
     "@commercetools/sdk-middleware-user-agent": "1.2.11",
     "JSONStream": "1.3.5",
     "node-fetch": "2.3.0",
-    "pino": "5.10.5",
+    "pino": "5.10.6",
     "pretty-error": "2.1.1",
     "yargs": "12.0.5"
   },

--- a/packages/product-json-to-csv/package.json
+++ b/packages/product-json-to-csv/package.json
@@ -51,7 +51,7 @@
     "json2csv": "4.3.2",
     "lodash": "4.17.11",
     "node-fetch": "2.3.0",
-    "pino": "5.10.5",
+    "pino": "5.10.6",
     "pretty-error": "2.1.1",
     "single-emit": "2.0.0",
     "slugify": "1.3.4",

--- a/packages/product-json-to-xlsx/package.json
+++ b/packages/product-json-to-xlsx/package.json
@@ -39,7 +39,7 @@
     "common-tags": "1.8.0",
     "exceljs": "1.6.3",
     "highland": "2.13.0",
-    "pino": "5.10.5",
+    "pino": "5.10.6",
     "pretty-error": "2.1.1",
     "slugify": "1.3.4",
     "tmp": "0.0.33",

--- a/packages/sdk-auth/package.json
+++ b/packages/sdk-auth/package.json
@@ -39,7 +39,7 @@
     "lodash.defaultsdeep": "4.6.0"
   },
   "devDependencies": {
-    "nock": "10.0.5",
+    "nock": "10.0.6",
     "node-fetch": "2.3.0"
   }
 }

--- a/packages/sdk-middleware-auth/package.json
+++ b/packages/sdk-middleware-auth/package.json
@@ -39,6 +39,6 @@
     "node-fetch": "2.3.0"
   },
   "devDependencies": {
-    "nock": "10.0.5"
+    "nock": "10.0.6"
   }
 }

--- a/packages/sdk-middleware-http/package.json
+++ b/packages/sdk-middleware-http/package.json
@@ -35,7 +35,7 @@
     "build:cjs": "cross-env NODE_ENV=rollup rollup -c ../../rollup.config.js -f cjs -n CommercetoolsSdkMiddlewareHttp -i src/index.js -o dist/commercetools-sdk-middleware-http.cjs.js"
   },
   "devDependencies": {
-    "nock": "10.0.5",
+    "nock": "10.0.6",
     "node-fetch": "2.3.0"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -9994,10 +9994,10 @@ rollup-plugin-commonjs@9.2.0:
     resolve "^1.8.1"
     rollup-pluginutils "^2.3.3"
 
-rollup-plugin-filesize@5.0.1:
-  version "5.0.1"
-  resolved "https://registry.yarnpkg.com/rollup-plugin-filesize/-/rollup-plugin-filesize-5.0.1.tgz#442a994465abf4f4f63ea20ac3267c3e0d05ee5d"
-  integrity sha512-zVUkEuJ543D86EaC5Ql2M6d6aAXwWbRwJ9NWSzTUS7F3vdd1cf+zlL+roQY8sW2hLIpbDMnGfev0dcy4bHQbjw==
+rollup-plugin-filesize@6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/rollup-plugin-filesize/-/rollup-plugin-filesize-6.0.0.tgz#6188769eff2ee6f4508e0f6de5cf64409e2a269d"
+  integrity sha512-yU1nNkB2RP1PwLpBFIzH9oIwLL+Si6AEuy0/hAhFW+68hy6x/W/MxhhsUe7bDhG7Gnei7FOGC4Ag4W9+CninMQ==
   dependencies:
     boxen "^2.0.0"
     brotli-size "0.0.3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -10064,10 +10064,10 @@ rollup-watch@4.3.1:
     require-relative "0.8.7"
     rollup-pluginutils "^2.0.1"
 
-rollup@1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/rollup/-/rollup-1.0.0.tgz#db97a04a15364d1cd3823a0024ae8d8fda530a1c"
-  integrity sha512-LV6Qz+RkuDAfxr9YopU4k5o5P/QA7YNq9xi2Ug2IqOmhPt9sAm89vh3SkNtFok3bqZHX54eMJZ8F68HPejgqtw==
+rollup@1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/rollup/-/rollup-1.0.2.tgz#df88abda5cfe96afaa07dbd540510f87e60d1baf"
+  integrity sha512-FkkSrWUVo1WliS+/GIgEmKQPILubgVdBRTWampfdhkasxx7sM2nfwSfKiX3paIBVnN0HG3DvkTy13RfjkyBX9w==
   dependencies:
     "@types/estree" "0.0.39"
     "@types/node" "*"

--- a/yarn.lock
+++ b/yarn.lock
@@ -9950,12 +9950,19 @@ right-pad@^1.0.1:
   resolved "https://registry.yarnpkg.com/right-pad/-/right-pad-1.0.1.tgz#8ca08c2cbb5b55e74dafa96bf7fd1a27d568c8d0"
   integrity sha1-jKCMLLtbVedNr6lr9/0aJ9VoyNA=
 
-rimraf@2, rimraf@2.6.2, rimraf@^2.2.8, rimraf@^2.5.2, rimraf@^2.5.4, rimraf@^2.6.1, rimraf@^2.6.2, rimraf@~2.6.2:
+rimraf@2, rimraf@^2.2.8, rimraf@^2.5.2, rimraf@^2.5.4, rimraf@^2.6.1, rimraf@^2.6.2, rimraf@~2.6.2:
   version "2.6.2"
   resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.6.2.tgz#2ed8150d24a16ea8651e6d6ef0f47c4158ce7a36"
   integrity sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==
   dependencies:
     glob "^7.0.5"
+
+rimraf@2.6.3:
+  version "2.6.3"
+  resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.6.3.tgz#b2d104fe0d8fb27cf9e0a1cda8262dd3833c6cab"
+  integrity sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==
+  dependencies:
+    glob "^7.1.3"
 
 rimraf@~2.2.6:
   version "2.2.8"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3880,10 +3880,10 @@ eslint-plugin-prettier@3.0.1:
   dependencies:
     prettier-linter-helpers "^1.0.0"
 
-eslint-plugin-react@7.12.1:
-  version "7.12.1"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-react/-/eslint-plugin-react-7.12.1.tgz#b9c4639f72469ff317ac31e3bd630d22d0dbf8f4"
-  integrity sha512-1YyXVhp6KSB+xRC1BWzmlA4BH9Wp9jMMBE6AJizxuk+bg/KUJpQGRwsU1/q1pV8rM6oEdLCxunXn7Nfh2BOWBg==
+eslint-plugin-react@7.12.3:
+  version "7.12.3"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-react/-/eslint-plugin-react-7.12.3.tgz#b9ca4cd7cd3f5d927db418a1950366a12d4568fd"
+  integrity sha512-WTIA3cS8OzkPeCi4KWuPmjR33lgG9r9Y/7RmnLTRw08MZKgAfnK/n3BO4X0S67MPkVLazdfCNT/XWqcDu4BLTA==
   dependencies:
     array-includes "^3.0.3"
     doctrine "^2.1.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2437,6 +2437,11 @@ callsites@^2.0.0:
   resolved "https://registry.yarnpkg.com/callsites/-/callsites-2.0.0.tgz#06eb84f00eea413da86affefacbffb36093b3c50"
   integrity sha1-BuuE8A7qQT2oav/vrL/7Ngk7PFA=
 
+callsites@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/callsites/-/callsites-3.0.0.tgz#fb7eb569b72ad7a45812f93fd9430a3e410b3dd3"
+  integrity sha512-tWnkwu9YEq2uzlBDI4RcLn8jrFvF9AOi8PxDNU3hZZjJcjkcRAq3vCI+vZcg1SuxISDYe86k9VZFwAxDiJGoAw==
+
 camelcase-keys@^2.0.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/camelcase-keys/-/camelcase-keys-2.1.0.tgz#308beeaffdf28119051efa1d932213c91b8f92e7"
@@ -3924,7 +3929,50 @@ eslint-visitor-keys@^1.0.0:
   resolved "https://registry.yarnpkg.com/eslint-visitor-keys/-/eslint-visitor-keys-1.0.0.tgz#3f3180fb2e291017716acb4c9d6d5b5c34a6a81d"
   integrity sha512-qzm/XxIbxm/FHyH341ZrbnMUpe+5Bocte9xkmFMzPMjRaZMcXww+MpBptFvtU+79L362nqiLhekCxCxDPaUMBQ==
 
-eslint@5.11.1, eslint@^5.6.0:
+eslint@5.12.0:
+  version "5.12.0"
+  resolved "https://registry.yarnpkg.com/eslint/-/eslint-5.12.0.tgz#fab3b908f60c52671fb14e996a450b96c743c859"
+  integrity sha512-LntwyPxtOHrsJdcSwyQKVtHofPHdv+4+mFwEe91r2V13vqpM8yLr7b1sW+Oo/yheOPkWYsYlYJCkzlFAt8KV7g==
+  dependencies:
+    "@babel/code-frame" "^7.0.0"
+    ajv "^6.5.3"
+    chalk "^2.1.0"
+    cross-spawn "^6.0.5"
+    debug "^4.0.1"
+    doctrine "^2.1.0"
+    eslint-scope "^4.0.0"
+    eslint-utils "^1.3.1"
+    eslint-visitor-keys "^1.0.0"
+    espree "^5.0.0"
+    esquery "^1.0.1"
+    esutils "^2.0.2"
+    file-entry-cache "^2.0.0"
+    functional-red-black-tree "^1.0.1"
+    glob "^7.1.2"
+    globals "^11.7.0"
+    ignore "^4.0.6"
+    import-fresh "^3.0.0"
+    imurmurhash "^0.1.4"
+    inquirer "^6.1.0"
+    js-yaml "^3.12.0"
+    json-stable-stringify-without-jsonify "^1.0.1"
+    levn "^0.3.0"
+    lodash "^4.17.5"
+    minimatch "^3.0.4"
+    mkdirp "^0.5.1"
+    natural-compare "^1.4.0"
+    optionator "^0.8.2"
+    path-is-inside "^1.0.2"
+    pluralize "^7.0.0"
+    progress "^2.0.0"
+    regexpp "^2.0.1"
+    semver "^5.5.1"
+    strip-ansi "^4.0.0"
+    strip-json-comments "^2.0.1"
+    table "^5.0.2"
+    text-table "^0.2.0"
+
+eslint@^5.6.0:
   version "5.11.1"
   resolved "https://registry.yarnpkg.com/eslint/-/eslint-5.11.1.tgz#8deda83db9f354bf9d3f53f9677af7e0e13eadda"
   integrity sha512-gOKhM8JwlFOc2acbOrkYR05NW8M6DCMSvfcJiBB5NDxRE1gv8kbvxKaC9u69e6ZGEMWXcswA/7eKR229cEIpvg==
@@ -5306,6 +5354,14 @@ import-fresh@^2.0.0:
   dependencies:
     caller-path "^2.0.0"
     resolve-from "^3.0.0"
+
+import-fresh@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/import-fresh/-/import-fresh-3.0.0.tgz#a3d897f420cab0e671236897f75bc14b4885c390"
+  integrity sha512-pOnA9tfM3Uwics+SaBLCNyZZZbK+4PTu0OPZtLlMIrv17EdBoC15S9Kn8ckJ9TZTyKb3ywNE5y1yeDxxGA7nTQ==
+  dependencies:
+    parent-module "^1.0.0"
+    resolve-from "^4.0.0"
 
 import-lazy@^2.1.0:
   version "2.1.0"
@@ -8828,6 +8884,13 @@ parallel-transform@^1.1.0:
     cyclist "~0.2.2"
     inherits "^2.0.3"
     readable-stream "^2.1.5"
+
+parent-module@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/parent-module/-/parent-module-1.0.0.tgz#df250bdc5391f4a085fb589dad761f5ad6b865b5"
+  integrity sha512-8Mf5juOMmiE4FcmzYc4IaiS9L3+9paz2KOiXzkRviCP6aDmN49Hz6EMWz0lGNp9pX80GvvAuLADtyGfW/Em3TA==
+  dependencies:
+    callsites "^3.0.0"
 
 parse-github-repo-url@^1.3.0:
   version "1.4.1"


### PR DESCRIPTION
#### Summary

Update deps

#### Description

Dependencies update of the following:-

- circleci/node:6 docker digest to cdb5d59
- circleci/node:8 docker digest to fa335a5
- eslint from v5.11.1 to v5.12.0
- eslint-plugin-react from v7.12.1 to v7.12.3
- nock from v10.0.5 to v10.0.6
- rimraf from v2.6.2 to v2.6.3
- rollup from v1.0.0 to v1.0.2
- pino from v5.10.5 to v5.10.6
- rollup-plugin-filesize from v5.0.1 to v6.0.0 (breaking change  to be compactible with rollup v1.0.0)

#### Todo

- Tests
  - [x] Unit
  - [x] Integration

resolves #1054
resolves #1055
resolves #1056
resolves #1057
resolves #1058
resolves #1059
resolves #1060
resolves #1061
resolves #1062
