### PR TITLE
fix(auth): correctly encode token

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 ## commercetools-sdk changed artefact generation
 
+## @commercetools/sdk-middleware-auth@5.1.1, @commercetools/sdk-auth@2.1.1 (2019-05-23)
+
+#### :bug: Bug Fix
+
+- `sdk-auth`, `sdk-middleware-auth`
+  - [#1334](https://github.com/commercetools/nodejs/pull/1334) Correctly encode tokens with non-ascii characters.
+
 #### :rocket: New Feature (2019-05-21)
 
 - Now replaces Node.js globals (such as `Buffer`) in UMD builds to allow direct consumption in browsers without requiring a separate build step (e.g. webpack). This helps smaller projects to get started quicker.

--- a/packages/sdk-auth/src/auth.js
+++ b/packages/sdk-auth/src/auth.js
@@ -281,7 +281,7 @@ export default class SdkAuth {
       this.BASE_AUTH_FLOW_URI,
       'refresh_token'
     )
-    request.body += `&refresh_token=${token}`
+    request.body += `&refresh_token=${encodeURIComponent(token)}`
 
     return this._process(request)
   }
@@ -291,7 +291,7 @@ export default class SdkAuth {
     if (!token) throw new Error('Missing required token value')
 
     const request = SdkAuth._buildRequest(_config, this.INTROSPECT_URI)
-    request.body = `token=${token}`
+    request.body = `token=${encodeURIComponent(token)}`
 
     return this._process(request)
   }

--- a/packages/sdk-middleware-auth/src/build-requests.js
+++ b/packages/sdk-middleware-auth/src/build-requests.js
@@ -118,7 +118,9 @@ export function buildRequestForRefreshTokenFlow(
   // other oauth endpoints.
   const oauthUri = options.oauthUri || '/oauth/token'
   const url = options.host.replace(/\/$/, '') + oauthUri
-  const body = `grant_type=refresh_token&refresh_token=${options.refreshToken}`
+  const body = `grant_type=refresh_token&refresh_token=${encodeURIComponent(
+    options.refreshToken
+  )}`
 
   return { basicAuth, url, body }
 }

--- a/packages/sdk-middleware-auth/test/refresh-token-flow.spec.js
+++ b/packages/sdk-middleware-auth/test/refresh-token-flow.spec.js
@@ -21,7 +21,7 @@ function createTestMiddlewareOptions(options) {
       clientId: '123',
       clientSecret: 'secret',
     },
-    refreshToken: 'foobar123',
+    refreshToken: 'foobar123@#%=',
     ...options,
   }
 }
@@ -47,7 +47,7 @@ describe('Refresh Token Flow', () => {
           pendingTasks: [],
           url: 'https://auth.commercetools.co/oauth/token',
           basicAuth: 'MTIzOnNlY3JldA==',
-          body: 'grant_type=refresh_token&refresh_token=foobar123',
+          body: 'grant_type=refresh_token&refresh_token=foobar123%40%23%25%3D',
         })
         expect(authMiddlewareBase).toHaveBeenCalledTimes(1)
         resolve()


### PR DESCRIPTION
#### Summary

PR fixes problem where tokens would not be encoded and, thus, fail whenever they contained a non-ascii character as the query string would be wrong.

#### Todo

- Tests
  - [x] Unit
  - [x] Integration

resolves #1333