### PR TITLE
chore(deps): deps update

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,6 @@
 node8Environment: &node8Environment
   docker:
-    - image: circleci/node:8@sha256:fbacb358b81169b319c95a5135de49efbb6bcdcee60dcd57d276c4a0fb676c9f
+    - image: circleci/node:8@sha256:b0b6b8d233527835f1a4617a73dfc589d022db127f6cb59718e36890cfc2e623
   working_directory: ~/nodejs
 node10Environment: &node10Environment
   docker:

--- a/.flowconfig
+++ b/.flowconfig
@@ -59,4 +59,4 @@ emoji=true
 esproposal.optional_chaining=enable
 
 [version]
-0.90.0
+0.91.0

--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
     "eslint-plugin-jest": "22.1.3",
     "eslint-plugin-jsx-a11y": "6.1.2",
     "eslint-plugin-prettier": "3.0.1",
-    "eslint-plugin-react": "7.12.3",
+    "eslint-plugin-react": "7.12.4",
     "flow-bin": "0.90.0",
     "gitbook-cli": "daern91/gitbook-cli",
     "gitbook-plugin-anchorjs": "2.1.0",

--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
     "jest-runner-eslint": "0.7.1",
     "jest-runner-flowtype": "0.0.7",
     "jest-silent-reporter": "0.1.1",
-    "leasot": "7.0.0",
+    "leasot": "7.1.0",
     "lerna": "3.6.0",
     "lint-staged": "8.1.0",
     "npm-check-updates": "2.15.0",

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "@babel/plugin-syntax-optional-chaining": "7.2.0",
     "@babel/preset-env": "7.2.3",
     "@babel/preset-flow": "7.0.0",
-    "@commitlint/cli": "7.3.1",
+    "@commitlint/cli": "7.3.2",
     "@commitlint/config-conventional": "7.3.1",
     "babel-core": "7.0.0-bridge.0",
     "babel-eslint": "10.0.1",

--- a/package.json
+++ b/package.json
@@ -91,7 +91,7 @@
     "prettier": "1.16.0",
     "resolve": "1.9.0",
     "rimraf": "2.6.3",
-    "rollup": "1.1.0",
+    "rollup": "1.1.2",
     "rollup-plugin-babel": "4.3.0",
     "rollup-plugin-commonjs": "9.2.0",
     "rollup-plugin-filesize": "6.0.0",

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "eslint-config-airbnb": "17.1.0",
     "eslint-config-airbnb-base": "13.1.0",
     "eslint-config-prettier": "3.6.0",
-    "eslint-formatter-pretty": "2.0.0",
+    "eslint-formatter-pretty": "2.1.1",
     "eslint-plugin-flowtype": "3.2.1",
     "eslint-plugin-import": "2.14.0",
     "eslint-plugin-jest": "22.1.3",

--- a/package.json
+++ b/package.json
@@ -88,7 +88,7 @@
     "lerna": "3.6.0",
     "lint-staged": "8.1.0",
     "npm-check-updates": "2.15.0",
-    "prettier": "1.15.3",
+    "prettier": "1.16.0",
     "resolve": "1.9.0",
     "rimraf": "2.6.3",
     "rollup": "1.1.0",

--- a/package.json
+++ b/package.json
@@ -92,7 +92,7 @@
     "resolve": "1.9.0",
     "rimraf": "2.6.3",
     "rollup": "1.1.2",
-    "rollup-plugin-babel": "4.3.0",
+    "rollup-plugin-babel": "4.3.2",
     "rollup-plugin-commonjs": "9.2.0",
     "rollup-plugin-filesize": "6.0.0",
     "rollup-plugin-includepaths": "0.2.3",

--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
     "eslint-plugin-jsx-a11y": "6.1.2",
     "eslint-plugin-prettier": "3.0.1",
     "eslint-plugin-react": "7.12.4",
-    "flow-bin": "0.90.0",
+    "flow-bin": "0.91.0",
     "gitbook-cli": "daern91/gitbook-cli",
     "gitbook-plugin-anchorjs": "2.1.0",
     "gitbook-plugin-edit-link": "2.0.2",

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "eslint": "5.12.1",
     "eslint-config-airbnb": "17.1.0",
     "eslint-config-airbnb-base": "13.1.0",
