### PR TITLE
feat(product-json-to-csv): add customerGroup to product prices

### DIFF
--- a/TODOS.md
+++ b/TODOS.md
@@ -3,6 +3,7 @@
 |:------|:------:|:------
 | packages/api-request-builder/src/create-service.js | 129 | this can lead to invalid URIs as getIdOrKey can return
 | packages/custom-objects-importer/src/main.js | 127 | remove `FlowFixMe` when [this](https://github.com/facebook/flow/issues/5294) issue is fixed
+| packages/product-json-to-csv/src/main.js | 207 | 
 | packages/product-json-to-csv/test/writer.spec.js | 263 | the "unzip" package fires finish event before entry events
 | packages/product-json-to-csv/test/writer.spec.js | 310 | the "unzip" package fires finish event before entry events
 | packages/sync-actions/src/utils/diffpatcher.js | 3 | create an issue here https://github.com/benjamine/jsondiffpatch/issues/new

--- a/TODOS.md
+++ b/TODOS.md
@@ -3,7 +3,6 @@
 |:------|:------:|:------
 | packages/api-request-builder/src/create-service.js | 129 | this can lead to invalid URIs as getIdOrKey can return
 | packages/custom-objects-importer/src/main.js | 127 | remove `FlowFixMe` when [this](https://github.com/facebook/flow/issues/5294) issue is fixed
-| packages/product-json-to-csv/src/main.js | 207 | 
 | packages/product-json-to-csv/test/writer.spec.js | 263 | the "unzip" package fires finish event before entry events
 | packages/product-json-to-csv/test/writer.spec.js | 310 | the "unzip" package fires finish event before entry events
 | packages/sync-actions/src/utils/diffpatcher.js | 3 | create an issue here https://github.com/benjamine/jsondiffpatch/issues/new

--- a/integration-tests/cli/helpers/product-json2csv.data.js
+++ b/integration-tests/cli/helpers/product-json2csv.data.js
@@ -90,7 +90,7 @@ export const samplePriceCustomerGroup = {
   groupName: 'priceCustomerGroup',
 }
 
-export const createProducts = (state, taxCategory) => [
+export const createProducts = (state, taxCategory, channel, customerGroup) => [
   {
     key: 'productKey-1',
     name: {
@@ -131,6 +131,8 @@ export const createProducts = (state, taxCategory) => [
             centAmount: 2233,
           },
           country: 'US',
+          channel,
+          customerGroup,
         },
       ],
     },

--- a/integration-tests/cli/helpers/product-json2csv.data.js
+++ b/integration-tests/cli/helpers/product-json2csv.data.js
@@ -85,6 +85,11 @@ export const samplePriceChannel = {
   },
 }
 
+export const samplePriceCustomerGroup = {
+  key: 'priceCustomerGroup',
+  groupName: 'priceCustomerGroup',
+}
+
 export const createProducts = (state, taxCategory) => [
   {
     key: 'productKey-1',

--- a/integration-tests/cli/product-json-to-csv.it.js
+++ b/integration-tests/cli/product-json-to-csv.it.js
@@ -13,6 +13,7 @@ import {
   sampleParentCategory,
   sampleCategory,
   samplePriceChannel,
+  samplePriceCustomerGroup,
   createProducts,
 } from './helpers/product-json2csv.data'
 import { createData, clearData } from './helpers/utils'
@@ -31,6 +32,7 @@ async function cleanup(apiConfig) {
     clearData(apiConfig, 'states'),
     clearData(apiConfig, 'taxCategories'),
     clearData(apiConfig, 'channels'),
+    clearData(apiConfig, 'customerGroups'),
   ])
 }
 
@@ -61,6 +63,9 @@ describe('CSV and CLI Tests', () => {
     const priceChannel = await createData(apiConfig, 'channels', [
       samplePriceChannel,
     ])
+    const priceCustomerGroup = await createData(apiConfig, 'customerGroups', [
+      samplePriceCustomerGroup,
+    ])
     const state = await createData(apiConfig, 'states', [sampleState])
     const taxCategory = await createData(apiConfig, 'taxCategories', [
       sampleTaxCategory,
@@ -79,6 +84,10 @@ describe('CSV and CLI Tests', () => {
     sampleProducts[0].masterVariant.prices[0].channel = {
       typeId: 'channel',
       id: priceChannel[0].body.id,
+    }
+    sampleProducts[0].masterVariant.prices[0].customerGroup = {
+      typeId: 'customer-group',
+      id: priceCustomerGroup[0].body.id,
     }
 
     await createData(apiConfig, 'products', sampleProducts)
@@ -220,6 +229,11 @@ describe('CSV and CLI Tests', () => {
             expect(product[0]).toEqual(expect.objectContaining({ tax }))
             expect(product[1]).toEqual(expect.objectContaining({ tax }))
             expect(product[2]).toEqual(expect.objectContaining({ tax }))
+          })
+
+          it('contains resolved `prices`', () => {
+            const prices = 'US-USD 2233@priceCustomerGroup#priceChannel'
+            expect(product[0]).toEqual(expect.objectContaining({ prices }))
           })
 
           it('contains variants `SKUs`', () => {
@@ -609,6 +623,11 @@ describe('CSV and CLI Tests', () => {
             expect(product[0]).toEqual(expect.objectContaining({ tax }))
             expect(product[1]).toEqual(expect.objectContaining({ tax }))
             expect(product[2]).toEqual(expect.objectContaining({ tax }))
+          })
+
+          it('contains resolved `prices`', () => {
+            const prices = 'US-USD 2233@priceCustomerGroup#priceChannel'
+            expect(product[0]).toEqual(expect.objectContaining({ prices }))
           })
 
           it('contains variants `SKUs`', () => {

--- a/integration-tests/cli/product-json-to-csv.it.js
+++ b/integration-tests/cli/product-json-to-csv.it.js
@@ -79,17 +79,21 @@ describe('CSV and CLI Tests', () => {
       typeId: 'tax-category',
       id: taxCategory[0].body.id,
     }
-
-    const sampleProducts = createProducts(stateRef, taxCategoryRef)
-    sampleProducts[0].masterVariant.prices[0].channel = {
+    const priceChannelRef = {
       typeId: 'channel',
       id: priceChannel[0].body.id,
     }
-    sampleProducts[0].masterVariant.prices[0].customerGroup = {
+    const priceCustomerGroupRef = {
       typeId: 'customer-group',
       id: priceCustomerGroup[0].body.id,
     }
 
+    const sampleProducts = createProducts(
+      stateRef,
+      taxCategoryRef,
+      priceChannelRef,
+      priceCustomerGroupRef
+    )
     await createData(apiConfig, 'products', sampleProducts)
   }, 20000)
 

--- a/packages/product-json-to-csv/src/map-product-data.js
+++ b/packages/product-json-to-csv/src/map-product-data.js
@@ -263,13 +263,17 @@ export default class ProductMapping {
 
   static _mapPriceToString(price: Price): string {
     // Full price:
-    // 'country-currencyCode centAmount|discounted.centAmount customerGroup.name#channel.key$validFrom~validUntil'
+    // 'country-currencyCode centAmount|discounted.centAmount@customerGroup.name#channel.key$validFrom~validUntil'
 
     return oneLineTrim`
       ${price.country ? `${price.country}-` : ''}
       ${price.value.currencyCode} ${price.value.centAmount}
       ${price.discounted ? `|${price.discounted.value.centAmount}` : ''}
-      ${`${price.customerGroup?.name ?? ''}`}
+      ${
+        price.customerGroup && price.customerGroup.name
+          ? `@${price.customerGroup.name}`
+          : ''
+      }
       ${price.channel && price.channel.key ? `#${price.channel.key}` : ''}
       ${price.validFrom ? `$${price.validFrom}` : ''}
       ${price.validUntil ? `~${price.validUntil}` : ''}

--- a/packages/product-json-to-csv/test/main.spec.js
+++ b/packages/product-json-to-csv/test/main.spec.js
@@ -262,15 +262,14 @@ describe('ProductJsonToCsv', () => {
         productJsonToCsv._resolveProductType = jest.fn(() => ({ productType }))
         productJsonToCsv._resolveTaxCategory = jest.fn(() => ({ taxCategory }))
         productJsonToCsv._resolveState = jest.fn(() => ({ state }))
-        productJsonToCsv._getChannelsById = jest.fn(() => ({ channelsById }))
-        productJsonToCsv._getCustomerGroupsById = jest.fn(() => ({
-          customerGroupsById,
-        }))
         productJsonToCsv._resolveCategories = jest.fn(() => ({ categories }))
         productJsonToCsv._resolveCategoryOrderHints = jest.fn(() => ({
           categoryOrderHints,
         }))
         productJsonToCsv._getChannelsById = jest.fn(() => channelsById)
+        productJsonToCsv._getCustomerGroupsById = jest.fn(
+          () => customerGroupsById
+        )
       })
 
       test('should pass the products to all resolver functions', async () => {

--- a/packages/product-json-to-csv/test/main.spec.js
+++ b/packages/product-json-to-csv/test/main.spec.js
@@ -184,6 +184,9 @@ describe('ProductJsonToCsv', () => {
               channel: {
                 id: '123',
               },
+              customerGroup: {
+                id: '123',
+              },
             },
             {
               country: 'GB',
@@ -192,6 +195,9 @@ describe('ProductJsonToCsv', () => {
                 centAmount: 1023,
               },
               channel: {
+                id: '456',
+              },
+              customerGroup: {
                 id: '456',
               },
             },
@@ -209,6 +215,9 @@ describe('ProductJsonToCsv', () => {
                 centAmount: 9383,
               },
               channel: {
+                id: 'unknown',
+              },
+              customerGroup: {
                 id: 'unknown',
               },
             },
@@ -241,6 +250,10 @@ describe('ProductJsonToCsv', () => {
           '123': { id: '123', key: 'channel123' },
           '456': { id: '456', key: 'channel456' },
         }
+        const customerGroupsById = {
+          '123': { id: '123', key: 'customerGroup123' },
+          '456': { id: '456', key: 'customerGroup456' },
+        }
         const categoryOrderHints = {
           'res-cat-name-1': '0.015',
           'res-cat-name-2': '0.987',
@@ -250,6 +263,9 @@ describe('ProductJsonToCsv', () => {
         productJsonToCsv._resolveTaxCategory = jest.fn(() => ({ taxCategory }))
         productJsonToCsv._resolveState = jest.fn(() => ({ state }))
         productJsonToCsv._getChannelsById = jest.fn(() => ({ channelsById }))
+        productJsonToCsv._getCustomerGroupsById = jest.fn(() => ({
+          customerGroupsById,
+        }))
         productJsonToCsv._resolveCategories = jest.fn(() => ({ categories }))
         productJsonToCsv._resolveCategoryOrderHints = jest.fn(() => ({
           categoryOrderHints,
@@ -295,6 +311,11 @@ describe('ProductJsonToCsv', () => {
           '456',
           'unknown',
         ])
+        expect(productJsonToCsv._getCustomerGroupsById).toHaveBeenCalledWith([
+          '123',
+          '456',
+          'unknown',
+        ])
       })
 
       test('should return object with resolved references', async () => {
@@ -333,6 +354,10 @@ describe('ProductJsonToCsv', () => {
                   id: '123',
                   key: 'channel123',
                 },
+                customerGroup: {
+                  id: '123',
+                  key: 'customerGroup123',
+                },
               },
               {
                 country: 'GB',
@@ -343,6 +368,10 @@ describe('ProductJsonToCsv', () => {
                 channel: {
                   id: '456',
                   key: 'channel456',
+                },
+                customerGroup: {
+                  id: '456',
+                  key: 'customerGroup456',
                 },
               },
               {
@@ -359,6 +388,9 @@ describe('ProductJsonToCsv', () => {
                   centAmount: 9383,
                 },
                 channel: {
+                  id: 'unknown',
+                },
+                customerGroup: {
                   id: 'unknown',
                 },
               },
@@ -510,6 +542,45 @@ describe('ProductJsonToCsv', () => {
                 centAmount: 4995,
               },
               channel: {
+                id: 'uuid',
+                name: 'resolved-name',
+                key: 'resolved-key',
+              },
+            },
+          ],
+        })
+      })
+
+      test('resolve variant with prices with customerGroups', async () => {
+        const sampleVariant = {
+          key: 'variantKey',
+          prices: [
+            {
+              value: {
+                currencyCode: 'EUR',
+                centAmount: 4995,
+              },
+              customerGroup: {
+                typeId: 'customerGroup',
+                id: 'uuid',
+              },
+            },
+          ],
+          attributes: [],
+        }
+
+        expect(
+          await productJsonToCsv._resolveVariantReferences(sampleVariant)
+        ).toEqual({
+          key: 'variantKey',
+          attributes: [],
+          prices: [
+            {
+              value: {
+                currencyCode: 'EUR',
+                centAmount: 4995,
+              },
+              customerGroup: {
                 id: 'uuid',
                 name: 'resolved-name',
                 key: 'resolved-key',
@@ -902,6 +973,49 @@ describe('ProductJsonToCsv', () => {
 
       // should not call fetchReferences again as it was already cached
       await productJsonToCsv._getChannelsById(['channel-id'])
+      expect(productJsonToCsv.fetchReferences).toHaveBeenCalledTimes(1)
+    })
+  })
+
+  describe('::fetchCustomerGroups', () => {
+    beforeEach(() => {
+      productJsonToCsv.fetchReferences = jest
+        .fn()
+        .mockImplementationOnce(() =>
+          Promise.resolve({
+            body: {
+              results: [
+                {
+                  id: 'customerGroup-id',
+                  key: 'customerGroup-key',
+                },
+              ],
+            },
+          })
+        )
+        .mockImplementation(() =>
+          Promise.reject(new Error('I should not be called'))
+        )
+    })
+
+    test('should fetch and cache customerGroup from API', async () => {
+      const res = await productJsonToCsv._getCustomerGroupsById([
+        'customerGroup-id',
+      ])
+
+      expect(res).toEqual({
+        'customerGroup-id': {
+          id: 'customerGroup-id',
+          key: 'customerGroup-key',
+        },
+      })
+      expect(productJsonToCsv.fetchReferences).toHaveBeenCalledWith(
+        '/project-key/customer-groups?where=id%20in%20(%22customerGroup-id%22)'
+      )
+      expect(productJsonToCsv.fetchReferences).toHaveBeenCalledTimes(1)
+
+      // should not call fetchReferences again as it was already cached
+      await productJsonToCsv._getCustomerGroupsById(['customerGroup-id'])
       expect(productJsonToCsv.fetchReferences).toHaveBeenCalledTimes(1)
     })
   })

--- a/types/product.js
+++ b/types/product.js
@@ -126,10 +126,10 @@ export type Channel = {
 
 export type CustomerGroup = {
   id: string,
-  version?: number,
-  key: string,
+  key?: string,
+  version: number,
   name: string,
-  custom: Object,
+  custom?: Object,
 }
 
 type ScopedPrice = {

--- a/types/product.js
+++ b/types/product.js
@@ -124,6 +124,14 @@ export type Channel = {
   description: Object,
 }
 
+export type CustomerGroup = {
+  id: string,
+  version?: number,
+  key: string,
+  name: string,
+  custom: Object,
+}
+
 type ScopedPrice = {
   id: string,
   value: Money,


### PR DESCRIPTION
#### Summary

PR adds missing functionality to include the customerGroup when exporting product prices

#### Description

For some reason, this was never implemented. PR should be straight-forward as it's only extending parts of the current code.

#### Todo

- Tests
  - [x] Unit
  - [x] Integration

closes #1166
