### PR TITLE
docs(): fix broken query predicate docs link

### DIFF
--- a/docs/cli/category-exporter.md
+++ b/docs/cli/category-exporter.md
@@ -9,7 +9,7 @@ The constructor accepts two arguments:
 - A required object containing the following values:
   - `apiConfig` (Object): `AuthMiddleware` options for authentication on the commercetools platform. (Required. See [here](https://commercetools.github.io/nodejs/sdk/api/sdkMiddlewareAuth.html#named-arguments-options))
   - `accessToken` (String): [Access token] to be used to authenticate requests to API. Requires scope of [`view_products`, `manage_products`]. More info on how to get the access token [here](https://docs.commercetools.com/http-api-authorization.html#authorization-flows)
-  - `predicate` (String): Query string specifying (where) predicate. More info on predicates [here](https://docs.commercetools.com/http-api.html#predicates) (Optional)
+  - `predicate` (String): Query string specifying (where) predicate. More info on predicates [here](https://docs.commercetools.com/http-api-query-predicates) (Optional)
 - An optional logger object having four functions (`info`, `warn`, `error` and `debug`)
 
 ## Usage
@@ -47,7 +47,7 @@ Options:
   - If the file specified already exists, it will be overwritten.
   - The default location for status report logging is the standard output.
   - If no output path is specified, the exported categories will be logged to the standard output as a result, status reports will be logged to a `category-exporter.log` file in the current directory.
-- The `where` flag specifies an optional (where) query predicate to be included in the request. This predicate should be wrapped in single quotes ('single quoted predicate'). More info on predicates [here](https://docs.commercetools.com/http-api.html#predicates)
+- The `where` flag specifies an optional (where) query predicate to be included in the request. This predicate should be wrapped in single quotes ('single quoted predicate'). More info on predicates [here](https://docs.commercetools.com/http-api-query-predicates)
 
 ### JS
 

--- a/docs/cli/custom-objects-exporter.md
+++ b/docs/cli/custom-objects-exporter.md
@@ -9,7 +9,7 @@ The constructor accepts two arguments:
 - A required object containing the following values:
   - `apiConfig` (Object): `AuthMiddleware` options for authentication on the commercetools platform. (Required. See [here](https://commercetools.github.io/nodejs/sdk/api/sdkMiddlewareAuth.html#named-arguments-options))
   - `accessToken` (String): [Access token] to be used to authenticate requests to API. Requires scope of [`view_products`, `view_orders`, `view_customers`]. More info on how to get the access token [here](https://docs.commercetools.com/http-api-authorization.html#authorization-flows)
-  - `predicate` (String): Query string specifying (where) predicate. More info on predicates [here](https://docs.commercetools.com/http-api.html#predicates) (Optional)
+  - `predicate` (String): Query string specifying (where) predicate. More info on predicates [here](https://docs.commercetools.com/http-api-query-predicates) (Optional)
 - An optional logger object having four functions (`info`, `warn`, `error` and `debug`)
 
 ## Usage
@@ -46,7 +46,7 @@ Options:
   - If the file specified already exists, it will be overwritten.
   - The default location for status report logging is the standard output.
   - If no output path is specified, the exported objects will be logged to the standard output as a result, status reports will be logged to a `custom-objects-export.log` file in the current directory.
-- The `where` flag specifies an optional (where) query predicate to be included in the request. This predicate should be wrapped in single quotes ('single quoted predicate'). More info on predicates [here](https://docs.commercetools.com/http-api.html#predicates)
+- The `where` flag specifies an optional (where) query predicate to be included in the request. This predicate should be wrapped in single quotes ('single quoted predicate'). More info on predicates [here](https://docs.commercetools.com/http-api-query-predicates)
 
 ### JS
 

--- a/docs/cli/customer-groups-exporter.md
+++ b/docs/cli/customer-groups-exporter.md
@@ -9,7 +9,7 @@ The constructor accepts two arguments:
 - A required object containing the following values:
   - `apiConfig` (Object): `AuthMiddleware` options for authentication on the commercetools platform. (Required. See [here](https://commercetools.github.io/nodejs/sdk/api/sdkMiddlewareAuth.html#named-arguments-options))
   - `accessToken` (String): [Access token] to be used to authenticate requests to API. Requires scope of [`view_customers`]. More info on how to get the access token [here](https://docs.commercetools.com/http-api-authorization.html#authorization-flows)
-  - `predicate` (String): Query string specifying (where) predicate. More info on predicates [here](https://docs.commercetools.com/http-api.html#predicates) (Optional)
+  - `predicate` (String): Query string specifying (where) predicate. More info on predicates [here](https://docs.commercetools.com/http-api-query-predicates) (Optional)
 - An optional logger object having four functions (`info`, `warn`, `error` and `debug`)
 
 ## Usage
@@ -46,7 +46,7 @@ Options:
   - If the file specified already exists, it will be overwritten.
   - The default location for status report logging is the standard output.
   - If no output path is specified, the exported groups will be logged to the standard output as a result, status reports will be logged to a `customer-groups-export.log` file in the current directory.
-- The `where` flag specifies an optional (where) query predicate to be included in the request. This predicate should be wrapped in single quotes ('single quoted predicate'). More info on predicates [here](https://docs.commercetools.com/http-api.html#predicates)
+- The `where` flag specifies an optional (where) query predicate to be included in the request. This predicate should be wrapped in single quotes ('single quoted predicate'). More info on predicates [here](https://docs.commercetools.com/http-api-query-predicates)
 
 ### JS
 

--- a/docs/cli/discount-code-exporter.md
+++ b/docs/cli/discount-code-exporter.md
@@ -14,7 +14,7 @@ The constructor accepts two arguments:
   - `delimiter` (String): CSV delimiter (Optional. Default: `','`)
   - `multiValueDelimiter` (String): CSV delimiter used in multivalue fields (Optional. Default: `';'`)
   - `exportFormat` (String): Export format ['csv', 'json'] (Optional. Default: 'json')
-  - `predicate` (String): Query string specifying (where) predicate. More info on predicates [here](https://docs.commercetools.com/http-api.html#predicates) (Optional)
+  - `predicate` (String): Query string specifying (where) predicate. More info on predicates [here](https://docs.commercetools.com/http-api-query-predicates) (Optional)
   - `fields` (Array<String>): An array of column names the exported CSV file should contain. This fields array should contain the required columns of the CSV file (Optional. If omitted, a default set of column fields is used. Currently, these fields are: `name`, `description`, `code`, `cartDiscounts`,`cartPredicate`,`groups`,`isActive`,`validFrom`,`validUntil`,`references`,`maxApplications`,`maxApplicationsPerCustomer`.
     The localised fields (`name` and `description` default to the language specified in the `language` value above.
     This is synonymous with the `--template` flag in the CLI)
@@ -66,7 +66,7 @@ Options:
   - If no output path is specified, the exported codes will be logged to the standard output as a result, status reports will be logged to a `discount-code-export.log` file in the current directory.
 - The `--delimiter` flag specifies the delimiter used in the output file if CSV. Defaults to `','` if omitted.
 - The `--multiValueDelimiter` flag specifies the delimiter for multiValue cells in the output file if CSV. Defaults to `';'` if omitted.
-- The `where` flag specifies an optional (where) query predicate to be included in the request. This predicate should be wrapped in single quotes ('single quoted predicate'). More info on predicates [here](https://docs.commercetools.com/http-api.html#predicates)
+- The `where` flag specifies an optional (where) query predicate to be included in the request. This predicate should be wrapped in single quotes ('single quoted predicate'). More info on predicates [here](https://docs.commercetools.com/http-api-query-predicates)
 
 ### JS
 

--- a/docs/cli/price-exporter.md
+++ b/docs/cli/price-exporter.md
@@ -11,7 +11,7 @@ The constructor accepts two arguments:
   - `accessToken` (String): Access token to be used to authenticate requests to API. Requires scope of [`view_orders`]
   - `delimiter` (String): CSV delimiter (Optional. Default: `','`)
   - `exportFormat` (String): Export format ['csv', 'json'] (Optional. Default: 'json')
-  - `predicate` (String): Query string specifying (where) predicate. More info on predicates [here](https://docs.commercetools.com/http-api.html#predicates) (Optional)
+  - `predicate` (String): Query string specifying (where) predicate. More info on predicates [here](https://docs.commercetools.com/http-api-query-predicates) (Optional)
   - `staged` (Boolean): Specify if prices should be fetched from all products (true) or only published products (false) (Optional. Default: false)
   - `csvHeaders` (Array<String>): Array containing headers for the returned CSV price data. If omitted, all headers will be turned. (Optional)
 - An optional logger object having four functions (`info`, `warn`, `error` and `verbose`)
@@ -59,7 +59,7 @@ Options:
   - The default location for status report logging is the standard output.
   - If no output path is specified, the exported prices will be logged to the standard output.
 - The `--delimiter` flag specifies the delimiter used in the input and output file if CSV. Defaults to `','` if omitted.
-- The `where` flag specifies an optional (where) query predicate to be included in the request. This predicate is on the products containing the prices (`product-proections` endpoint) and not on the prices themselves. This predicate should be wrapped in single quotes ('single quoted predicate'). More info on predicates [here](https://docs.commercetools.com/http-api.html#predicates)
+- The `where` flag specifies an optional (where) query predicate to be included in the request. This predicate is on the products containing the prices (`product-proections` endpoint) and not on the prices themselves. This predicate should be wrapped in single quotes ('single quoted predicate'). More info on predicates [here](https://docs.commercetools.com/http-api-query-predicates)
 - The `--staged` flag specifies the projection of the products from which the prices should be fetched.
   - If passed `true`, prices from published and unpublished products are retrieved
   - If passed `false` (or omitted), only prices from published products are retrieved

--- a/docs/cli/product-exporter.md
+++ b/docs/cli/product-exporter.md
@@ -12,7 +12,7 @@ The constructor accepts four arguments:
   - `batch` (Number): Amount of products to fetch for each API call
   - `expand` (Array): An array of strings signifying reference fields to expand in the returned product
   - `json` (Boolean): Specify if products returned should be in JSON file format. If set to false, the products will be output in chunks (Default: true)
-  - `predicate` (String): Query string specifying (where) predicate. More info on predicates [here](https://docs.commercetools.com/http-api.html#predicates) (Optional)
+  - `predicate` (String): Query string specifying (where) predicate. More info on predicates [here](https://docs.commercetools.com/http-api-query-predicates) (Optional)
   - `staged` (Boolean): Specify if prices should be fetched from all products (true) or only published products (false) (Optional. Default: false)
   - `total` (Number): The total number of products to fetch
 - An optional logger object having four methods (`info`, `warn`, `error` and `debug`)
@@ -63,7 +63,7 @@ Options:
   - If the file specified already exists, it will be overwritten.
   - The default location for status report logging is the standard output.
   - If no output path is specified, the exported products will be logged to the standard output.
-- The `--predicate` flag specifies an optional (where) query predicate to be included in the request. This predicate should be wrapped in single quotes ('single quoted predicate'). More info on predicates [here](https://docs.commercetools.com/http-api.html#predicates)
+- The `--predicate` flag specifies an optional (where) query predicate to be included in the request. This predicate should be wrapped in single quotes ('single quoted predicate'). More info on predicates [here](https://docs.commercetools.com/http-api-query-predicates)
 - The `--expand` flag specifies the Reference or References to expand in the returned products. The required references for expansion should be passed in as normal strings separated by a space. More information about reference expansion can be found [here](https://docs.commercetools.com/http-api.html#reference-expansion)
 - The `--exportType` flag specifies if products returned should be in JSON file format or chunks. The chunk output is particularly useful if a different output format is desired (such as CSV), in which case, the chunks can be piped to a parser to get the desired format.
 - The `--staged` flag specifies the projection of the products to be fetched.


### PR DESCRIPTION
#### Summary

Fix broken Link to query predicate docs.

#### Description

The query predicate documentation link in README files of CLIs is not valid anymore.

It is changed from https://docs.commercetools.com/http-api.html#predicates to https://docs.commercetools.com/http-api-query-predicates

#### Todo

- [x] Documentation

Closes #1131 