-    "eslint-config-prettier": "3.4.0",
+    "eslint-config-prettier": "3.6.0",
     "eslint-formatter-pretty": "2.0.0",
     "eslint-plugin-flowtype": "3.2.1",
     "eslint-plugin-import": "2.14.0",

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "cross-env": "5.2.0",
     "cz-lerna-changelog": "2.0.0",
     "debug": "4.1.1",
-    "eslint": "5.12.0",
+    "eslint": "5.12.1",
     "eslint-config-airbnb": "17.1.0",
     "eslint-config-airbnb-base": "13.1.0",
     "eslint-config-prettier": "3.4.0",

--- a/packages/category-exporter/package.json
+++ b/packages/category-exporter/package.json
@@ -39,7 +39,7 @@
         "@commercetools/sdk-middleware-http": "5.0.0",
         "@commercetools/sdk-middleware-user-agent": "2.0.0",
         "node-fetch": "2.3.0",
-        "pino": "5.10.6",
+        "pino": "5.10.8",
         "pino-pretty": "2.5.0",
         "pretty-error": "2.1.1",
         "yargs": "12.0.5"

--- a/packages/csv-parser-orders/package.json
+++ b/packages/csv-parser-orders/package.json
@@ -45,7 +45,7 @@
     "yargs": "12.0.5"
   },
   "devDependencies": {
-    "sinon": "7.2.2",
+    "sinon": "7.2.3",
     "streamtest": "1.2.4",
     "tmp": "0.0.33"
   }

--- a/packages/csv-parser-price/package.json
+++ b/packages/csv-parser-price/package.json
@@ -53,7 +53,7 @@
     "yargs": "12.0.5"
   },
   "devDependencies": {
-    "sinon": "7.2.2",
+    "sinon": "7.2.3",
     "streamtest": "1.2.4",
     "tmp": "0.0.33"
   }

--- a/packages/csv-parser-state/package.json
+++ b/packages/csv-parser-state/package.json
@@ -48,7 +48,7 @@
     "highland": "2.13.0",
     "lodash.memoize": "4.1.2",
     "node-fetch": "2.3.0",
-    "pino": "5.10.6",
+    "pino": "5.10.8",
     "pretty-error": "2.1.1",
     "yargs": "12.0.5"
   }

--- a/packages/custom-objects-exporter/package.json
+++ b/packages/custom-objects-exporter/package.json
@@ -38,7 +38,7 @@
         "@commercetools/sdk-middleware-user-agent": "2.0.0",
         "JSONStream": "1.3.5",
         "node-fetch": "2.3.0",
-        "pino": "5.10.6",
+        "pino": "5.10.8",
         "pretty-error": "2.1.1",
         "yargs": "12.0.5"
     },

--- a/packages/customer-groups-exporter/package.json
+++ b/packages/customer-groups-exporter/package.json
@@ -39,7 +39,7 @@
         "@commercetools/sdk-middleware-user-agent": "2.0.0",
         "JSONStream": "1.3.5",
         "node-fetch": "2.3.0",
-        "pino": "5.10.6",
+        "pino": "5.10.8",
         "pretty-error": "2.1.1",
         "yargs": "12.0.5"
     },

--- a/packages/get-credentials/package.json
+++ b/packages/get-credentials/package.json
@@ -24,7 +24,7 @@
     "build": "babel src --out-dir lib --config-file '../../babel.config.js'"
   },
   "devDependencies": {
-    "sinon": "7.2.2"
+    "sinon": "7.2.3"
   },
   "dependencies": {
     "dotenv": "6.2.0"

--- a/packages/personal-data-erasure/package.json
+++ b/packages/personal-data-erasure/package.json
@@ -37,7 +37,7 @@
         "@commercetools/sdk-middleware-user-agent": "2.0.0",
         "lodash.flatten": "4.4.0",
         "node-fetch": "2.3.0",
-        "pino": "5.10.6",
+        "pino": "5.10.8",
         "pretty-error": "2.1.1",
         "prompt-confirm": "2.0.4",
         "yargs": "12.0.5"

--- a/packages/product-exporter/package.json
+++ b/packages/product-exporter/package.json
@@ -40,7 +40,7 @@
     "@commercetools/sdk-middleware-user-agent": "2.0.0",
     "JSONStream": "1.3.5",
     "node-fetch": "2.3.0",
-    "pino": "5.10.6",
+    "pino": "5.10.8",
     "pretty-error": "2.1.1",
     "yargs": "12.0.5"
   },

