### PR TITLE
chore: configure rollup to build multiple outputs

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -34,13 +34,6 @@ module.exports = {
         devDependencies: ['**/test/**/*.js'],
       },
     ],
-    'prettier/prettier': [
-      'error',
-      {
-        trailingComma: 'es5',
-        singleQuote: true,
-      },
-    ],
     'jest/no-disabled-tests': 'warn',
     'jest/no-focused-tests': 'error',
     'jest/no-identical-title': 'error',

--- a/packages/api-request-builder/package.json
+++ b/packages/api-request-builder/package.json
@@ -17,9 +17,9 @@
   "bugs": "https://github.com/commercetools/nodejs/issues",
   "license": "MIT",
   "author": "Nicola Molinari <nicola.molinari@commercetools.com> (https://github.com/emmenko)",
-  "main": "dist/commercetools-api-request-builder.cjs.js",
-  "module": "dist/commercetools-api-request-builder.es.js",
-  "browser": "dist/commercetools-api-request-builder.umd.js",
+  "main": "dist/api-request-builder.cjs.js",
+  "module": "dist/api-request-builder.es.js",
+  "browser": "dist/api-request-builder.umd.js",
   "repository": {
     "type": "git",
     "url": "https://github.com/commercetools/nodejs.git"

--- a/packages/api-request-builder/package.json
+++ b/packages/api-request-builder/package.json
@@ -25,14 +25,10 @@
     "url": "https://github.com/commercetools/nodejs.git"
   },
   "files": [
-    "dist",
-    "lib"
+    "dist"
   ],
   "scripts": {
-    "build": "cross-env npm run build:umd && npm run build:umd:min && npm run build:es && npm run build:cjs",
-    "build:umd": "cross-env NODE_ENV=rollup rollup -c ../../rollup.config.js -f umd -n CommercetoolsApiRequestBuilder -i src/index.js -o dist/commercetools-api-request-builder.umd.js",
-    "build:umd:min": "cross-env NODE_ENV=production rollup -c ../../rollup.config.js -f umd -n CommercetoolsApiRequestBuilder -i src/index.js -o dist/commercetools-api-request-builder.umd.min.js",
-    "build:es": "cross-env NODE_ENV=rollup rollup -c ../../rollup.config.js -f es -n CommercetoolsApiRequestBuilder -i src/index.js -o dist/commercetools-api-request-builder.es.js",
-    "build:cjs": "cross-env NODE_ENV=rollup rollup -c ../../rollup.config.js -f cjs -n CommercetoolsApiRequestBuilder -i src/index.js -o dist/commercetools-api-request-builder.cjs.js"
+    "build": "cross-env yarn build:bundles",
+    "build:bundles": "cross-env NODE_ENV=production rollup -c ../../rollup.config.js -n CommercetoolsApiRequestBuilder -i ./src/index.js"
   }
 }

