### PR TITLE
fix: add locale action in customer sync actions

### DIFF
--- a/packages/sync-actions/src/customer-actions.js
+++ b/packages/sync-actions/src/customer-actions.js
@@ -18,6 +18,7 @@ export const baseActionsList = [
   { action: 'setExternalId', key: 'externalId' },
   { action: 'setCompanyName', key: 'companyName' },
   { action: 'setDateOfBirth', key: 'dateOfBirth' },
+  { action: 'setLocale', key: 'locale' },
   { action: 'setVatId', key: 'vatId' },
   {
     action: 'setDefaultBillingAddress',

--- a/packages/sync-actions/test/customer-sync.spec.js
+++ b/packages/sync-actions/test/customer-sync.spec.js
@@ -17,6 +17,7 @@ describe('Exports', () => {
       { action: 'setExternalId', key: 'externalId' },
       { action: 'setCompanyName', key: 'companyName' },
       { action: 'setDateOfBirth', key: 'dateOfBirth' },
+      { action: 'setLocale', key: 'locale' },
       { action: 'setVatId', key: 'vatId' },
       {
         action: 'setDefaultBillingAddress',


### PR DESCRIPTION
affects: @commercetools/sync-actions

ISSUES CLOSED: 1240

#### Summary

#### Description

This PR adds locale for the sync-actions for customers.


- Tests
  - [X] Unit

Closes #1240 