--- a/packages/product-json-to-csv/package.json
+++ b/packages/product-json-to-csv/package.json
@@ -60,7 +60,7 @@
     "yargs": "12.0.5"
   },
   "devDependencies": {
-    "stream-to-string": "1.1.0",
+    "stream-to-string": "1.2.0",
     "streamtest": "1.2.4",
     "unzip": "0.1.11"
   }

--- a/packages/product-json-to-csv/package.json
+++ b/packages/product-json-to-csv/package.json
@@ -52,7 +52,7 @@
     "json2csv": "4.3.3",
     "lodash": "4.17.11",
     "node-fetch": "2.3.0",
-    "pino": "5.10.6",
+    "pino": "5.10.8",
     "pretty-error": "2.1.1",
     "single-emit": "2.0.0",
     "slugify": "1.3.4",

--- a/packages/product-json-to-xlsx/package.json
+++ b/packages/product-json-to-xlsx/package.json
@@ -40,7 +40,7 @@
     "common-tags": "1.8.0",
     "exceljs": "1.7.0",
     "highland": "2.13.0",
-    "pino": "5.10.6",
+    "pino": "5.10.8",
     "pretty-error": "2.1.1",
     "slugify": "1.3.4",
     "tmp": "0.0.33",

--- a/yarn.lock
+++ b/yarn.lock
@@ -10052,10 +10052,10 @@ rollup-watch@4.3.1:
     require-relative "0.8.7"
     rollup-pluginutils "^2.0.1"
 
-rollup@1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/rollup/-/rollup-1.1.0.tgz#461a7534b55be48aa4a6e6810a1543a5769e75d1"
-  integrity sha512-NK03gkkOz0CchHBMGomcNqa6U3jLNzHuWK9SI0+1FV475JA6cQxVtjlDcQoKKDNIQ3IwYumIlgoKYDEWUyFBwQ==
+rollup@1.1.2:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/rollup/-/rollup-1.1.2.tgz#8d094b85683b810d0c05a16bd7618cf70d48eba7"
+  integrity sha512-OkdMxqMl8pWoQc5D8y1cIinYQPPLV8ZkfLgCzL6SytXeNA2P7UHynEQXI9tYxuAjAMsSyvRaWnyJDLHMxq0XAg==
   dependencies:
     "@types/estree" "0.0.39"
     "@types/node" "*"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4416,10 +4416,10 @@ flat-cache@^1.2.1:
     rimraf "~2.6.2"
     write "^0.2.1"
 
-flow-bin@0.90.0:
-  version "0.90.0"
-  resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.90.0.tgz#733b6d29a8c8a22b9a5d273611d9a8402faf3445"
-  integrity sha512-/syDchjhLLL7nELK1ggyWJifGXuMCTz74kvkjR1t9DcmasMrilLl9qAAotsACcNb98etEEJpsCrvP7WL64kadw==
+flow-bin@0.91.0:
+  version "0.91.0"
+  resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.91.0.tgz#f5c89729f74b2ccbd47df6fbfadbdcc89cc1e478"
+  integrity sha512-j+L+xNiUYnZZ27MjVI0y2c9474ZHOvdSQq0Tjwh56mEA7tfxYqp5Dcb6aZSwvs3tGMTjCrZow9aUlZf3OoRyDQ==
 
 flow-bin@^0.63.1:
   version "0.63.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3928,7 +3928,50 @@ eslint-visitor-keys@^1.0.0:
   resolved "https://registry.yarnpkg.com/eslint-visitor-keys/-/eslint-visitor-keys-1.0.0.tgz#3f3180fb2e291017716acb4c9d6d5b5c34a6a81d"
   integrity sha512-qzm/XxIbxm/FHyH341ZrbnMUpe+5Bocte9xkmFMzPMjRaZMcXww+MpBptFvtU+79L362nqiLhekCxCxDPaUMBQ==
 
