### PR TITLE
test(auth.it.js): Fix failing auth integration test

### DIFF
--- a/integration-tests/sdk/auth.it.js
+++ b/integration-tests/sdk/auth.it.js
@@ -24,37 +24,21 @@ function getApiClient(token) {
 }
 
 function modifiedTokenInfo(tokenInput, unUsedParameter) {
-  const receivedScope = tokenInput.scope
-  let changeScopeToArrayOfObject = '[{'
-  const newScope = receivedScope.split(' ')
+  const scopeDetails = tokenInput.scope
 
-  for (let i = 0; i < newScope.length; i++) {
-    const splitScope = newScope[i].split(':')
-    changeScopeToArrayOfObject +=
-      '"' + splitScope[0] + '":"' + splitScope[1] + '",'
+  let i
+  const newScope = {}
+  const receivedScope = scopeDetails.split(' ')
+  for (i in receivedScope) {
+    receivedScope[i] = receivedScope[i].split(':')
+    newScope[receivedScope[i][0]] = receivedScope[i][1]
   }
+  delete newScope[unUsedParameter]
+  const scopeKey = Object.keys(newScope)
+  const scopeValue = Object.values(newScope)
+  const modifiedScope = scopeKey + ':' + scopeValue
 
-  // This remove the last comma from the object before the closing tag
-  changeScopeToArrayOfObject = changeScopeToArrayOfObject.substr(
-    0,
-    changeScopeToArrayOfObject.length - 1
-  )
-  changeScopeToArrayOfObject += '}]'
-
-  // Convert to JSON
-  const modifiedScope = JSON.parse(changeScopeToArrayOfObject)
-
-  const deleteScopeParams = modifiedScope.map(scopeParams => {
-    if (scopeParams.hasOwnProperty(unUsedParameter))
-      delete scopeParams[unUsedParameter]
-    return scopeParams
-  })
-  const scopeValue = String(JSON.stringify(deleteScopeParams[0]))
-  const redefineScopeValue = scopeValue.split(/ |:|"/)
-  let returnModifiedScope = []
-  const redefinedScope = redefineScopeValue[1] + ':' + redefineScopeValue[4]
-  returnModifiedScope.push(redefinedScope)
-  tokenInput.scope = returnModifiedScope[0]
+  tokenInput.scope = modifiedScope
   return tokenInput
 }
 

--- a/integration-tests/sdk/auth.it.js
+++ b/integration-tests/sdk/auth.it.js
@@ -23,27 +23,6 @@ function getApiClient(token) {
   })
 }
 
-function modifiedTokenInfo(tokenInput, unUsedParameter) {
-  const scopeDetails = tokenInput.scope
-
-  let i
-  const newScope = {}
-  const receivedScope = scopeDetails.split(' ')
-  for (i in receivedScope) {
-    receivedScope[i] = receivedScope[i].split(':')
-    newScope[receivedScope[i][0]] = receivedScope[i][1]
-  }
-  delete newScope[unUsedParameter]
-  const scopeKey = Object.keys(newScope)
-  const scopeValue = Object.values(newScope)
-  const modifiedScope = scopeKey + ':' + scopeValue
-
-  tokenInput.scope = modifiedScope
-  return tokenInput
-}
-
-const ignoredResponseKeys = ['anonymous_id', 'customer_id']
-
 describe('Auth Flows', () => {
   const userEmail = `user+date_is/${Date.now()}@commercetooler.com`
   const userPassword = 'testing4^lks*aJ@ETso+/\\HdE1!x0u4q5'
@@ -91,9 +70,9 @@ describe('Auth Flows', () => {
 
       // check returned properties
       expect(tokenInfo).toHaveProperty('access_token')
-      expect(
-        modifiedTokenInfo(tokenInfo, ignoredResponseKeys[0])
-      ).toHaveProperty('scope', `manage_project:${projectKey}`)
+      expect(tokenInfo.scope).toMatch(
+        `manage_project:${projectKey} anonymous_id`
+      )
       expect(tokenInfo).toHaveProperty('expires_in')
       expect(tokenInfo).toHaveProperty('expires_at')
       expect(tokenInfo).toHaveProperty('refresh_token')
@@ -127,9 +106,9 @@ describe('Auth Flows', () => {
 
       // check returned properties
       expect(tokenInfo).toHaveProperty('access_token')
-      expect(
-        modifiedTokenInfo(tokenInfo, ignoredResponseKeys[1])
-      ).toHaveProperty('scope', `manage_project:${projectKey}`)
+      expect(tokenInfo.scope).toMatch(
+        `manage_project:${projectKey} customer_id`
+      )
       expect(tokenInfo).toHaveProperty('expires_in')
       expect(tokenInfo).not.toHaveProperty('refresh_token')
       expect(tokenInfo).toHaveProperty('token_type', 'Bearer')


### PR DESCRIPTION
#### Summary

Fix failing auth integration tests

#### Description
This PR fix the failing integration tests ([details](https://circleci.com/gh/commercetools/nodejs/10624)).
The `anonymous_id` and `customer_id` are needed in order to generate a `refresh token` which is a mandatory requirement to obtain an `access token`.
This is as a result of the newly added feature to the SDKs for external OAuth. For more details, see [here](https://github.com/commercetools/docs.commercetools.com/pull/1255).

#### Todo

- Tests
  - [x] Unit
  - [x] Integration

Closes #1203 
