### PR TITLE
fix(sync-actions): customer resourceId undefined error

### DIFF
--- a/packages/sync-actions/src/utils/common-actions.js
+++ b/packages/sync-actions/src/utils/common-actions.js
@@ -95,6 +95,17 @@ export function buildReferenceActions({
 
         if (!newValue) return { action }
 
+        // When the `id` of the object is undefined
+        if (!newValue.id) {
+          return {
+            action,
+            [key]: {
+              typeId: newValue.typeId,
+              key: newValue.key,
+            },
+          }
+        }
+
         return {
           action,
           // We only need to pass a reference to the object.

--- a/packages/sync-actions/test/customer-sync.spec.js
+++ b/packages/sync-actions/test/customer-sync.spec.js
@@ -1,4 +1,3 @@
-import omit from 'lodash.omit'
 import customerSyncFn, { actionGroups } from '../src/customers'
 import { baseActionsList, referenceActionsList } from '../src/customer-actions'
 
@@ -235,7 +234,7 @@ describe('Actions', () => {
     const expected = [
       {
         action: 'setCustomerGroup',
-        customerGroup: omit(now.customerGroup, ['key']),
+        customerGroup: now.customerGroup,
       },
     ]
     expect(actual).toEqual(expected)

--- a/packages/sync-actions/test/customer-sync.spec.js
+++ b/packages/sync-actions/test/customer-sync.spec.js
@@ -1,3 +1,4 @@
+import omit from 'lodash.omit'
 import customerSyncFn, { actionGroups } from '../src/customers'
 import { baseActionsList, referenceActionsList } from '../src/customer-actions'
 
@@ -217,6 +218,24 @@ describe('Actions', () => {
         // CREATE ACTIONS LAST
         action: 'addAddress',
         address: now.addresses[2],
+      },
+    ]
+    expect(actual).toEqual(expected)
+  })
+
+  test('should build `setCustomerGroup` action with key', () => {
+    const before = {}
+    const now = {
+      customerGroup: {
+        typeId: 'customer-group',
+        key: 'foo-customer-group',
+      },
+    }
+    const actual = customerSync.buildActions(now, before)
+    const expected = [
+      {
+        action: 'setCustomerGroup',
+        customerGroup: omit(now.customerGroup, ['key']),
       },
     ]
     expect(actual).toEqual(expected)


### PR DESCRIPTION
#### Summary

<!-- Provide a short summary of your changes -->

#### Description

This PR fixes the `sync-actions` for customer resource `id` undefined error and allows the customerGroup property of a customer to be set using `key` as a reference.

#### Todo

- Tests
  - [x] Unit
  - [x] Integration

Closes #1229 