-eslint@5.12.0, eslint@^5.6.0:
+eslint@5.12.1:
+  version "5.12.1"
+  resolved "https://registry.yarnpkg.com/eslint/-/eslint-5.12.1.tgz#5ca9931fb9029d04e7be92b03ce3b58edfac7e3b"
+  integrity sha512-54NV+JkTpTu0d8+UYSA8mMKAG4XAsaOrozA9rCW7tgneg1mevcL7wIotPC+fZ0SkWwdhNqoXoxnQCTBp7UvTsg==
+  dependencies:
+    "@babel/code-frame" "^7.0.0"
+    ajv "^6.5.3"
+    chalk "^2.1.0"
+    cross-spawn "^6.0.5"
+    debug "^4.0.1"
+    doctrine "^2.1.0"
+    eslint-scope "^4.0.0"
+    eslint-utils "^1.3.1"
+    eslint-visitor-keys "^1.0.0"
+    espree "^5.0.0"
+    esquery "^1.0.1"
+    esutils "^2.0.2"
+    file-entry-cache "^2.0.0"
+    functional-red-black-tree "^1.0.1"
+    glob "^7.1.2"
+    globals "^11.7.0"
+    ignore "^4.0.6"
+    import-fresh "^3.0.0"
+    imurmurhash "^0.1.4"
+    inquirer "^6.1.0"
+    js-yaml "^3.12.0"
+    json-stable-stringify-without-jsonify "^1.0.1"
+    levn "^0.3.0"
+    lodash "^4.17.5"
+    minimatch "^3.0.4"
+    mkdirp "^0.5.1"
+    natural-compare "^1.4.0"
+    optionator "^0.8.2"
+    path-is-inside "^1.0.2"
+    pluralize "^7.0.0"
+    progress "^2.0.0"
+    regexpp "^2.0.1"
+    semver "^5.5.1"
+    strip-ansi "^4.0.0"
+    strip-json-comments "^2.0.1"
+    table "^5.0.2"
+    text-table "^0.2.0"
+
+eslint@^5.6.0:
   version "5.12.0"
   resolved "https://registry.yarnpkg.com/eslint/-/eslint-5.12.0.tgz#fab3b908f60c52671fb14e996a450b96c743c859"
   integrity sha512-LntwyPxtOHrsJdcSwyQKVtHofPHdv+4+mFwEe91r2V13vqpM8yLr7b1sW+Oo/yheOPkWYsYlYJCkzlFAt8KV7g==

--- a/yarn.lock
+++ b/yarn.lock
@@ -6626,10 +6626,10 @@ lcid@^2.0.0:
   dependencies:
     invert-kv "^2.0.0"
 
-leasot@7.0.0:
-  version "7.0.0"
-  resolved "https://registry.yarnpkg.com/leasot/-/leasot-7.0.0.tgz#368d05dc14c5728212e585ba1d4f6aeb691cad3b"
-  integrity sha512-BrMfFi9uO1G/j/vSfBEKU/xNQBildpuv+yfg7AN1mwjw2SkscXG6C4IwrSAuUS4OWPw2V8Bwxt7GDp9Xs5m+7w==
+leasot@7.1.0:
+  version "7.1.0"
+  resolved "https://registry.yarnpkg.com/leasot/-/leasot-7.1.0.tgz#ce32080b6882b39bf0caa534a80a0883ad148b5b"
+  integrity sha512-FgdEMj+NtQyJCBJWkGC7e9NN5kLKHfBPAnsSbw8ZU1gDlnbz+fkUrV/31alAXowvX6uc5LJt+dwrlp2/VIA1jw==
   dependencies:
     async "^2.6.1"
     chalk "^2.4.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1583,7 +1583,7 @@ ansi-escapes@^1.1.0:
   resolved "https://registry.yarnpkg.com/ansi-escapes/-/ansi-escapes-1.4.0.tgz#d3a8a83b319aa67793662b13e761c7911422306e"
   integrity sha1-06ioOzGapneTZisT52HHkRQiMG4=
 
-ansi-escapes@^3.0.0:
+ansi-escapes@^3.0.0, ansi-escapes@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/ansi-escapes/-/ansi-escapes-3.1.0.tgz#f73207bb81207d75fd6c83f125af26eea378ca30"
   integrity sha512-UgAb8H9D41AQnu/PbWlCofQVcnV4Gs2bBJi9eZPxfU/hgglFh3SMDMENRIqdr7H6XFnXdoknctFByVsCOotTVw==
@@ -3801,12 +3801,12 @@ eslint-config-prettier@3.6.0:
   dependencies:
     get-stdin "^6.0.0"
 
