### PR TITLE
feat(api-request-builder): add My Shopping Lists and My Payments services

### DIFF
--- a/packages/api-request-builder/src/default-services.js
+++ b/packages/api-request-builder/src/default-services.js
@@ -179,6 +179,18 @@ export default {
       features.queryExpand,
     ],
   },
+  myShoppingLists: {
+    type: 'my-shopping-lists',
+    endpoint: '/me/shopping-lists',
+    features: [
+      features.create,
+      features.update,
+      features.del,
+      features.query,
+      features.queryOne,
+      features.queryExpand,
+    ],
+  },
   orders: {
     type: 'orders',
     endpoint: '/orders',

--- a/packages/api-request-builder/src/default-services.js
+++ b/packages/api-request-builder/src/default-services.js
@@ -179,6 +179,18 @@ export default {
       features.queryExpand,
     ],
   },
+  myPayments: {
+    type: 'my-payments',
+    endpoint: '/me/payments',
+    features: [
+      features.create,
+      features.update,
+      features.del,
+      features.query,
+      features.queryOne,
+      features.queryExpand,
+    ],
+  },
   myShoppingLists: {
     type: 'my-shopping-lists',
     endpoint: '/me/shopping-lists',


### PR DESCRIPTION
#### Summary

<!-- Provide a short summary of your changes -->
- [x] Add [My Shopping Lists](https://docs.commercetools.com/http-api-projects-me-shoppingLists) and [My Payments](https://docs.commercetools.com/http-api-projects-me-payments) services
#### Description

<!-- Describe the changes in this PR here and provide some context -->
These services are currently missing from the default services so to use them we have to add them as custom services. Since [My Cart](https://github.com/commercetools/nodejs/blob/master/packages/api-request-builder/src/default-services.js#L158) already exists in there I thought I would add these two as well to save us needing to do a custom service for each.
#### Todo

- Tests
  - [x] Unit
  - [x] Integration
  <!-- Two persons should review a PR, don't forget to assign them. -->