### PR TITLE
fix(sdk-middleware-auth): remove authScopes.MANAGE_PROJECT as default scope

### DIFF
--- a/packages/sdk-middleware-auth/src/build-requests.js
+++ b/packages/sdk-middleware-auth/src/build-requests.js
@@ -5,8 +5,6 @@ import type {
   RefreshAuthMiddlewareOptions,
 } from 'types/sdk'
 
-import * as authScopes from './scopes'
-
 type BuiltRequestParams = {
   basicAuth: string,
   url: string,
@@ -33,8 +31,7 @@ export function buildRequestForClientCredentialsFlow(
   if (!(clientId && clientSecret))
     throw new Error('Missing required credentials (clientId, clientSecret)')
 
-  const defaultScope = `${authScopes.MANAGE_PROJECT}:${options.projectKey}`
-  const scope = (options.scopes || [defaultScope]).join(' ')
+  const scope = options.scopes ? options.scopes.join(' ') : undefined
 
   const basicAuth = Buffer.from(`${clientId}:${clientSecret}`).toString(
     'base64'
@@ -43,7 +40,7 @@ export function buildRequestForClientCredentialsFlow(
   // other oauth endpoints.
   const oauthUri = options.oauthUri || '/oauth/token'
   const url = options.host.replace(/\/$/, '') + oauthUri
-  const body = `grant_type=client_credentials&scope=${scope}`
+  const body = `grant_type=client_credentials${scope ? `&scope=${scope}` : ''}`
 
   return { basicAuth, url, body }
 }

--- a/packages/sdk-middleware-auth/test/base-auth-flow.spec.js
+++ b/packages/sdk-middleware-auth/test/base-auth-flow.spec.js
@@ -77,9 +77,7 @@ describe('Base Auth Flow', () => {
 
       nock(middlewareOptions.host)
         .filteringRequestBody(body => {
-          expect(body).toBe(
-            'grant_type=client_credentials&scope=manage_project:foo'
-          )
+          expect(body).toBe('grant_type=client_credentials')
           return '*'
         })
         .post('/oauth/token', '*')
@@ -106,9 +104,7 @@ describe('Base Auth Flow', () => {
 
       nock(middlewareOptions.host)
         .filteringRequestBody(body => {
-          expect(body).toBe(
-            'grant_type=client_credentials&scope=manage_project:foo'
-          )
+          expect(body).toBe('grant_type=client_credentials')
           return '*'
         })
         .post('/oauth/token', '*')


### PR DESCRIPTION
#### Summary

This PR removes authScopes.MANAGE_PROJECT as aoujth2 default scope.

#### Description

Instead of sending a default scope we now don't send any scope. The resulting scope thus will be the scope of the given api client.

Closes #1382 

#### Todo

- Tests
  - [ ] Unit
  - [ ] Integration
  - [ ] Acceptance
- [ ] Documentation