-eslint-formatter-pretty@2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/eslint-formatter-pretty/-/eslint-formatter-pretty-2.0.0.tgz#7bc011def9a01d457928988c736a8d5b8b13a00c"
-  integrity sha512-FEbP+ntP+b+lYo6xSd2nj8bvME3FKMzLP+FkNP3msPRrEDcm9LEC0T+6Js7ii/yH2hBtqwkXu2S2ttjlFmhOmw==
+eslint-formatter-pretty@2.1.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/eslint-formatter-pretty/-/eslint-formatter-pretty-2.1.1.tgz#0794a1009195d14e448053fe99667413b7d02e44"
+  integrity sha512-gWfagucSWBn82WxzwFloBTLAcwYDgnpAfiV5pQfyAV5YpZikuLflRU8nc3Ts9wnNvLhwk4blzb42/C495Yw7BA==
   dependencies:
-    ansi-escapes "^3.0.0"
+    ansi-escapes "^3.1.0"
     chalk "^2.1.0"
     eslint-rule-docs "^1.1.5"
     log-symbols "^2.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -9964,10 +9964,10 @@ rimraf@~2.5.4:
   dependencies:
     glob "^7.0.5"
 
-rollup-plugin-babel@4.3.0:
-  version "4.3.0"
-  resolved "https://registry.yarnpkg.com/rollup-plugin-babel/-/rollup-plugin-babel-4.3.0.tgz#1900e66af70c3975fef26a54111b87ee22a50974"
-  integrity sha512-HoNMaLA56MPZ9XCeG+RD2QzTySVe168R/k6bPEm8noB9PSK8wBnY4matFluwmH2Bj3PQdqYAknV1jDqw8GAc8g==
+rollup-plugin-babel@4.3.2:
+  version "4.3.2"
+  resolved "https://registry.yarnpkg.com/rollup-plugin-babel/-/rollup-plugin-babel-4.3.2.tgz#8c0e1bd7aa9826e90769cf76895007098ffd1413"
+  integrity sha512-KfnizE258L/4enADKX61ozfwGHoqYauvoofghFJBhFnpH9Sb9dNPpWg8QHOaAfVASUYV8w0mCx430i9z0LJoJg==
   dependencies:
     "@babel/helper-module-imports" "^7.0.0"
     rollup-pluginutils "^2.3.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3794,10 +3794,10 @@ eslint-config-airbnb@17.1.0:
     object.assign "^4.1.0"
     object.entries "^1.0.4"
 
-eslint-config-prettier@3.4.0:
-  version "3.4.0"
-  resolved "https://registry.yarnpkg.com/eslint-config-prettier/-/eslint-config-prettier-3.4.0.tgz#97dd5bf33d4d85862fdadf2ea89b4d6cebf3ba4f"
-  integrity sha512-VDBMmnwA1SH4tGoyTVStbjI18xAFtozvrodjEuoqtP/P/XLJs5Ga8sFf7GSSPxAkgh65CGYT/zOXzsf2IA0aqw==
+eslint-config-prettier@3.6.0:
+  version "3.6.0"
+  resolved "https://registry.yarnpkg.com/eslint-config-prettier/-/eslint-config-prettier-3.6.0.tgz#8ca3ffac4bd6eeef623a0651f9d754900e3ec217"
+  integrity sha512-ixJ4U3uTLXwJts4rmSVW/lMXjlGwCijhBJHk8iVqKKSifeI0qgFEfWl8L63isfc8Od7EiBALF6BX3jKLluf/jQ==
   dependencies:
     get-stdin "^6.0.0"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -9137,10 +9137,10 @@ prettier-linter-helpers@^1.0.0:
   dependencies:
     fast-diff "^1.1.2"
 
-prettier@1.15.3:
-  version "1.15.3"
-  resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.15.3.tgz#1feaac5bdd181237b54dbe65d874e02a1472786a"
-  integrity sha512-gAU9AGAPMaKb3NNSUUuhhFAS7SCO4ALTN4nRIn6PJ075Qd28Yn2Ig2ahEJWdJwJmlEBTUfC7mMUSFy8MwsOCfg==
+prettier@1.16.0:
+  version "1.16.0"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.16.0.tgz#104dd25f5ee3d0c9d0a6ce4bb40ced8481d51219"
+  integrity sha512-MCBCYeAuZfejUPdEpkleLWvpRBwLii/Sp5jQs0eb8Ul/drGIDjkL6tAU24tk6yCGf0KPV5rhPPPlczfBmN2pWQ==
 
 pretty-format@^23.6.0:
   version "23.6.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3879,10 +3879,10 @@ eslint-plugin-prettier@3.0.1:
   dependencies:
     prettier-linter-helpers "^1.0.0"
 
