### PR TITLE
feat(api-req-builder): add myActiveCart as a service

### DIFF
--- a/packages/api-request-builder/src/default-services.js
+++ b/packages/api-request-builder/src/default-services.js
@@ -155,6 +155,11 @@ export default {
     endpoint: '/messages',
     features: [features.query, features.queryOne, features.queryExpand],
   },
+  myActiveCart: {
+    type: 'my-carts',
+    endpoint: '/me/active-cart',
+    features: [features.queryOne],
+  },
   myCarts: {
     type: 'my-carts',
     endpoint: '/me/carts',

--- a/packages/api-request-builder/test/create-request-builder.spec.js
+++ b/packages/api-request-builder/test/create-request-builder.spec.js
@@ -19,6 +19,7 @@ const expectedServiceKeys = [
   'inventory',
   'login',
   'messages',
+  'myActiveCart',
   'myCarts',
   'myOrders',
   'orders',


### PR DESCRIPTION
#### Summary

The API design is a bit strange in this case as the `active cart` lies under its own endpoint as `/me/active-cart` and does not follow the design of the others like `/me/carts/whatever` ([doc ref](https://docs.commercetools.com/http-api-projects-me-carts#get-active-cart)). 

Therefore, we opted to put it as a service and be built as `requestBuilder.myActiveCart.build()`

resolves #1338