### PR TITLE
feat(sync-actions): add actions for customer billing/shipping addresses

### DIFF
--- a/packages/sync-actions/src/customer-actions.js
+++ b/packages/sync-actions/src/customer-actions.js
@@ -81,13 +81,13 @@ export function actionsMapAddresses(diff, oldObj, newObj) {
 
 export function actionsMapBillingAddresses(diff, oldObj, newObj) {
   const handler = createBuildArrayActions('billingAddressIds', {
-    [ADD_ACTIONS]: newObject => ({
+    [ADD_ACTIONS]: addressId => ({
       action: 'addBillingAddressId',
-      addressId: newObject,
+      addressId,
     }),
-    [REMOVE_ACTIONS]: objectToRemove => ({
+    [REMOVE_ACTIONS]: addressId => ({
       action: 'removeBillingAddressId',
-      addressId: objectToRemove,
+      addressId,
     }),
   })
 
@@ -95,13 +95,13 @@ export function actionsMapBillingAddresses(diff, oldObj, newObj) {
 }
 export function actionsMapShippingAddresses(diff, oldObj, newObj) {
   const handler = createBuildArrayActions('shippingAddressIds', {
-    [ADD_ACTIONS]: newObject => ({
+    [ADD_ACTIONS]: addressId => ({
       action: 'addShippingAddressId',
-      addressId: newObject,
+      addressId,
     }),
-    [REMOVE_ACTIONS]: objectToRemove => ({
+    [REMOVE_ACTIONS]: addressId => ({
       action: 'removeShippingAddressId',
-      addressId: objectToRemove,
+      addressId,
     }),
   })
 

--- a/packages/sync-actions/src/customer-actions.js
+++ b/packages/sync-actions/src/customer-actions.js
@@ -93,3 +93,17 @@ export function actionsMapBillingAddresses(diff, oldObj, newObj) {
 
   return handler(diff, oldObj, newObj)
 }
+export function actionsMapShippingAddresses(diff, oldObj, newObj) {
+  const handler = createBuildArrayActions('shippingAddressIds', {
+    [ADD_ACTIONS]: newObject => ({
+      action: 'addShippingAddressId',
+      addressId: newObject,
+    }),
+    [REMOVE_ACTIONS]: objectToRemove => ({
+      action: 'removeShippingAddressId',
+      addressId: objectToRemove,
+    }),
+  })
+
+  return handler(diff, oldObj, newObj)
+}

--- a/packages/sync-actions/src/customer-actions.js
+++ b/packages/sync-actions/src/customer-actions.js
@@ -78,3 +78,18 @@ export function actionsMapAddresses(diff, oldObj, newObj) {
 
   return handler(diff, oldObj, newObj)
 }
+
+export function actionsMapBillingAddresses(diff, oldObj, newObj) {
+  const handler = createBuildArrayActions('billingAddressIds', {
+    [ADD_ACTIONS]: newObject => ({
+      action: 'addBillingAddressId',
+      addressId: newObject,
+    }),
+    [REMOVE_ACTIONS]: objectToRemove => ({
+      action: 'removeBillingAddressId',
+      addressId: objectToRemove,
+    }),
+  })
+
+  return handler(diff, oldObj, newObj)
+}

--- a/packages/sync-actions/src/customers.js
+++ b/packages/sync-actions/src/customers.js
@@ -51,6 +51,14 @@ function createCustomerMapActions(
 
     allActions.push(
       mapActionGroup(
+        'billingAddressIds',
+        (): Array<UpdateAction> =>
+          customerActions.actionsMapBillingAddresses(diff, oldObj, newObj)
+      )
+    )
+
+    allActions.push(
+      mapActionGroup(
         'custom',
         (): Array<UpdateAction> => actionsMapCustom(diff, newObj, oldObj)
       )

--- a/packages/sync-actions/src/customers.js
+++ b/packages/sync-actions/src/customers.js
@@ -59,6 +59,14 @@ function createCustomerMapActions(
 
     allActions.push(
       mapActionGroup(
+        'shippingAddressIds',
+        (): Array<UpdateAction> =>
+          customerActions.actionsMapShippingAddresses(diff, oldObj, newObj)
+      )
+    )
+
+    allActions.push(
+      mapActionGroup(
         'custom',
         (): Array<UpdateAction> => actionsMapCustom(diff, newObj, oldObj)
       )

--- a/packages/sync-actions/test/customer-sync.spec.js
+++ b/packages/sync-actions/test/customer-sync.spec.js
@@ -224,14 +224,26 @@ describe('Actions', () => {
   })
 
   test('should build `addBillingAddressId` action', () => {
-    const before = { billingAddressIds: [] }
     const addressId = 'addressId'
+    const before = { billingAddressIds: [] }
     const now = {
       billingAddressIds: [addressId],
     }
 
     const actual = customerSync.buildActions(now, before)
     const expected = [{ action: 'addBillingAddressId', addressId }]
+    expect(actual).toEqual(expected)
+  })
+
+  test('should build `removeBillingAddressId` action', () => {
+    const addressId = 'addressId'
+    const before = {
+      billingAddressIds: [addressId],
+    }
+    const now = { billingAddressIds: [] }
+
+    const actual = customerSync.buildActions(now, before)
+    const expected = [{ action: 'removeBillingAddressId', addressId }]
     expect(actual).toEqual(expected)
   })
 

--- a/packages/sync-actions/test/customer-sync.spec.js
+++ b/packages/sync-actions/test/customer-sync.spec.js
@@ -272,6 +272,55 @@ describe('Actions', () => {
     ]
     expect(actual).toEqual(expected)
   })
+  test('should build `addShippingAddressId` action', () => {
+    const addressId = 'addressId'
+    const before = { shippingAddressIds: [] }
+    const now = {
+      shippingAddressIds: [addressId],
+    }
+
+    const actual = customerSync.buildActions(now, before)
+    const expected = [{ action: 'addShippingAddressId', addressId }]
+    expect(actual).toEqual(expected)
+  })
+
+  test('should build `removeShippingAddressId` action', () => {
+    const addressId = 'addressId'
+    const before = {
+      shippingAddressIds: [addressId],
+    }
+    const now = { shippingAddressIds: [] }
+
+    const actual = customerSync.buildActions(now, before)
+    const expected = [{ action: 'removeShippingAddressId', addressId }]
+    expect(actual).toEqual(expected)
+  })
+
+  test('should build both `add-` and `removeShippingAddressId` actions', () => {
+    const before = {
+      shippingAddressIds: ['remove', 'keep', 'remove2'],
+    }
+    const now = {
+      shippingAddressIds: ['keep', 'new'],
+    }
+
+    const actual = customerSync.buildActions(now, before)
+    const expected = [
+      {
+        action: 'removeShippingAddressId',
+        addressId: 'remove',
+      },
+      {
+        action: 'removeShippingAddressId',
+        addressId: 'remove2',
+      },
+      {
+        action: 'addShippingAddressId',
+        addressId: 'new',
+      },
+    ]
+    expect(actual).toEqual(expected)
+  })
 
   test('should build `setCustomerGroup` action with key', () => {
     const before = {}

--- a/packages/sync-actions/test/customer-sync.spec.js
+++ b/packages/sync-actions/test/customer-sync.spec.js
@@ -247,6 +247,32 @@ describe('Actions', () => {
     expect(actual).toEqual(expected)
   })
 
+  test('should build both `add-` and `removeBillingAddressId` actions', () => {
+    const before = {
+      billingAddressIds: ['remove', 'keep', 'remove2'],
+    }
+    const now = {
+      billingAddressIds: ['keep', 'new'],
+    }
+
+    const actual = customerSync.buildActions(now, before)
+    const expected = [
+      {
+        action: 'removeBillingAddressId',
+        addressId: 'remove',
+      },
+      {
+        action: 'removeBillingAddressId',
+        addressId: 'remove2',
+      },
+      {
+        action: 'addBillingAddressId',
+        addressId: 'new',
+      },
+    ]
+    expect(actual).toEqual(expected)
+  })
+
   test('should build `setCustomerGroup` action with key', () => {
     const before = {}
     const now = {

--- a/packages/sync-actions/test/customer-sync.spec.js
+++ b/packages/sync-actions/test/customer-sync.spec.js
@@ -223,6 +223,18 @@ describe('Actions', () => {
     expect(actual).toEqual(expected)
   })
 
+  test('should build `addBillingAddressId` action', () => {
+    const before = { billingAddressIds: [] }
+    const addressId = 'addressId'
+    const now = {
+      billingAddressIds: [addressId],
+    }
+
+    const actual = customerSync.buildActions(now, before)
+    const expected = [{ action: 'addBillingAddressId', addressId }]
+    expect(actual).toEqual(expected)
+  })
+
   test('should build `setCustomerGroup` action with key', () => {
     const before = {}
     const now = {


### PR DESCRIPTION
#### Summary

PR adds support to four new actions [addShippingAddressId](https://docs.commercetools.com/http-api-projects-customers#add-shipping-address-id), [removeShippingAddressId](https://docs.commercetools.com/http-api-projects-customers#remove-shipping-address-id), [addBillingAddressId](https://docs.commercetools.com/http-api-projects-customers#add-billing-address-id) and [removeBillingAddressId](https://docs.commercetools.com/http-api-projects-customers#remove-billing-address-id).

#### Todo

- Tests
  - [x] Unit

resolves #1241