### PR TITLE
feat(inventories-exporter): add a possibility to export predefined fields

### DIFF
--- a/docs/cli/inventories-exporter.md
+++ b/docs/cli/inventories-exporter.md
@@ -46,6 +46,8 @@ Options:
                     https://docs.commercetools.com/http-api-projects-inventory.html#query-inventory
                     can be used with channelKey flag
 
+  --template, -t    Path to a CSV template file with headers which should be
+                    exported.
   --format, -f      Format for export [choices: "csv", "json"] [default: "json"]
   --logLevel        Logging level: error, warn, info or verbose.
                                                                [default: "info"]
@@ -78,6 +80,7 @@ const logger = {
   verbose: console.debug,
 }
 const exportConfig = {
+  headerFields: null, // can contain an array of header fields which should be exported
   delimiter: ',',
   format: 'csv,
   queryString: 'description="new stocks"',

--- a/integration-tests/cli/__snapshots__/inventories-exporter.it.js.snap
+++ b/integration-tests/cli/__snapshots__/inventories-exporter.it.js.snap
@@ -37,6 +37,8 @@ Options:
                     can be used with channelKey flag
 
   --format, -f      Format for export [choices: \\"csv\\", \\"json\\"] [default: \\"json\\"]
+  --template, -t    Path to a CSV template file with headers which should be
+                    exported.
   --logLevel        Logging level: error, warn, info or verbose.
                                                                [default: \\"info\\"]
   --logFile         Path to file where to save logs.

--- a/types/inventory.js
+++ b/types/inventory.js
@@ -18,6 +18,7 @@ export type Inventory = {
 }
 
 export type ExportConfig = {
+  headerFields: Array<string> | null,
   format: string,
   delimiter: string,
   channelKey?: string,


### PR DESCRIPTION
#### Summary
This PR adds a possibility to provide a template with fields which should be exported when mapping inventory entries to CSV.
Resolves #1268

#### Todo

- Tests
  - [x] Unit
  - [ ] Integration
  - [ ] Acceptance
- [x] Documentation
  <!-- Two persons should review a PR, don't forget to assign them. -->
