### PR TITLE
fix(sync-actions): add key in setting custom types 

### DIFF
--- a/packages/sync-actions/src/utils/action-map-custom.js
+++ b/packages/sync-actions/src/utils/action-map-custom.js
@@ -16,6 +16,10 @@ const extractTypeId = (type, nextObject) =>
   Array.isArray(type.id)
     ? diffpatcher.getDeltaValue(type.id)
     : nextObject.custom.type.id
+const extractTypeKey = (type, nextObject) =>
+  Array.isArray(type.key)
+    ? diffpatcher.getDeltaValue(type.key)
+    : nextObject.custom.type.key
 const extractTypeFields = (diffedFields, nextFields) =>
   Array.isArray(diffedFields)
     ? diffpatcher.getDeltaValue(diffedFields)
@@ -43,6 +47,15 @@ export default function actionsMapCustom(diff, nextObject, previousObject) {
         type: {
           typeId: 'type',
           id: extractTypeId(type, nextObject),
+        },
+        fields: extractTypeFields(diff.custom.fields, nextObject.custom.fields),
+      })
+    else if (type.key)
+      actions.push({
+        action: Actions.setCustomType,
+        type: {
+          typeId: 'type',
+          key: extractTypeKey(type, nextObject),
         },
         fields: extractTypeFields(diff.custom.fields, nextObject.custom.fields),
       })

--- a/packages/sync-actions/test/utils/action-map-custom.spec.js
+++ b/packages/sync-actions/test/utils/action-map-custom.spec.js
@@ -36,6 +36,34 @@ describe('buildActions', () => {
     expect(actual).toEqual(expected)
   })
 
+  test('should build `setCustomType` action with key', () => {
+    const before = {
+      custom: {
+        type: {
+          typeId: 'type',
+          key: 'customType1',
+        },
+        fields: {
+          customField1: true,
+        },
+      },
+    }
+    const now = {
+      custom: {
+        type: {
+          typeId: 'type',
+          key: 'customType2',
+        },
+        fields: {
+          customField1: true,
+        },
+      },
+    }
+    const actual = buildActions(now, before)
+    const expected = [{ action: 'setCustomType', ...now.custom }]
+    expect(actual).toEqual(expected)
+  })
+
   test('should build `setCustomField` action', () => {
     const before = {
       custom: {


### PR DESCRIPTION
#### Summary

This PR fixes sync-actions for using key as a resource identifier in setting custom fields/types.

#### Todo

- Tests
  - [x] Unit
  - [x] Integration
  - [ ] Acceptance