--- a/packages/category-exporter/package.json
+++ b/packages/category-exporter/package.json
@@ -1,4 +1,8 @@
 {
+  "private": false,
+  "publishConfig": {
+    "access": "public"
+  },
   "name": "@commercetools/category-exporter",
   "version": "2.0.15",
   "publishConfig": {
@@ -10,6 +14,7 @@
     "category-exporter": "bin/category-exporter.js"
   },
   "scripts": {
+    "prebuild": "rimraf lib/**",
     "build": "babel src --out-dir lib --config-file '../../babel.config.js'"
   },
   "repository": {

--- a/packages/csv-parser-discount-code/package.json
+++ b/packages/csv-parser-discount-code/package.json
@@ -1,4 +1,8 @@
 {
+  "private": false,
+  "publishConfig": {
+    "access": "public"
+  },
   "name": "@commercetools/csv-parser-discount-code",
   "version": "2.0.6",
   "description": "Converts commercetools discount code data from CSV to JSON.",
@@ -29,6 +33,7 @@
     "lib"
   ],
   "scripts": {
+    "prebuild": "rimraf lib/**",
     "build": "babel src --out-dir lib --config-file '../../babel.config.js'"
   },
   "dependencies": {

--- a/packages/csv-parser-orders/package.json
+++ b/packages/csv-parser-orders/package.json
@@ -1,4 +1,8 @@
 {
+  "private": false,
+  "publishConfig": {
+    "access": "public"
+  },
   "name": "@commercetools/csv-parser-orders",
   "version": "2.0.7",
   "description": "Converts commercetools order data from CSV to JSON.",
@@ -32,6 +36,7 @@
     "lib"
   ],
   "scripts": {
+    "prebuild": "rimraf lib/**",
     "build": "babel src --out-dir lib --config-file '../../babel.config.js'"
   },
   "dependencies": {

--- a/packages/csv-parser-price/package.json
+++ b/packages/csv-parser-price/package.json
@@ -1,4 +1,8 @@
 {
+  "private": false,
+  "publishConfig": {
+    "access": "public"
+  },
   "name": "@commercetools/csv-parser-price",
   "version": "3.0.14",
   "description": "Converts commercetools price data from CSV to JSON.",
@@ -30,6 +34,7 @@
     "lib"
   ],
   "scripts": {
+    "prebuild": "rimraf lib/**",
     "build": "babel src --out-dir lib --config-file '../../babel.config.js'"
   },
   "dependencies": {

--- a/packages/csv-parser-state/package.json
+++ b/packages/csv-parser-state/package.json
@@ -1,9 +1,14 @@
 {
+  "private": false,
+  "publishConfig": {
+    "access": "public"
+  },
   "name": "@commercetools/csv-parser-state",
   "version": "2.0.14",
   "description": "Package to parse states from CSV to JSON",
   "main": "lib/main.js",
   "scripts": {
+    "prebuild": "rimraf lib/**",
     "build": "babel src --out-dir lib --config-file '../../babel.config.js'"
   },
   "repository": {

--- a/packages/custom-objects-exporter/package.json
+++ b/packages/custom-objects-exporter/package.json
@@ -1,4 +1,8 @@
 {
+  "private": false,
+  "publishConfig": {
+    "access": "public"
+  },
   "name": "@commercetools/custom-objects-exporter",
   "version": "2.0.15",
   "description": "Exports custom objects from the commercetools platform.",
@@ -7,6 +11,7 @@
     "custom-objects-exporter": "bin/custom-objects-exporter.js"
   },
   "scripts": {
+    "prebuild": "rimraf lib/**",
     "build": "babel src --out-dir lib --config-file '../../babel.config.js'"
   },
   "repository": {

--- a/packages/custom-objects-importer/package.json
+++ b/packages/custom-objects-importer/package.json
@@ -1,9 +1,14 @@
 {
+  "private": false,
+  "publishConfig": {
+    "access": "public"
+  },
   "name": "@commercetools/custom-objects-importer",
   "version": "2.0.17",
   "description": "Import custom objects to the commercetools platform",
   "main": "lib/main.js",
   "scripts": {
+    "prebuild": "rimraf lib/**",
     "build": "babel src --out-dir lib --config-file '../../babel.config.js'"
   },
   "repository": {

--- a/packages/customer-groups-exporter/package.json
+++ b/packages/customer-groups-exporter/package.json
@@ -1,4 +1,8 @@
 {
+  "private": false,
+  "publishConfig": {
+    "access": "public"
+  },
   "name": "@commercetools/customer-groups-exporter",
   "version": "2.0.15",
   "description": "Exports customer groups from the commercetools platform.",
@@ -7,6 +11,7 @@
     "customer-groups-exporter": "bin/customer-groups-exporter.js"
   },
   "scripts": {
+    "prebuild": "rimraf lib/**",
     "build": "babel src --out-dir lib --config-file '../../babel.config.js'"
   },
   "repository": {

--- a/packages/discount-code-exporter/package.json
+++ b/packages/discount-code-exporter/package.json
@@ -1,4 +1,8 @@
 {
+  "private": false,
+  "publishConfig": {
+    "access": "public"
+  },
   "name": "@commercetools/discount-code-exporter",
   "version": "3.0.15",
   "description": "Exports discount codes from the commercetools platform.",
@@ -29,6 +33,7 @@
     "lib"
   ],
   "scripts": {
+    "prebuild": "rimraf lib/**",
     "build": "babel src --out-dir lib --config-file '../../babel.config.js'"
   },
   "dependencies": {

--- a/packages/discount-code-generator/package.json
+++ b/packages/discount-code-generator/package.json
@@ -1,4 +1,8 @@
 {
+  "private": false,
+  "publishConfig": {
+    "access": "public"
+  },
   "name": "@commercetools/discount-code-generator",
   "version": "2.0.4",
   "description": "Generates discount codes for the commercetools platform, according to constraints.",
@@ -28,6 +32,7 @@
     "lib"
   ],
   "scripts": {
+    "prebuild": "rimraf lib/**",
     "build": "babel src --out-dir lib --config-file '../../babel.config.js'"
   },
   "dependencies": {

--- a/packages/discount-code-importer/package.json
+++ b/packages/discount-code-importer/package.json
@@ -1,4 +1,8 @@
 {
+  "private": false,
+  "publishConfig": {
+    "access": "public"
+  },
   "name": "@commercetools/discount-code-importer",
   "version": "2.0.17",
   "description": "Import discount codes to the commercetools platform.",
@@ -25,6 +29,7 @@
     "lib"
   ],
   "scripts": {
+    "prebuild": "rimraf lib/**",
     "build": "babel src --out-dir lib --config-file '../../babel.config.js'"
   },
   "dependencies": {

--- a/packages/get-credentials/package.json
+++ b/packages/get-credentials/package.json
@@ -1,4 +1,8 @@
 {
+  "private": false,
+  "publishConfig": {
+    "access": "public"
+  },
   "name": "@commercetools/get-credentials",
   "version": "3.0.6",
   "description": "Get CT credentials from the system environment.",
@@ -21,6 +25,7 @@
     "lib"
   ],
   "scripts": {
+    "prebuild": "rimraf lib/**",
     "build": "babel src --out-dir lib --config-file '../../babel.config.js'"
   },
   "devDependencies": {

--- a/packages/http-user-agent/package.json
+++ b/packages/http-user-agent/package.json
@@ -15,9 +15,9 @@
   "bugs": "https://github.com/commercetools/nodejs/issues",
   "license": "MIT",
   "author": "Nicola Molinari <nicola.molinari@commercetools.com> (https://github.com/emmenko)",
-  "main": "dist/commercetools-http-user-agent.cjs.js",
-  "module": "dist/commercetools-http-user-agent.es.js",
-  "browser": "dist/commercetools-http-user-agent.umd.js",
+  "main": "dist/http-user-agent.cjs.js",
+  "module": "dist/http-user-agent.es.js",
+  "browser": "dist/http-user-agent.umd.js",
   "repository": {
     "type": "git",
     "url": "https://github.com/commercetools/nodejs.git"

--- a/packages/http-user-agent/package.json
+++ b/packages/http-user-agent/package.json
@@ -23,14 +23,11 @@
     "url": "https://github.com/commercetools/nodejs.git"
   },
   "files": [
-    "dist",
-    "lib"
+    "dist"
   ],
   "scripts": {
-    "build": "cross-env npm run build:umd && npm run build:umd:min && npm run build:es && npm run build:cjs",
-    "build:umd": "cross-env NODE_ENV=rollup rollup -c ../../rollup.config.js -f umd -n CommercetoolsHttpUserAgent -i src/index.js -o dist/commercetools-http-user-agent.umd.js",
-    "build:umd:min": "cross-env NODE_ENV=production rollup -c ../../rollup.config.js -f umd -n CommercetoolsHttpUserAgent -i src/index.js -o dist/commercetools-http-user-agent.umd.min.js",
-    "build:es": "cross-env NODE_ENV=rollup rollup -c ../../rollup.config.js -f es -n CommercetoolsHttpUserAgent -i src/index.js -o dist/commercetools-http-user-agent.es.js",
-    "build:cjs": "cross-env NODE_ENV=rollup rollup -c ../../rollup.config.js -f cjs -n CommercetoolsHttpUserAgent -i src/index.js -o dist/commercetools-http-user-agent.cjs.js"
+    "prebuild": "rimraf dist/**",
+    "build": "cross-env yarn build:bundles",
+    "build:bundles": "cross-env NODE_ENV=production rollup -c ../../rollup.config.js -n CommercetoolsHttpUserAgent -i ./src/index.js"
   }
 }

--- a/packages/inventories-exporter/package.json
+++ b/packages/inventories-exporter/package.json
@@ -1,4 +1,8 @@
 {
+  "private": false,
+  "publishConfig": {
+    "access": "public"
+  },
   "name": "@commercetools/inventories-exporter",
   "version": "2.1.10",
   "description": "Exports inventories from the commercetools platform.",
@@ -32,6 +36,7 @@
     "bin"
   ],
   "scripts": {
+    "prebuild": "rimraf lib/**",
     "build": "babel src --out-dir lib --config-file '../../babel.config.js'"
   },
   "dependencies": {

--- a/packages/personal-data-erasure/package.json
+++ b/packages/personal-data-erasure/package.json
@@ -1,4 +1,8 @@
 {
+  "private": false,
+  "publishConfig": {
+    "access": "public"
+  },
   "name": "@commercetools/personal-data-erasure",
   "version": "2.0.13",
   "description": "Export and delete all data related to a single customer",
@@ -7,6 +11,7 @@
     "personal-data-erasure": "bin/personal-data-erasure.js"
   },
   "scripts": {
+    "prebuild": "rimraf lib/**",
     "build": "babel src --out-dir lib --config-file '../../babel.config.js'"
   },
   "repository": {

--- a/packages/price-exporter/package.json
+++ b/packages/price-exporter/package.json
@@ -1,4 +1,8 @@
 {
+  "private": false,
+  "publishConfig": {
+    "access": "public"
+  },
   "name": "@commercetools/price-exporter",
   "version": "2.0.15",
   "description": "Exports prices from the commercetools platform",
@@ -30,6 +34,7 @@
     "lib"
   ],
   "scripts": {
+    "prebuild": "rimraf lib/**",
     "build": "babel src --out-dir lib --config-file '../../babel.config.js'"
   },
   "dependencies": {

--- a/packages/product-exporter/package.json
+++ b/packages/product-exporter/package.json
@@ -1,4 +1,8 @@
 {
+  "private": false,
+  "publishConfig": {
+    "access": "public"
+  },
   "name": "@commercetools/product-exporter",
   "version": "2.0.15",
   "description": "Exports products from the commercetools platform",
@@ -29,6 +33,7 @@
     "lib"
   ],
   "scripts": {
+    "prebuild": "rimraf lib/**",
     "build": "babel src --out-dir lib --config-file '../../babel.config.js'"
   },
   "dependencies": {

--- a/packages/product-json-to-csv/package.json
+++ b/packages/product-json-to-csv/package.json
@@ -1,4 +1,8 @@
 {
+  "private": false,
+  "publishConfig": {
+    "access": "public"
+  },
   "name": "@commercetools/product-json-to-csv",
   "version": "3.1.14",
   "description": "Converts commercetools products from JSON to CSV",
@@ -32,6 +36,7 @@
     "lib"
   ],
   "scripts": {
+    "prebuild": "rimraf lib/**",
     "build": "babel src --out-dir lib --config-file '../../babel.config.js'"
   },
   "dependencies": {

--- a/packages/product-json-to-xlsx/package.json
+++ b/packages/product-json-to-xlsx/package.json
@@ -1,4 +1,8 @@
 {
+  "private": false,
+  "publishConfig": {
+    "access": "public"
+  },
   "name": "@commercetools/product-json-to-xlsx",
   "version": "2.0.17",
   "description": "Converts commercetools products from JSON to XLSX",
@@ -32,6 +36,7 @@
     "lib"
   ],
   "scripts": {
+    "prebuild": "rimraf lib/**",
     "build": "babel src --out-dir lib --config-file '../../babel.config.js'"
   },
   "dependencies": {

--- a/packages/resource-deleter/package.json
+++ b/packages/resource-deleter/package.json
@@ -1,4 +1,8 @@
 {
+  "private": false,
+  "publishConfig": {
+    "access": "public"
+  },
   "name": "@commercetools/resource-deleter",
   "version": "1.0.11",
   "description": "Delete resources from the commercetools platform",
@@ -7,6 +11,7 @@
     "resource-deleter": "bin/resource-deleter.js"
   },
   "scripts": {
+    "prebuild": "rimraf lib/**",
     "build": "babel src --out-dir lib --config-file '../../babel.config.js'"
   },
   "repository": {

--- a/packages/sdk-auth/package.json
+++ b/packages/sdk-auth/package.json
@@ -16,9 +16,9 @@
   "bugs": "https://github.com/commercetools/nodejs/issues",
   "license": "MIT",
   "author": "Jan Juna <jan.juna-ext@commercetools.com> (https://github.com/junajan)",
-  "main": "dist/commercetools-sdk-auth.cjs.js",
-  "module": "dist/commercetools-sdk-auth.es.js",
-  "browser": "dist/commercetools-sdk-auth.umd.js",
+  "main": "dist/sdk-auth.cjs.js",
+  "module": "dist/sdk-auth.es.js",
+  "browser": "dist/sdk-auth.umd.js",
   "repository": {
     "type": "git",
     "url": "https://github.com/commercetools/nodejs.git"

--- a/packages/sdk-auth/package.json
+++ b/packages/sdk-auth/package.json
@@ -24,15 +24,12 @@
     "url": "https://github.com/commercetools/nodejs.git"
   },
   "files": [
-    "dist",
-    "lib"
+    "dist"
   ],
   "scripts": {
-    "build": "cross-env npm run build:umd && npm run build:umd:min && npm run build:es && npm run build:cjs",
-    "build:umd": "cross-env NODE_ENV=rollup rollup -c ../../rollup.config.js -f umd -n CommercetoolsSdkAuth -i src/index.js -o dist/commercetools-sdk-auth.umd.js",
-    "build:umd:min": "cross-env NODE_ENV=production rollup -c ../../rollup.config.js -f umd -n CommercetoolsSdkAuth -i src/index.js -o dist/commercetools-sdk-auth.umd.min.js",
-    "build:es": "cross-env NODE_ENV=rollup rollup -c ../../rollup.config.js -f es -n CommercetoolsSdkAuth -i src/index.js -o dist/commercetools-sdk-auth.es.js",
-    "build:cjs": "cross-env NODE_ENV=rollup rollup -c ../../rollup.config.js -f cjs -n CommercetoolsSdkAuth -i src/index.js -o dist/commercetools-sdk-auth.cjs.js"
+    "prebuild": "rimraf dist/**",
+    "build": "cross-env yarn build:bundles",
+    "build:bundles": "cross-env NODE_ENV=production rollup -c ../../rollup.config.js -n CommercetoolsSdkAuth -i ./src/index.js"
   },
   "dependencies": {
     "@commercetools/sdk-middleware-http": "^5.2.1",

--- a/packages/sdk-client/package.json
+++ b/packages/sdk-client/package.json
@@ -16,9 +16,9 @@
   "bugs": "https://github.com/commercetools/nodejs/issues",
   "license": "MIT",
   "author": "Nicola Molinari <nicola.molinari@commercetools.com> (https://github.com/emmenko)",
-  "main": "dist/commercetools-sdk-client.cjs.js",
-  "module": "dist/commercetools-sdk-client.es.js",
-  "browser": "dist/commercetools-sdk-client.umd.js",
+  "main": "dist/sdk-client.cjs.js",
+  "module": "dist/sdk-client.es.js",
+  "browser": "dist/sdk-client.umd.js",
   "repository": {
     "type": "git",
     "url": "https://github.com/commercetools/nodejs.git"

--- a/packages/sdk-client/package.json
+++ b/packages/sdk-client/package.json
@@ -24,14 +24,11 @@
     "url": "https://github.com/commercetools/nodejs.git"
   },
   "files": [
-    "dist",
-    "lib"
+    "dist"
   ],
   "scripts": {
-    "build": "cross-env npm run build:umd && npm run build:umd:min && npm run build:es && npm run build:cjs",
-    "build:umd": "cross-env NODE_ENV=rollup rollup -c ../../rollup.config.js -f umd -n CommercetoolsSdkClient -i src/index.js -o dist/commercetools-sdk-client.umd.js",
-    "build:umd:min": "cross-env NODE_ENV=production rollup -c ../../rollup.config.js -f umd -n CommercetoolsSdkClient -i src/index.js -o dist/commercetools-sdk-client.umd.min.js",
-    "build:es": "cross-env NODE_ENV=rollup rollup -c ../../rollup.config.js -f es -n CommercetoolsSdkClient -i src/index.js -o dist/commercetools-sdk-client.es.js",
-    "build:cjs": "cross-env NODE_ENV=rollup rollup -c ../../rollup.config.js -f cjs -n CommercetoolsSdkClient -i src/index.js -o dist/commercetools-sdk-client.cjs.js"
+    "prebuild": "rimraf dist/**",
+    "build": "cross-env yarn build:bundles",
+    "build:bundles": "cross-env NODE_ENV=production rollup -c ../../rollup.config.js -n CommercetoolsSdkClient -i ./src/index.js"
   }
 }

--- a/packages/sdk-middleware-auth/package.json
+++ b/packages/sdk-middleware-auth/package.json
@@ -17,9 +17,9 @@
   "bugs": "https://github.com/commercetools/nodejs/issues",
   "license": "MIT",
   "author": "Nicola Molinari <nicola.molinari@commercetools.com> (https://github.com/emmenko)",
-  "main": "dist/commercetools-sdk-middleware-auth.cjs.js",
-  "module": "dist/commercetools-sdk-middleware-auth.es.js",
-  "browser": "dist/commercetools-sdk-middleware-auth.umd.js",
+  "main": "dist/sdk-middleware-auth.cjs.js",
+  "module": "dist/sdk-middleware-auth.es.js",
+  "browser": "dist/sdk-middleware-auth.umd.js",
   "repository": {
     "type": "git",
     "url": "https://github.com/commercetools/nodejs.git"

--- a/packages/sdk-middleware-auth/package.json
+++ b/packages/sdk-middleware-auth/package.json
@@ -25,15 +25,12 @@
     "url": "https://github.com/commercetools/nodejs.git"
   },
   "files": [
-    "dist",
-    "lib"
+    "dist"
   ],
   "scripts": {
-    "build": "cross-env npm run build:umd && npm run build:umd:min && npm run build:es && npm run build:cjs",
-    "build:umd": "cross-env NODE_ENV=rollup rollup -c ../../rollup.config.js -f umd -n CommercetoolsSdkMiddlewareAuth -i src/index.js -o dist/commercetools-sdk-middleware-auth.umd.js",
-    "build:umd:min": "cross-env NODE_ENV=production rollup -c ../../rollup.config.js -f umd -n CommercetoolsSdkMiddlewareAuth -i src/index.js -o dist/commercetools-sdk-middleware-auth.umd.min.js",
-    "build:es": "cross-env NODE_ENV=rollup rollup -c ../../rollup.config.js -f es -n CommercetoolsSdkMiddlewareAuth -i src/index.js -o dist/commercetools-sdk-middleware-auth.es.js",
-    "build:cjs": "cross-env NODE_ENV=rollup rollup -c ../../rollup.config.js -f cjs -n CommercetoolsSdkMiddlewareAuth -i src/index.js -o dist/commercetools-sdk-middleware-auth.cjs.js"
+    "prebuild": "rimraf dist/**",
+    "build": "cross-env yarn build:bundles",
+    "build:bundles": "cross-env NODE_ENV=production rollup -c ../../rollup.config.js -n CommercetoolsSdkMiddlewareAuth -i ./src/index.js"
   },
   "dependencies": {
     "node-fetch": "^2.3.0"

--- a/packages/sdk-middleware-correlation-id/package.json
+++ b/packages/sdk-middleware-correlation-id/package.json
@@ -25,14 +25,11 @@
     "url": "https://github.com/commercetools/nodejs.git"
   },
   "files": [
-    "dist",
-    "lib"
+    "dist"
   ],
   "scripts": {
-    "build": "cross-env npm run build:umd && npm run build:umd:min && npm run build:es && npm run build:cjs",
-    "build:umd": "cross-env NODE_ENV=rollup rollup -c ../../rollup.config.js -f umd -n CommercetoolsSdkMiddlewareCorrelationId -i src/index.js -o dist/commercetools-sdk-middleware-correlation-id.umd.js",
-    "build:umd:min": "cross-env NODE_ENV=production rollup -c ../../rollup.config.js -f umd -n CommercetoolsSdkMiddlewareCorrelationId -i src/index.js -o dist/commercetools-sdk-middleware-correlation-id.umd.min.js",
-    "build:es": "cross-env NODE_ENV=rollup rollup -c ../../rollup.config.js -f es -n CommercetoolsSdkMiddlewareCorrelationId -i src/index.js -o dist/commercetools-sdk-middleware-correlation-id.es.js",
-    "build:cjs": "cross-env NODE_ENV=rollup rollup -c ../../rollup.config.js -f cjs -n CommercetoolsSdkMiddlewareCorrelationId -i src/index.js -o dist/commercetools-sdk-middleware-correlation-id.cjs.js"
+    "prebuild": "rimraf dist/**",
+    "build": "cross-env yarn build:bundles",
+    "build:bundles": "cross-env NODE_ENV=production rollup -c ../../rollup.config.js -n CommercetoolsSdkMiddlewareCorrelationId -i ./src/index.js"
   }
 }

--- a/packages/sdk-middleware-correlation-id/package.json
+++ b/packages/sdk-middleware-correlation-id/package.json
@@ -17,9 +17,9 @@
   "bugs": "https://github.com/commercetools/nodejs/issues",
   "license": "MIT",
   "author": "Tobias Deekens <tobias.deekens@commercetools.com> (https://github.com/tdeekens)",
-  "main": "dist/commercetools-sdk-middleware-correlation-id.cjs.js",
-  "module": "dist/commercetools-sdk-middleware-correlation-id.es.js",
-  "browser": "dist/commercetools-sdk-middleware-correlation-id.umd.js",
+  "main": "dist/sdk-middleware-correlation-id.cjs.js",
+  "module": "dist/sdk-middleware-correlation-id.es.js",
+  "browser": "dist/sdk-middleware-correlation-id.umd.js",
   "repository": {
     "type": "git",
     "url": "https://github.com/commercetools/nodejs.git"

--- a/packages/sdk-middleware-http/package.json
+++ b/packages/sdk-middleware-http/package.json
@@ -16,9 +16,9 @@
   "bugs": "https://github.com/commercetools/nodejs/issues",
   "license": "MIT",
   "author": "Nicola Molinari <nicola.molinari@commercetools.com> (https://github.com/emmenko)",
-  "main": "dist/commercetools-sdk-middleware-http.cjs.js",
-  "module": "dist/commercetools-sdk-middleware-http.es.js",
-  "browser": "dist/commercetools-sdk-middleware-http.umd.js",
+  "main": "dist/sdk-middleware-http.cjs.js",
+  "module": "dist/sdk-middleware-http.es.js",
+  "browser": "dist/sdk-middleware-http.umd.js",
   "repository": {
     "type": "git",
     "url": "https://github.com/commercetools/nodejs.git"

--- a/packages/sdk-middleware-http/package.json
+++ b/packages/sdk-middleware-http/package.json
@@ -24,15 +24,12 @@
     "url": "https://github.com/commercetools/nodejs.git"
   },
   "files": [
-    "dist",
-    "lib"
+    "dist"
   ],
   "scripts": {
-    "build": "cross-env npm run build:umd && npm run build:umd:min && npm run build:es && npm run build:cjs",
-    "build:umd": "cross-env NODE_ENV=rollup rollup -c ../../rollup.config.js -f umd -n CommercetoolsSdkMiddlewareHttp -i src/index.js -o dist/commercetools-sdk-middleware-http.umd.js",
-    "build:umd:min": "cross-env NODE_ENV=production rollup -c ../../rollup.config.js -f umd -n CommercetoolsSdkMiddlewareHttp -i src/index.js -o dist/commercetools-sdk-middleware-http.umd.min.js",
-    "build:es": "cross-env NODE_ENV=rollup rollup -c ../../rollup.config.js -f es -n CommercetoolsSdkMiddlewareHttp -i src/index.js -o dist/commercetools-sdk-middleware-http.es.js",
-    "build:cjs": "cross-env NODE_ENV=rollup rollup -c ../../rollup.config.js -f cjs -n CommercetoolsSdkMiddlewareHttp -i src/index.js -o dist/commercetools-sdk-middleware-http.cjs.js"
+    "prebuild": "rimraf dist/**",
+    "build": "cross-env yarn build:bundles",
+    "build:bundles": "cross-env NODE_ENV=production rollup -c ../../rollup.config.js -n CommercetoolsSdkMiddlewareHttp -i ./src/index.js"
   },
   "devDependencies": {
     "nock": "10.0.6",

--- a/packages/sdk-middleware-logger/package.json
+++ b/packages/sdk-middleware-logger/package.json
@@ -16,9 +16,9 @@
   "bugs": "https://github.com/commercetools/nodejs/issues",
   "license": "MIT",
   "author": "Nicola Molinari <nicola.molinari@commercetools.com> (https://github.com/emmenko)",
-  "main": "dist/commercetools-sdk-middleware-logger.cjs.js",
-  "module": "dist/commercetools-sdk-middleware-logger.es.js",
-  "browser": "dist/commercetools-sdk-middleware-logger.umd.js",
+  "main": "dist/sdk-middleware-logger.cjs.js",
+  "module": "dist/sdk-middleware-logger.es.js",
+  "browser": "dist/sdk-middleware-logger.umd.js",
   "repository": {
     "type": "git",
     "url": "https://github.com/commercetools/nodejs.git"

--- a/packages/sdk-middleware-logger/package.json
+++ b/packages/sdk-middleware-logger/package.json
@@ -24,14 +24,11 @@
     "url": "https://github.com/commercetools/nodejs.git"
   },
   "files": [
-    "dist",
-    "lib"
+    "dist"
   ],
   "scripts": {
-    "build": "cross-env npm run build:umd && npm run build:umd:min && npm run build:es && npm run build:cjs",
-    "build:umd": "cross-env NODE_ENV=rollup rollup -c ../../rollup.config.js -f umd -n CommercetoolsSdkMiddlewareLogger -i src/index.js -o dist/commercetools-sdk-middleware-logger.umd.js",
-    "build:umd:min": "cross-env NODE_ENV=production rollup -c ../../rollup.config.js -f umd -n CommercetoolsSdkMiddlewareLogger -i src/index.js -o dist/commercetools-sdk-middleware-logger.umd.min.js",
-    "build:es": "cross-env NODE_ENV=rollup rollup -c ../../rollup.config.js -f es -n CommercetoolsSdkMiddlewareLogger -i src/index.js -o dist/commercetools-sdk-middleware-logger.es.js",
-    "build:cjs": "cross-env NODE_ENV=rollup rollup -c ../../rollup.config.js -f cjs -n CommercetoolsSdkMiddlewareLogger -i src/index.js -o dist/commercetools-sdk-middleware-logger.cjs.js"
+    "prebuild": "rimraf dist/**",
+    "build": "cross-env yarn build:bundles",
+    "build:bundles": "cross-env NODE_ENV=production rollup -c ../../rollup.config.js -n CommercetoolsSdkMiddlewareLogger -i ./src/index.js"
   }
 }

--- a/packages/sdk-middleware-queue/package.json
+++ b/packages/sdk-middleware-queue/package.json
@@ -24,14 +24,11 @@
     "url": "https://github.com/commercetools/nodejs.git"
   },
   "files": [
-    "dist",
-    "lib"
+    "dist"
   ],
   "scripts": {
-    "build": "cross-env npm run build:umd && npm run build:umd:min && npm run build:es && npm run build:cjs",
-    "build:umd": "cross-env NODE_ENV=rollup rollup -c ../../rollup.config.js -f umd -n CommercetoolsSdkMiddlewareQueue -i src/index.js -o dist/commercetools-sdk-middleware-queue.umd.js",
-    "build:umd:min": "cross-env NODE_ENV=production rollup -c ../../rollup.config.js -f umd -n CommercetoolsSdkMiddlewareQueue -i src/index.js -o dist/commercetools-sdk-middleware-queue.umd.min.js",
-    "build:es": "cross-env NODE_ENV=rollup rollup -c ../../rollup.config.js -f es -n CommercetoolsSdkMiddlewareQueue -i src/index.js -o dist/commercetools-sdk-middleware-queue.es.js",
-    "build:cjs": "cross-env NODE_ENV=rollup rollup -c ../../rollup.config.js -f cjs -n CommercetoolsSdkMiddlewareQueue -i src/index.js -o dist/commercetools-sdk-middleware-queue.cjs.js"
+    "prebuild": "rimraf dist/**",
+    "build": "cross-env yarn build:bundles",
+    "build:bundles": "cross-env NODE_ENV=production rollup -c ../../rollup.config.js -n CommercetoolsSdkMiddlewareQueue -i ./src/index.js"
   }
 }

--- a/packages/sdk-middleware-queue/package.json
+++ b/packages/sdk-middleware-queue/package.json
@@ -16,9 +16,9 @@
   "bugs": "https://github.com/commercetools/nodejs/issues",
   "license": "MIT",
   "author": "Nicola Molinari <nicola.molinari@commercetools.com> (https://github.com/emmenko)",
-  "main": "dist/commercetools-sdk-middleware-queue.cjs.js",
-  "module": "dist/commercetools-sdk-middleware-queue.es.js",
-  "browser": "dist/commercetools-sdk-middleware-queue.umd.js",
+  "main": "dist/sdk-middleware-queue.cjs.js",
+  "module": "dist/sdk-middleware-queue.es.js",
+  "browser": "dist/sdk-middleware-queue.umd.js",
   "repository": {
     "type": "git",
     "url": "https://github.com/commercetools/nodejs.git"

--- a/packages/sdk-middleware-user-agent/package.json
+++ b/packages/sdk-middleware-user-agent/package.json
@@ -24,15 +24,12 @@
     "url": "https://github.com/commercetools/nodejs.git"
   },
   "files": [
-    "dist",
-    "lib"
+    "dist"
   ],
   "scripts": {
-    "build": "cross-env npm run build:umd && npm run build:umd:min && npm run build:es && npm run build:cjs",
-    "build:umd": "cross-env NODE_ENV=rollup rollup -c ../../rollup.config.js -f umd -n CommercetoolsSdkMiddlewareUserAgent -i src/index.js -o dist/commercetools-sdk-middleware-user-agent.umd.js",
-    "build:umd:min": "cross-env NODE_ENV=production rollup -c ../../rollup.config.js -f umd -n CommercetoolsSdkMiddlewareUserAgent -i src/index.js -o dist/commercetools-sdk-middleware-user-agent.umd.min.js",
-    "build:es": "cross-env NODE_ENV=rollup rollup -c ../../rollup.config.js -f es -n CommercetoolsSdkMiddlewareUserAgent -i src/index.js -o dist/commercetools-sdk-middleware-user-agent.es.js",
-    "build:cjs": "cross-env NODE_ENV=rollup rollup -c ../../rollup.config.js -f cjs -n CommercetoolsSdkMiddlewareUserAgent -i src/index.js -o dist/commercetools-sdk-middleware-user-agent.cjs.js"
+    "prebuild": "rimraf dist/**",
+    "build": "cross-env yarn build:bundles",
+    "build:bundles": "cross-env NODE_ENV=production rollup -c ../../rollup.config.js -n CommercetoolsSdkMiddlewareUserAgent -i ./src/index.js"
   },
   "dependencies": {
     "@commercetools/http-user-agent": "^2.1.1"

--- a/packages/sdk-middleware-user-agent/package.json
+++ b/packages/sdk-middleware-user-agent/package.json
@@ -16,9 +16,9 @@
   "bugs": "https://github.com/commercetools/nodejs/issues",
   "license": "MIT",
   "author": "Nicola Molinari <nicola.molinari@commercetools.com> (https://github.com/emmenko)",
-  "main": "dist/commercetools-sdk-middleware-user-agent.cjs.js",
-  "module": "dist/commercetools-sdk-middleware-user-agent.es.js",
-  "browser": "dist/commercetools-sdk-middleware-user-agent.umd.js",
+  "main": "dist/sdk-middleware-user-agent.cjs.js",
+  "module": "dist/sdk-middleware-user-agent.es.js",
+  "browser": "dist/sdk-middleware-user-agent.umd.js",
   "repository": {
     "type": "git",
     "url": "https://github.com/commercetools/nodejs.git"

--- a/packages/state-importer/package.json
+++ b/packages/state-importer/package.json
@@ -1,9 +1,17 @@
 {
+  "private": false,
+  "publishConfig": {
+    "access": "public"
+  },
   "name": "@commercetools/state-importer",
   "version": "2.0.17",
   "description": "Import states to the commercetools platform",
   "main": "lib/main.js",
+  "files": [
+    "lib"
+  ],
   "scripts": {
+    "prebuild": "rimraf lib/**",
     "build": "babel src --out-dir lib --config-file '../../babel.config.js'"
   },
   "repository": {

--- a/packages/sync-actions/package.json
+++ b/packages/sync-actions/package.json
@@ -15,9 +15,9 @@
   "bugs": "https://github.com/commercetools/nodejs/issues",
   "license": "MIT",
   "author": "Nicola Molinari <nicola.molinari@commercetools.com> (https://github.com/emmenko)",
-  "main": "dist/commercetools-sync-actions.cjs.js",
-  "module": "dist/commercetools-sync-actions.es.js",
-  "browser": "dist/commercetools-sync-actions.umd.js",
+  "main": "dist/sync-actions.cjs.js",
+  "module": "dist/sync-actions.es.js",
+  "browser": "dist/sync-actions.umd.js",
   "repository": {
     "type": "git",
     "url": "https://github.com/commercetools/nodejs.git"

--- a/packages/sync-actions/package.json
+++ b/packages/sync-actions/package.json
@@ -27,11 +27,9 @@
     "lib"
   ],
   "scripts": {
-    "build": "cross-env npm run build:umd && npm run build:umd:min && npm run build:es && npm run build:cjs",
-    "build:umd": "cross-env NODE_ENV=rollup rollup -c ../../rollup.config.js -f umd -n CommercetoolsSyncActions -i src/index.js -o dist/commercetools-sync-actions.umd.js",
-    "build:umd:min": "cross-env NODE_ENV=production rollup -c ../../rollup.config.js -f umd -n CommercetoolsSyncActions -i src/index.js -o dist/commercetools-sync-actions.umd.min.js",
-    "build:es": "cross-env NODE_ENV=rollup rollup -c ../../rollup.config.js -f es -n CommercetoolsSyncActions -i src/index.js -o dist/commercetools-sync-actions.es.js",
-    "build:cjs": "cross-env NODE_ENV=rollup rollup -c ../../rollup.config.js -f cjs -n CommercetoolsSyncActions -i src/index.js -o dist/commercetools-sync-actions.cjs.js"
+    "prebuild": "rimraf dist/**",
+    "build": "cross-env yarn build:bundles",
+    "build:bundles": "cross-env NODE_ENV=production rollup -c ../../rollup.config.js -n CommercetoolsSyncActions -i ./src/index.js"
   },
   "dependencies": {
     "fast-equals": "^2.0.0",

--- a/packages/typescript-sdk/package.json
+++ b/packages/typescript-sdk/package.json
@@ -29,11 +29,8 @@
   ],
   "scripts": {
     "prebuild": "rimraf dist/**",
-    "build": "cross-env yarn build:umd && yarn build:umd:min && yarn build:es && yarn build:cjs",
-    "build:umd": "cross-env NODE_ENV=rollup rollup -c ../../rollup.config.js -f umd -n TypescriptSdk -i ./src/index.ts -o dist/typescript-sdk.umd.js",
-    "build:umd:min": "cross-env NODE_ENV=production rollup -c ../../rollup.config.js -f umd -n TypescriptSdk -i ./src/index.ts -o dist/typescript-sdk.umd.min.js",
-    "build:es": "cross-env NODE_ENV=rollup rollup -c ../../rollup.config.js -f es -n TypescriptSdk -i ./src/index.ts -o dist/typescript-sdk.es.js",
-    "build:cjs": "cross-env NODE_ENV=rollup rollup -c ../../rollup.config.js -f cjs -n TypescriptSdk -i ./src/index.ts -o dist/typescript-sdk.cjs.js",
+    "build": "cross-env yarn build:bundles && yarn build:typings",
+    "build:bundles": "cross-env NODE_ENV=production rollup -c ../../rollup.config.js -n TypescriptSdk -i ./src/index.ts",
     "build:typings": "tsc -p tsconfig.declarations.json --emitDeclarationOnly --declarationDir dist/typings"
   },
   "dependencies": {


### PR DESCRIPTION
Instead of having one build command for each output format, we can include them in rollup.