### PR TITLE
feat(sync-actions): add sync actions for category assets

### DIFF
--- a/packages/sync-actions/src/assets-actions.js
+++ b/packages/sync-actions/src/assets-actions.js
@@ -26,32 +26,20 @@ export default function actionsMapAssets(diff) {
 
   if (assets && assets._t === 'a') {
     const keys = Object.keys(assets)
-    const changeDeltas = keys
-      .filter(key => REGEX_NUMBER.test(key))
-      .map(key => assets[key])
-    const addAssetActions = changeDeltas.map(createAddAssetAction)
-    assetsActions.push(addAssetActions)
 
     const removeDeltas = keys
       .filter(key => REGEX_UNDERSCORE_NUMBER.test(key))
       .map(key => assets[key])
     const removeAssetActions = removeDeltas.map(createRemoveAssetAction)
     assetsActions.push(removeAssetActions)
-  } else if (Array.isArray(assets)) {
-    const assetActions = diff.assets.map(assetDiff => {
-      let assetAction
-      if (Array.isArray(assetDiff)) {
-        const asset = assetDiff[0]
 
-        if (assetDiff.length === 1) {
-          assetAction = {
-            action: 'addAsset',
-            asset,
-          }
-        }
-      }
-      return assetAction
-    })
+    const changeDeltas = keys
+      .filter(key => REGEX_NUMBER.test(key))
+      .map(key => assets[key])
+    const addAssetActions = changeDeltas.map(createAddAssetAction)
+    assetsActions.push(addAssetActions)
+  } else if (Array.isArray(assets)) {
+    const assetActions = diff.assets.map(createAddAssetAction)
     assetsActions.push(assetActions)
   }
   return flatten(assetsActions)

--- a/packages/sync-actions/src/assets-actions.js
+++ b/packages/sync-actions/src/assets-actions.js
@@ -1,46 +1,41 @@
-import flatten from 'lodash.flatten'
+import createBuildArrayActions, {
+  ADD_ACTIONS,
+  REMOVE_ACTIONS,
+  CHANGE_ACTIONS,
+} from './utils/create-build-array-actions'
 
-const REGEX_NUMBER = new RegExp(/^\d+$/)
-const REGEX_UNDERSCORE_NUMBER = new RegExp(/^_\d+$/)
-
-function createRemoveAssetAction(delta) {
-  const assetIdentifier = asset =>
-    asset.id ? { assetId: asset.id } : { assetKey: asset.key }
-  const action = Object.assign(
-    { action: 'removeAsset' },
-    assetIdentifier(delta[0])
-  )
-  return action
+function toAssetIdentifier(asset) {
+  const assetIdentifier = asset.id
+    ? { assetId: asset.id }
+    : { assetKey: asset.key }
+  return assetIdentifier
 }
 
-function createAddAssetAction(delta) {
-  const asset = delta[0]
-  const action = { action: 'addAsset', asset }
-  return action
-}
+export default function actionsMapAssets(diff, oldObj, newObj) {
+  const handler = createBuildArrayActions('assets', {
+    [ADD_ACTIONS]: newAsset => ({
+      action: 'addAsset',
+      asset: newAsset,
+    }),
+    [REMOVE_ACTIONS]: oldAsset => ({
+      action: 'removeAsset',
+      ...toAssetIdentifier(oldAsset),
+    }),
+    [CHANGE_ACTIONS]: (oldAsset, newAsset) => {
+      const result = []
+      result.push({
+        action: 'removeAsset',
+        ...toAssetIdentifier(oldAsset),
+      })
 
-export default function actionsMapAssets(diff) {
-  // }, nextObject, previousObject) {
-  const { assets } = diff
-  const assetsActions = []
+      result.push({
+        action: 'addAsset',
+        asset: newAsset,
+      })
 
-  if (assets && assets._t === 'a') {
-    const keys = Object.keys(assets)
+      return result
+    },
+  })
 
-    const removeDeltas = keys
-      .filter(key => REGEX_UNDERSCORE_NUMBER.test(key))
-      .map(key => assets[key])
-    const removeAssetActions = removeDeltas.map(createRemoveAssetAction)
-    assetsActions.push(removeAssetActions)
-
-    const changeDeltas = keys
-      .filter(key => REGEX_NUMBER.test(key))
-      .map(key => assets[key])
-    const addAssetActions = changeDeltas.map(createAddAssetAction)
-    assetsActions.push(addAssetActions)
-  } else if (Array.isArray(assets)) {
-    const assetActions = diff.assets.map(createAddAssetAction)
-    assetsActions.push(assetActions)
-  }
-  return flatten(assetsActions)
+  return handler(diff, oldObj, newObj)
 }

--- a/packages/sync-actions/src/assets-actions.js
+++ b/packages/sync-actions/src/assets-actions.js
@@ -27,12 +27,12 @@ export default function actionsMapAssets(diff, oldObj, newObj) {
       // re-add the asset - which reduces the code complexity
       [
         {
-          action: 'addAsset',
-          asset: newAsset,
-        },
-        {
           action: 'removeAsset',
           ...toAssetIdentifier(oldAsset),
+        },
+        {
+          action: 'addAsset',
+          asset: newAsset,
         },
       ],
   })

--- a/packages/sync-actions/src/assets-actions.js
+++ b/packages/sync-actions/src/assets-actions.js
@@ -1,0 +1,58 @@
+import flatten from 'lodash.flatten'
+
+const REGEX_NUMBER = new RegExp(/^\d+$/)
+const REGEX_UNDERSCORE_NUMBER = new RegExp(/^_\d+$/)
+
+function createRemoveAssetAction(delta) {
+  const assetIdentifier = asset =>
+    asset.id ? { assetId: asset.id } : { assetKey: asset.key }
+  const action = Object.assign(
+    { action: 'removeAsset' },
+    assetIdentifier(delta[0])
+  )
+  return action
+}
+
+function createAddAssetAction(delta) {
+  const asset = delta[0]
+  const action = { action: 'addAsset', asset }
+  return action
+}
+
+export default function actionsMapAssets(diff) {
+  // }, nextObject, previousObject) {
+  const { assets } = diff
+  const assetsActions = []
+
+  if (assets && assets._t === 'a') {
+    const keys = Object.keys(assets)
+    const changeDeltas = keys
+      .filter(key => REGEX_NUMBER.test(key))
+      .map(key => assets[key])
+    const addAssetActions = changeDeltas.map(createAddAssetAction)
+    assetsActions.push(addAssetActions)
+
+    const removeDeltas = keys
+      .filter(key => REGEX_UNDERSCORE_NUMBER.test(key))
+      .map(key => assets[key])
+    const removeAssetActions = removeDeltas.map(createRemoveAssetAction)
+    assetsActions.push(removeAssetActions)
+  } else if (Array.isArray(assets)) {
+    const assetActions = diff.assets.map(assetDiff => {
+      let assetAction
+      if (Array.isArray(assetDiff)) {
+        const asset = assetDiff[0]
+
+        if (assetDiff.length === 1) {
+          assetAction = {
+            action: 'addAsset',
+            asset,
+          }
+        }
+      }
+      return assetAction
+    })
+    assetsActions.push(assetActions)
+  }
+  return flatten(assetsActions)
+}

--- a/packages/sync-actions/src/assets-actions.js
+++ b/packages/sync-actions/src/assets-actions.js
@@ -21,20 +21,20 @@ export default function actionsMapAssets(diff, oldObj, newObj) {
       action: 'removeAsset',
       ...toAssetIdentifier(oldAsset),
     }),
-    [CHANGE_ACTIONS]: (oldAsset, newAsset) => {
-      const result = []
-      result.push({
-        action: 'removeAsset',
-        ...toAssetIdentifier(oldAsset),
-      })
-
-      result.push({
-        action: 'addAsset',
-        asset: newAsset,
-      })
-
-      return result
-    },
+    [CHANGE_ACTIONS]: (oldAsset, newAsset) =>
+      // here we could use more atomic update actions (e.g. changeAssetName)
+      // but for now we use the simpler approach to first remove and then
+      // re-add the asset - which reduces the code complexity
+      [
+        {
+          action: 'addAsset',
+          asset: newAsset,
+        },
+        {
+          action: 'removeAsset',
+          ...toAssetIdentifier(oldAsset),
+        },
+      ],
   })
 
   return handler(diff, oldObj, newObj)

