### PR TITLE
feat(sync-actions): add setSalutation to customer sync

### DIFF
--- a/packages/sync-actions/src/customer-actions.js
+++ b/packages/sync-actions/src/customer-actions.js
@@ -9,6 +9,7 @@ import createBuildArrayActions, {
 } from './utils/create-build-array-actions'
 
 export const baseActionsList = [
+  { action: 'setSalutation', key: 'salutation' },
   { action: 'changeEmail', key: 'email' },
   { action: 'setFirstName', key: 'firstName' },
   { action: 'setLastName', key: 'lastName' },

--- a/packages/sync-actions/test/customer-sync.spec.js
+++ b/packages/sync-actions/test/customer-sync.spec.js
@@ -8,6 +8,7 @@ describe('Exports', () => {
 
   test('correctly define base actions list', () => {
     expect(baseActionsList).toEqual([
+      { action: 'setSalutation', key: 'salutation' },
       { action: 'changeEmail', key: 'email' },
       { action: 'setFirstName', key: 'firstName' },
       { action: 'setLastName', key: 'lastName' },
@@ -43,6 +44,19 @@ describe('Actions', () => {
   let customerSync
   beforeEach(() => {
     customerSync = customerSyncFn()
+  })
+
+  test('should build `setSalutation` action', () => {
+    const before = {
+      salutation: 'Best',
+    }
+    const now = {
+      salutation: 'Dear',
+    }
+
+    const actual = customerSync.buildActions(now, before)
+    const expected = [{ action: 'setSalutation', salutation: now.salutation }]
+    expect(actual).toEqual(expected)
   })
 
   test('should build `changeEmail` action', () => {


### PR DESCRIPTION
#### Summary

This pull request adds the ability to sync customer salutations to sync actions.

#### Description

This feature has been demanded for the MC.

[API Reference](https://docs.commercetools.com/http-api-projects-customers#set-salutation).

Rough look

<img width="1158" alt="CleanShot 2019-09-09 at 10 13 04@2x" src="https://user-images.githubusercontent.com/1877073/64514179-6d555580-d2ea-11e9-9fd5-55cd44c6f763.png">