-eslint-plugin-react@7.12.3:
-  version "7.12.3"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-react/-/eslint-plugin-react-7.12.3.tgz#b9ca4cd7cd3f5d927db418a1950366a12d4568fd"
-  integrity sha512-WTIA3cS8OzkPeCi4KWuPmjR33lgG9r9Y/7RmnLTRw08MZKgAfnK/n3BO4X0S67MPkVLazdfCNT/XWqcDu4BLTA==
+eslint-plugin-react@7.12.4:
+  version "7.12.4"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-react/-/eslint-plugin-react-7.12.4.tgz#b1ecf26479d61aee650da612e425c53a99f48c8c"
+  integrity sha512-1puHJkXJY+oS1t467MjbqjvX53uQ05HXwjqDgdbGBqf5j9eeydI54G3KwiJmWciQ0HTBacIKw2jgwSBSH3yfgQ==
   dependencies:
     array-includes "^3.0.3"
     doctrine "^2.1.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -698,13 +698,13 @@
     lodash "^4.17.10"
     to-fast-properties "^2.0.0"
 
-"@commitlint/cli@7.3.1":
-  version "7.3.1"
-  resolved "https://registry.yarnpkg.com/@commitlint/cli/-/cli-7.3.1.tgz#3fa4f41b5363c061a4c9f82d32ad1f276e1e675d"
-  integrity sha512-/ySTlSegey0mOpz4TxikTCV1JaAPOpouMiGg18RI10lpL5cgD4FgbZUg5zsSv+ZzsobEBRdpuGAjg8vvCIkiWg==
+"@commitlint/cli@7.3.2":
+  version "7.3.2"
+  resolved "https://registry.yarnpkg.com/@commitlint/cli/-/cli-7.3.2.tgz#61abf30b48861e4fbd521690e6d4a3e1258980bb"
+  integrity sha512-QoVayW3kr6/pkWObaCmI6k8O02l/rOJmQIgy5785f6AVbUeHbLOVnh661XMunzAvDX2Cdz4mN+LenhsrLGsaug==
   dependencies:
     "@commitlint/format" "^7.3.1"
-    "@commitlint/lint" "^7.3.1"
+    "@commitlint/lint" "^7.3.2"
     "@commitlint/load" "^7.3.1"
     "@commitlint/read" "^7.3.1"
     babel-polyfill "6.26.0"
@@ -749,15 +749,16 @@
   dependencies:
     semver "5.6.0"
 
-"@commitlint/lint@^7.3.1":
-  version "7.3.1"
-  resolved "https://registry.yarnpkg.com/@commitlint/lint/-/lint-7.3.1.tgz#ee54c636c0ec7238410ac5d5a6f63e2c7b879182"
-  integrity sha512-aPfjqoOHhXDbA7pb+S7yGv8SsgCgfpOXybzO2NoiqVIvcuWXE+FuqVYDLjmzjvptYGYCB0oDFkewxoeHCzQOzg==
+"@commitlint/lint@^7.3.2":
+  version "7.3.2"
+  resolved "https://registry.yarnpkg.com/@commitlint/lint/-/lint-7.3.2.tgz#e5323ce5b65512e37089ca9e5dfd065849edbf80"
+  integrity sha512-NInm96JP89lMNR77R4zJRj/vaQWc4Ie5vR/5G5auFFiHuwyKmRWfXbGMA7zVYpAylPRgewGaELhuRzNTUW0Log==
   dependencies:
     "@commitlint/is-ignored" "^7.3.1"
     "@commitlint/parse" "^7.3.1"
     "@commitlint/rules" "^7.3.1"
     babel-runtime "^6.23.0"
+    lodash "4.17.11"
 
 "@commitlint/load@^7.3.1":
   version "7.3.1"
