### PR TITLE
fix: add isEmailVerified action to customer sync actions

### DIFF
--- a/packages/sync-actions/src/customer-actions.js
+++ b/packages/sync-actions/src/customer-actions.js
@@ -20,6 +20,7 @@ export const baseActionsList = [
   { action: 'setDateOfBirth', key: 'dateOfBirth' },
   { action: 'setLocale', key: 'locale' },
   { action: 'setVatId', key: 'vatId' },
+  { action: 'setIsEmailVerified', key: 'isEmailVerified' },
   {
     action: 'setDefaultBillingAddress',
     key: 'defaultBillingAddressId',

--- a/packages/sync-actions/test/customer-sync.spec.js
+++ b/packages/sync-actions/test/customer-sync.spec.js
@@ -19,6 +19,7 @@ describe('Exports', () => {
       { action: 'setDateOfBirth', key: 'dateOfBirth' },
       { action: 'setLocale', key: 'locale' },
       { action: 'setVatId', key: 'vatId' },
+      { action: 'setIsEmailVerified', key: 'isEmailVerified' },
       {
         action: 'setDefaultBillingAddress',
         key: 'defaultBillingAddressId',


### PR DESCRIPTION
#### Summary

Simply adds isEmailVerified action to customer-actions.js & customer-sync.spec.js

#### Description

Just as https://github.com/commercetools/nodejs/pull/1242 added locale to customer sync actions; this pr adds isEmailVerified for the sync-actions for customers.

- Tests
  - [x] Unit