--- a/packages/sync-actions/src/categories.js
+++ b/packages/sync-actions/src/categories.js
@@ -9,10 +9,11 @@ import type {
 import createBuildActions from './utils/create-build-actions'
 import createMapActionGroup from './utils/create-map-action-group'
 import actionsMapCustom from './utils/action-map-custom'
+import actionsMapAssets from './assets-actions'
 import * as categoryActions from './category-actions'
 import * as diffpatcher from './utils/diffpatcher'
 
-export const actionGroups = ['base', 'references', 'meta', 'custom']
+export const actionGroups = ['base', 'references', 'meta', 'custom', 'assets']
 
 function createCategoryMapActions(
   mapActionGroup: Function,
@@ -53,6 +54,13 @@ function createCategoryMapActions(
       mapActionGroup(
         'custom',
         (): Array<UpdateAction> => actionsMapCustom(diff, newObj, oldObj)
+      )
+    )
+
+    allActions.push(
+      mapActionGroup(
+        'assets',
+        (): Array<UpdateAction> => actionsMapAssets(diff, newObj, oldObj)
       )
     )
 

--- a/packages/sync-actions/src/categories.js
+++ b/packages/sync-actions/src/categories.js
@@ -60,7 +60,7 @@ function createCategoryMapActions(
     allActions.push(
       mapActionGroup(
         'assets',
-        (): Array<UpdateAction> => actionsMapAssets(diff, newObj, oldObj)
+        (): Array<UpdateAction> => actionsMapAssets(diff, oldObj, newObj)
       )
     )
 

--- a/packages/sync-actions/test/category-sync.spec.js
+++ b/packages/sync-actions/test/category-sync.spec.js
@@ -7,7 +7,13 @@ import {
 
 describe('Exports', () => {
   test('action group list', () => {
-    expect(actionGroups).toEqual(['base', 'references', 'meta', 'custom'])
+    expect(actionGroups).toEqual([
+      'base',
+      'references',
+      'meta',
+      'custom',
+      'assets',
+    ])
   })
 
   test('correctly define base actions list', () => {
@@ -104,5 +110,96 @@ describe('Actions', () => {
       },
     ]
     expect(actual).toEqual(expected)
+  })
+
+  describe('assets', () => {
+    test('should build "addAsset" action with empty assets', () => {
+      const before = {}
+      const now = {
+        assets: [
+          {
+            key: 'asset-key',
+            name: {
+              en: 'asset name ',
+            },
+            sources: [
+              {
+                uri: 'http://example.org/content/product-manual.pdf',
+              },
+            ],
+          },
+        ],
+      }
+      const actual = categorySync.buildActions(now, before)
+      const expected = [
+        {
+          action: 'addAsset',
+          asset: now.assets[0],
+        },
+      ]
+      expect(actual).toEqual(expected)
+    })
+
+    test('should build "addAsset" action with existing assets', () => {
+      const existingAsset = {
+        key: 'existing',
+        sources: [
+          {
+            uri: 'http://example.org/content/product-manual.pdf',
+          },
+        ],
+      }
+      const newAsset = {
+        key: 'new',
+        sources: [
+          {
+            uri: 'http://example.org/content/product-manual.gif',
+          },
+        ],
+      }
+      const before = {
+        assets: [existingAsset],
+      }
+      const now = {
+        assets: [existingAsset, newAsset],
+      }
+      const actual = categorySync.buildActions(now, before)
+      const expected = [
+        {
+          action: 'addAsset',
+          asset: newAsset,
+        },
+      ]
+      expect(actual).toEqual(expected)
+    })
+
+    test('should build "removeAsset" action', () => {
+      const before = {
+        assets: [
+          {
+            key: 'asset-key',
+            name: {
+              en: 'asset name ',
+            },
+            sources: [
+              {
+                uri: 'http://example.org/content/product-manual.pdf',
+              },
+            ],
+          },
+        ],
+      }
+      const now = {
+        assets: [],
+      }
+      const actual = categorySync.buildActions(now, before)
+      const expected = [
+        {
+          action: 'removeAsset',
+          assetKey: before.assets[0].key,
+        },
+      ]
+      expect(actual).toEqual(expected)
+    })
   })
 })

--- a/packages/sync-actions/test/category-sync.spec.js
+++ b/packages/sync-actions/test/category-sync.spec.js
@@ -114,7 +114,9 @@ describe('Actions', () => {
 
   describe('assets', () => {
     test('should build "addAsset" action with empty assets', () => {
-      const before = {}
+      const before = {
+        assets: [],
+      }
       const now = {
         assets: [
           {
@@ -232,7 +234,7 @@ describe('Actions', () => {
     })
   })
 
-  test('should build "removeAsset" and "addasset" action when asset is changed', () => {
+  test('should build "removeAsset" and "addAsset" action when asset is changed', () => {
     const initialAsset = {
       key: 'asset-key',
       name: {

--- a/packages/sync-actions/test/category-sync.spec.js
+++ b/packages/sync-actions/test/category-sync.spec.js
@@ -173,7 +173,36 @@ describe('Actions', () => {
       expect(actual).toEqual(expected)
     })
 
-    test('should build "removeAsset" action', () => {
+    test('should build "removeAsset" action with assetId prop', () => {
+      const before = {
+        assets: [
+          {
+            id: 'c136c9dc-51e8-40fe-8e2e-2a4c159f3358',
+            name: {
+              en: 'asset name ',
+            },
+            sources: [
+              {
+                uri: 'http://example.org/content/product-manual.pdf',
+              },
+            ],
+          },
+        ],
+      }
+      const now = {
+        assets: [],
+      }
+      const actual = categorySync.buildActions(now, before)
+      const expected = [
+        {
+          action: 'removeAsset',
+          assetId: before.assets[0].id,
+        },
+      ]
+      expect(actual).toEqual(expected)
+    })
+
+    test('should build "removeAsset" action with assetKey prop', () => {
       const before = {
         assets: [
           {
@@ -201,5 +230,39 @@ describe('Actions', () => {
       ]
       expect(actual).toEqual(expected)
     })
+  })
+
+  test('should build "removeAsset" and "addasset" action when asset is changed', () => {
+    const initialAsset = {
+      key: 'asset-key',
+      name: {
+        en: 'asset name ',
+      },
+    }
+    const changedName = {
+      name: {
+        en: 'asset name ',
+        de: 'Asset Name',
+      },
+    }
+    const changedAsset = Object.assign({}, initialAsset, changedName)
+    const before = {
+      assets: [initialAsset],
+    }
+    const now = {
+      assets: [changedAsset],
+    }
+    const actual = categorySync.buildActions(now, before)
+    const expected = [
+      {
+        action: 'removeAsset',
+        assetKey: before.assets[0].key,
+      },
+      {
+        action: 'addAsset',
+        asset: changedAsset,
+      },
+    ]
+    expect(actual).toEqual(expected)
   })
 })


### PR DESCRIPTION
#### Summary

This PR adds support for synching category assets to our `synch-actions` module.

#### Description

This implementation is the simplest solution for synching category assets and follows the approach we use for product variants:
- we only use `addAsset` and `removeAsset` update action instead of using the more fine grained asset update actions (e.g. `changeAssetName`)

#### Todo

- Tests
  - [ ] Unit
  - [ ] Integration
  - [ ] Acceptance
- [ ] Documentation
