### PR TITLE
feat: querying custom objects by container and key

### DIFF
--- a/packages/api-request-builder/src/create-service.js
+++ b/packages/api-request-builder/src/create-service.js
@@ -35,7 +35,9 @@ const requiredDefinitionProps = ['type', 'endpoint', 'features']
 
 function getIdOrKey(params: Object): string {
   if (params.id) return `/${params.id}`
-  if (params.key) return `/key=${params.key}`
+  if (params.key && !params.container) return `/key=${params.key}`
+  if (params.key && params.container)
+    return `/${params.container}/${params.key}`
   return ''
 }
 

--- a/packages/api-request-builder/src/default-params.js
+++ b/packages/api-request-builder/src/default-params.js
@@ -130,6 +130,7 @@ export function setParams(params: ServiceBuilderParams) {
     'dataErasure',
     'withTotal',
     'applyOrderEditTo',
+    'container',
   ]
   Object.keys(params).forEach((key: string) => {
     if (!knownKeys.includes(key)) throw new Error(`Unknown key "${key}"`)
@@ -143,7 +144,8 @@ export function setParams(params: ServiceBuilderParams) {
 
   // query-id
   if (hasKey(params, 'id')) this.byId(params.id)
-  if (hasKey(params, 'key')) this.byKey(params.key)
+  if (hasKey(params, 'key') && !hasKey(params, 'container'))
+    this.byKey(params.key)
   if (hasKey(params, 'customerId')) this.byCustomerId(params.customerId)
   if (hasKey(params, 'cartId')) this.byCartId(params.cartId)
 
@@ -219,4 +221,8 @@ export function setParams(params: ServiceBuilderParams) {
   // withTotal
   if (hasKey(params, 'applyOrderEditTo'))
     this.applyOrderEditTo(params.applyOrderEditTo)
+
+  // container and key
+  if (hasKey(params, 'container') && hasKey(params, 'key'))
+    this.byContainerAndKey(params.container, params.key)
 }

--- a/packages/api-request-builder/src/query-id.js
+++ b/packages/api-request-builder/src/query-id.js
@@ -88,3 +88,22 @@ export function byCartId(cartId: string): Object {
   this.params.cartId = cartId
   return this
 }
+
+/**
+ * Set the given `container` and `key` to the internal state of the service instance.
+ *
+ * @param  {string} container - A resource `container`
+ * @param  {string} key - A resource `key`
+ * @throws If `container` or `key` is missing.
+ * @return {Object} The instance of the service, can be chained.
+ */
+export function byContainerAndKey(container: string, key: string): Object {
+  if (typeof container !== 'string' || typeof key !== 'string')
+    throw new Error(
+      'Required `container` or `key` argument for `byContainerAndKey` needs to be a string'
+    )
+
+  this.params.container = container
+  this.params.key = key
+  return this
+}

--- a/packages/api-request-builder/test/create-service.spec.js
+++ b/packages/api-request-builder/test/create-service.spec.js
@@ -374,6 +374,12 @@ describe('createService', () => {
     test('should throw on unknown keys', () => {
       expect(() => service.parse({ foo: 'bar' })).toThrow('Unknown key "foo"')
     })
+
+    test('should support `container` and `key` together', () => {
+      expect(
+        service.parse({ container: 'container', key: 'key' }).build()
+      ).toBe('/my-project1/foo/container/key')
+    })
   })
 
   describe('build', () => {
@@ -516,6 +522,21 @@ describe('createService', () => {
     test('to throw error when order-edit-id is not a string', () => {
       expect(() => service.parse({ applyOrderEditTo: 2 })).toThrow(
         /A resource orderEditId is missing or invalid/
+      )
+    })
+    test('should add container and key', () => {
+      expect(service.byContainerAndKey('container', 'key123').build()).toBe(
+        '/my-project1/foo/container/key123'
+      )
+    })
+    test('to throw error when container is not a string', () => {
+      expect(() => service.byContainerAndKey(123, 'key123')).toThrow(
+        /Required `container` or `key` argument for `byContainerAndKey` needs to be a string/
+      )
+    })
+    test('to throw error when key is not supplied', () => {
+      expect(() => service.byContainerAndKey('container')).toThrow(
+        /Required `container` or `key` argument for `byContainerAndKey` needs to be a string/
       )
     })
   })

--- a/types/sdk.js
+++ b/types/sdk.js
@@ -351,6 +351,9 @@ export type ServiceBuilderParams = {
 
   // applyOrderEditTo
   applyOrderEditTo?: boolean,
+
+  // container
+  container?: ?string,
 }
 export type ServiceBuilder = {
   type: string,


### PR DESCRIPTION
#### Summary

PR adds functionality to get custom objects by [container and ID](https://docs.commercetools.com/http-api-projects-custom-objects#get-customobject-by-container-and-key).

#### Todo

- Tests
  - [x] Unit

resolves #1358
