### PR TITLE
fix(req-builder): enable setting fuzzyLevel to 0

### DIFF
--- a/TODOS.md
+++ b/TODOS.md
@@ -6,6 +6,3 @@
 | packages/product-json-to-csv/test/writer.spec.js | 263 | the "unzip" package fires finish event before entry events
 | packages/product-json-to-csv/test/writer.spec.js | 308 | the "unzip" package fires finish event before entry events
 | packages/sync-actions/src/utils/diffpatcher.js | 3 | create an issue here https://github.com/benjamine/jsondiffpatch/issues/new
-| /Users/deriksson/Sites/commercetools/nodejs/packages/custom-objects-importer/src/main.js | 127 | remove `FlowFixMe` when [this](https://github.com/facebook/flow/issues/5294) issue is fixed
-| /Users/deriksson/Sites/commercetools/nodejs/packages/product-json-to-csv/test/writer.spec.js | 263 | the "unzip" package fires finish event before entry events
-| /Users/deriksson/Sites/commercetools/nodejs/packages/product-json-to-csv/test/writer.spec.js | 308 | the "unzip" package fires finish event before entry events

--- a/packages/api-request-builder/src/query-search.js
+++ b/packages/api-request-builder/src/query-search.js
@@ -35,7 +35,7 @@ export function fuzzy(): Object {
  * @return {Object} The instance of the service, can be chained.
  */
 export function fuzzyLevel(value: number): Object {
-  if (!value && value !== 0)
+  if (value === undefined || value === null)
     throw new Error('Required argument for `fuzzyLevel` is missing')
   this.params.search.fuzzyLevel = value
   return this

--- a/packages/api-request-builder/src/query-search.js
+++ b/packages/api-request-builder/src/query-search.js
@@ -35,7 +35,8 @@ export function fuzzy(): Object {
  * @return {Object} The instance of the service, can be chained.
  */
 export function fuzzyLevel(value: number): Object {
-  if (!value) throw new Error('Required argument for `fuzzyLevel` is missing')
+  if (!value && value !== 0)
+    throw new Error('Required argument for `fuzzyLevel` is missing')
   this.params.search.fuzzyLevel = value
   return this
 }

--- a/packages/api-request-builder/test/query-search.spec.js
+++ b/packages/api-request-builder/test/query-search.spec.js
@@ -30,9 +30,14 @@ describe('querySearch', () => {
     expect(service.params.search.fuzzy).toBeTruthy()
   })
 
-  test('should set the fuzzy level', () => {
+  test('should set the fuzzy level to 2', () => {
     service.fuzzyLevel(2)
     expect(service.params.search.fuzzyLevel).toBe(2)
+  })
+
+  test('should set the fuzzy level to 0', () => {
+    service.fuzzyLevel(0)
+    expect(service.params.search.fuzzyLevel).toBe(0)
   })
 
   test('should throw if fuzzy level is missing', () => {


### PR DESCRIPTION
#### Summary

PR enables setting `fuzzyLevel` to 0.

#### Description

We were checking for falsey values in the conditional. And since `0` evaluates to falsey it was not possible to use it. More info in the referenced issue below.

#### Todo

- Tests
  - [x] Unit

resolves #1348