### PR TITLE
chore(renovate): automerge all non major updates and enable emergency… - autoclosed

### DIFF
--- a/.renovaterc.json
+++ b/.renovaterc.json
@@ -4,6 +4,10 @@
     ":pinOnlyDevDependencies",
     ":prHourlyLimitNone",
     ":prConcurrentLimitNone",
+    ":automergeMinor",
+    "group:allNonMajor",
+    ":automergeBranchMergeCommit",
+    ":enableVulnerabilityAlerts",
     "schedule:weekly"
   ],
   "ignoreDeps": ["lerna"]


### PR DESCRIPTION
PR enables renovate to automatically merge all `patch` and `minor` updates. It also groups them all together onto one branch and merges directly from there if tests pass. No noise from a PR needed.

In addition, PR enables vulnerability alerts which will override scheduled updates whenever an urgent update is needed.