### PR TITLE
fix(exporters): enable request retries

### DIFF
--- a/packages/category-exporter/src/main.js
+++ b/packages/category-exporter/src/main.js
@@ -43,6 +43,7 @@ export default class CategoryExporter {
         }),
         createHttpMiddleware({
           host: this.apiConfig.apiUrl,
+          enableRetry: true,
           fetch,
         }),
       ],

--- a/packages/custom-objects-exporter/src/main.js
+++ b/packages/custom-objects-exporter/src/main.js
@@ -44,6 +44,7 @@ export default class CustomObjectsExporter {
         }),
         createHttpMiddleware({
           host: this.apiConfig.apiUrl,
+          enableRetry: true,
           fetch,
         }),
       ],

--- a/packages/customer-groups-exporter/src/main.js
+++ b/packages/customer-groups-exporter/src/main.js
@@ -44,6 +44,7 @@ export default class CustomerGroupsExporter {
         }),
         createHttpMiddleware({
           host: this.apiConfig.apiUrl,
+          enableRetry: true,
           fetch,
         }),
       ],

--- a/packages/discount-code-exporter/src/main.js
+++ b/packages/discount-code-exporter/src/main.js
@@ -54,6 +54,7 @@ export default class DiscountCodeExport {
         }),
         createHttpMiddleware({
           host: this.apiConfig.apiUrl,
+          enableRetry: true,
           fetch,
         }),
       ],

--- a/packages/inventories-exporter/src/main.js
+++ b/packages/inventories-exporter/src/main.js
@@ -58,6 +58,7 @@ export default class InventoryExporter {
         }),
         createHttpMiddleware({
           host: apiConfig.apiUrl,
+          enableRetry: true,
           fetch,
         }),
       ],

--- a/packages/price-exporter/src/main.js
+++ b/packages/price-exporter/src/main.js
@@ -49,6 +49,7 @@ export default class PriceExporter {
         }),
         createHttpMiddleware({
           host: this.apiConfig.apiUrl,
+          enableRetry: true,
           fetch,
         }),
       ],

--- a/packages/product-exporter/src/main.js
+++ b/packages/product-exporter/src/main.js
@@ -43,6 +43,7 @@ export default class ProductExporter {
         }),
         createHttpMiddleware({
           host: this.apiConfig.apiUrl,
+          enableRetry: true,
           fetch,
         }),
       ],


### PR DESCRIPTION
#### Summary

PR enables retries for all exporter packages as users had problems on larger exports where some requests would timeout. That would then abort the whole export.

resolves #1293 