@@ -1587,11 +1588,6 @@ ansi-escapes@^3.0.0:
   resolved "https://registry.yarnpkg.com/ansi-escapes/-/ansi-escapes-3.1.0.tgz#f73207bb81207d75fd6c83f125af26eea378ca30"
   integrity sha512-UgAb8H9D41AQnu/PbWlCofQVcnV4Gs2bBJi9eZPxfU/hgglFh3SMDMENRIqdr7H6XFnXdoknctFByVsCOotTVw==
 
-ansi-regex@*, ansi-regex@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-4.0.0.tgz#70de791edf021404c3fd615aa89118ae0432e5a9"
-  integrity sha512-iB5Dda8t/UqpPI/IjsejXu5jOGDrzn41wJyljwPH65VCIbk6+1BzFIMJGFwTNrYXT1CrD+B4l19U7awiQ8rk7w==
-
 ansi-regex@^2.0.0:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-2.1.1.tgz#c3b33ab5ee360d86e0e628f0468ae7ef27d654df"
@@ -1601,6 +1597,11 @@ ansi-regex@^3.0.0, ansi-regex@~3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-3.0.0.tgz#ed0317c322064f79466c02966bddb605ab37d998"
   integrity sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=
+
+ansi-regex@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-4.0.0.tgz#70de791edf021404c3fd615aa89118ae0432e5a9"
+  integrity sha512-iB5Dda8t/UqpPI/IjsejXu5jOGDrzn41wJyljwPH65VCIbk6+1BzFIMJGFwTNrYXT1CrD+B4l19U7awiQ8rk7w==
 
 ansi-styles@^2.2.1:
   version "2.2.1"
@@ -3337,7 +3338,7 @@ debug@^3.1.0:
   dependencies:
     ms "^2.1.1"
 
-debuglog@*, debuglog@^1.0.1:
+debuglog@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/debuglog/-/debuglog-1.0.1.tgz#aa24ffb9ac3df9a2351837cfb2d279360cd78492"
   integrity sha1-qiT/uaw9+aI1GDfPstJ5NgzXhJI=
@@ -5344,7 +5345,7 @@ import-local@^1.0.0:
     pkg-dir "^2.0.0"
     resolve-cwd "^2.0.0"
 
-imurmurhash@*, imurmurhash@^0.1.4:
+imurmurhash@^0.1.4:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/imurmurhash/-/imurmurhash-0.1.4.tgz#9218b9b2b928a238b13dc4fb6b6d576f231453ea"
   integrity sha1-khi5srkoojixPcT7a21XbyMUU+o=
@@ -6927,11 +6928,6 @@ lodash._basecreate@^3.0.0:
   resolved "https://registry.yarnpkg.com/lodash._basecreate/-/lodash._basecreate-3.0.3.tgz#1bc661614daa7fc311b7d03bf16806a0213cf821"
   integrity sha1-G8ZhYU2qf8MRt9A78WgGoCE8+CE=
 
-lodash._baseindexof@*:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/lodash._baseindexof/-/lodash._baseindexof-3.1.0.tgz#fe52b53a1c6761e42618d654e4a25789ed61822c"
-  integrity sha1-/lK1OhxnYeQmGNZU5KJXie1hgiw=
-
 lodash._baseuniq@~4.6.0:
   version "4.6.0"
   resolved "https://registry.yarnpkg.com/lodash._baseuniq/-/lodash._baseuniq-4.6.0.tgz#0ebb44e456814af7905c6212fa2c9b2d51b841e8"
@@ -6940,29 +6936,12 @@ lodash._baseuniq@~4.6.0:
     lodash._createset "~4.0.0"
     lodash._root "~3.0.0"
 
-lodash._bindcallback@*:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/lodash._bindcallback/-/lodash._bindcallback-3.0.1.tgz#e531c27644cf8b57a99e17ed95b35c748789392e"
-  integrity sha1-5THCdkTPi1epnhftlbNcdIeJOS4=
-
-lodash._cacheindexof@*:
-  version "3.0.2"
-  resolved "https://registry.yarnpkg.com/lodash._cacheindexof/-/lodash._cacheindexof-3.0.2.tgz#3dc69ac82498d2ee5e3ce56091bafd2adc7bde92"
-  integrity sha1-PcaayCSY0u5ePOVgkbr9Ktx73pI=
-
-lodash._createcache@*:
-  version "3.1.2"
-  resolved "https://registry.yarnpkg.com/lodash._createcache/-/lodash._createcache-3.1.2.tgz#56d6a064017625e79ebca6b8018e17440bdcf093"
-  integrity sha1-VtagZAF2JeeevKa4AY4XRAvc8JM=
-  dependencies:
-    lodash._getnative "^3.0.0"
-
 lodash._createset@~4.0.0:
   version "4.0.3"
   resolved "https://registry.yarnpkg.com/lodash._createset/-/lodash._createset-4.0.3.tgz#0f4659fbb09d75194fa9e2b88a6644d363c9fe26"
   integrity sha1-D0ZZ+7CddRlPqeK4imZE02PJ/iY=
 
-lodash._getnative@*, lodash._getnative@^3.0.0:
+lodash._getnative@^3.0.0:
   version "3.9.1"
   resolved "https://registry.yarnpkg.com/lodash._getnative/-/lodash._getnative-3.9.1.tgz#570bc7dede46d61cdcde687d65d3eecbaa3aaff5"
   integrity sha1-VwvH3t5G1hzc3mh9ZdPuy6o6r/U=
@@ -7089,11 +7068,6 @@ lodash.reject@^4.4.0:
   version "4.6.0"
   resolved "https://registry.yarnpkg.com/lodash.reject/-/lodash.reject-4.6.0.tgz#80d6492dc1470864bbf583533b651f42a9f52415"
   integrity sha1-gNZJLcFHCGS79YNTO2UfQqn1JBU=
-
-lodash.restparam@*:
-  version "3.6.1"
-  resolved "https://registry.yarnpkg.com/lodash.restparam/-/lodash.restparam-3.6.1.tgz#936a4e309ef330a7645ed4145986c85ae5b20805"
-  integrity sha1-k2pOMJ7zMKdkXtQUWYbIWuWyCAU=
 
 lodash.some@^4.4.0:
   version "4.6.0"
@@ -9527,7 +9501,7 @@ readable-stream@~2.1.5:
     string_decoder "~0.10.x"
     util-deprecate "~1.0.1"
 
-readdir-scoped-modules@*, readdir-scoped-modules@^1.0.0:
+readdir-scoped-modules@^1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/readdir-scoped-modules/-/readdir-scoped-modules-1.0.2.tgz#9fafa37d286be5d92cbaebdee030dc9b5f406747"
   integrity sha1-n6+jfShr5dksuuve4DDcm19AZ0c=
@@ -11270,7 +11244,7 @@ uuid@^3.0.0, uuid@^3.0.1, uuid@^3.2.1, uuid@^3.3.2:
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.3.2.tgz#1b4af4955eb3077c501c23872fc6513811587131"
   integrity sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA==
 
-validate-npm-package-license@*, validate-npm-package-license@^3.0.1, validate-npm-package-license@^3.0.3, validate-npm-package-license@~3.0.1:
+validate-npm-package-license@^3.0.1, validate-npm-package-license@^3.0.3, validate-npm-package-license@~3.0.1:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz#fc91f6b9c7ba15c857f4cb2c5defeec39d4f410a"
   integrity sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==


### PR DESCRIPTION
#### Summary

Update deps

#### Description

Dependencies update of the following:-

- circleci/node:8 docker digest to b0b6b8d
- @commitlint/cli from v7.3.1 to v7.3.2
- eslint from v5.12.0 to v5.12.1
- eslint-config-prettier from v3.4.0 to v3.6.0
- eslint-formatter-pretty from v2.0.0 to v2.1.1
- eslint-plugin-react from v7.12.3 to v7.12.4
- flow-bin from v0.90 to v0.91.0
- leasot from v7.0.0 to v7.1.0
- prettier from v1.15.3 to v1.16.0
- rollup from v1.1.0 to v1.1.2
- rollup-plugin-babel from v4.3.0 to v4.3.2
- sinon from 7.2.2 to v7.2.3
- stream-to-string from v1.1.0 to v1.2.0
- pino from v5.10.6 to v5.10.8

resolves #1086
resolves #1087
resolves #1088
resolves #1089
resolves #1090
resolves #1091
resolves #1092
resolves #1093
resolves #1094
resolves #1095
resolves #1096
resolves #1097
resolves #1098
resolves #1099