### PR TITLE
feat(http-middleware): custom timeout and abortcontroller options

### DIFF
--- a/TODOS.md
+++ b/TODOS.md
@@ -1,9 +1,8 @@
 ### TODOs
-
-| Filename                                           | line # | TODO                                                                                        |
-| :------------------------------------------------- | :----: | :------------------------------------------------------------------------------------------ |
-| packages/api-request-builder/src/create-service.js |  136   | this can lead to invalid URIs as getIdOrKey can return                                      |
-| packages/custom-objects-importer/src/main.js       |  127   | remove `FlowFixMe` when [this](https://github.com/facebook/flow/issues/5294) issue is fixed |
-| packages/product-json-to-csv/test/writer.spec.js   |  263   | the "unzip" package fires finish event before entry events                                  |
-| packages/product-json-to-csv/test/writer.spec.js   |  308   | the "unzip" package fires finish event before entry events                                  |
-| packages/sync-actions/src/utils/diffpatcher.js     |   3    | create an issue here https://github.com/benjamine/jsondiffpatch/issues/new                  |
+| Filename | line # | TODO
+|:------|:------:|:------
+| packages/api-request-builder/src/create-service.js | 136 | this can lead to invalid URIs as getIdOrKey can return
+| packages/custom-objects-importer/src/main.js | 127 | remove `FlowFixMe` when [this](https://github.com/facebook/flow/issues/5294) issue is fixed
+| packages/product-json-to-csv/test/writer.spec.js | 263 | the "unzip" package fires finish event before entry events
+| packages/product-json-to-csv/test/writer.spec.js | 308 | the "unzip" package fires finish event before entry events
+| packages/sync-actions/src/utils/diffpatcher.js | 3 | create an issue here https://github.com/benjamine/jsondiffpatch/issues/new

--- a/babel.config.js
+++ b/babel.config.js
@@ -3,6 +3,7 @@ const getPresets = () => {
     case 'development':
       return {
         targets: { node: 'current' },
+        useBuiltIns: 'usage',
         modules: 'commonjs',
       }
     case 'rollup':
@@ -11,6 +12,7 @@ const getPresets = () => {
           browsers: ['last 2 versions'],
           node: 'current',
         },
+        useBuiltIns: 'usage',
         modules: false,
       }
     case 'production':
@@ -19,11 +21,13 @@ const getPresets = () => {
           browsers: ['last 2 versions'],
           node: '8',
         },
+        useBuiltIns: 'usage',
         modules: false,
       }
     case 'cli':
       return {
         targets: { node: '8' },
+        useBuiltIns: 'usage',
         modules: 'commonjs',
       }
     default:

--- a/docs/sdk/api/sdkMiddlewareHttp.md
+++ b/docs/sdk/api/sdkMiddlewareHttp.md
@@ -39,6 +39,8 @@ The HTTP middleware can run in either a browser or Node.js environment. For Node
 10. `backoff` _(Boolean)_: activates exponential backoff. Recommended to prevent spamming of the server. (Default: true)
 11. `maxDelay` _(Number)_: The maximum duration (milliseconds) to wait before retrying, useful if the delay time grew exponentially more than reasonable
 12. `fetch` _(Function)_: A `fetch` implementation which can be e.g. `node-fetch` or `unfetch` but also the native browser `fetch` function
+13. `timeout` _(Number)_: Req/res timeout in ms. Must have globally available or passed in `AbortController`
+14. `AbortController` (_AbortController_): An `AbortController` instance. Could be [abort-controller](https://www.npmjs.com/package/abort-controller) or globally available one.
 
 #### Retrying requests
 

--- a/packages/sdk-middleware-http/package.json
+++ b/packages/sdk-middleware-http/package.json
@@ -33,6 +33,7 @@
   },
   "devDependencies": {
     "nock": "11.3.6",
-    "node-fetch": "2.6.0"
+    "node-fetch": "2.6.0",
+    "abort-controller":"3.0.0"
   }
 }

--- a/packages/sdk-middleware-http/src/http.js
+++ b/packages/sdk-middleware-http/src/http.js
@@ -57,6 +57,7 @@ export default function createHttpMiddleware({
   includeOriginalRequest,
   maskSensitiveHeaderData = true,
   enableRetry,
+  signal,
   retryConfig: {
     // encourage exponential backoff to prevent spamming the server if down
     maxRetries = 10,
@@ -100,6 +101,7 @@ export default function createHttpMiddleware({
       method: request.method,
       headers: requestHeader,
       ...(credentialsMode ? { credentials: credentialsMode } : {}),
+      ...(signal ? { signal } : {}),
       ...(body ? { body } : null),
     }
     let retryCount = 0

--- a/packages/sdk-middleware-http/src/http.js
+++ b/packages/sdk-middleware-http/src/http.js
@@ -57,7 +57,7 @@ export default function createHttpMiddleware({
   includeOriginalRequest,
   maskSensitiveHeaderData = true,
   enableRetry,
-  signal,
+  timeout,
   retryConfig: {
     // encourage exponential backoff to prevent spamming the server if down
     maxRetries = 10,
@@ -66,10 +66,15 @@ export default function createHttpMiddleware({
     maxDelay = Infinity,
   } = {},
   fetch: fetcher,
+  AbortController: _AbortController,
 }: HttpMiddlewareOptions): Middleware {
   if (!fetcher && typeof fetch === 'undefined')
     throw new Error(
       '`fetch` is not available. Please pass in `fetch` as an option or have it globally available.'
+    )
+  if (timeout && !_AbortController && !AbortController)
+    throw new Error(
+      '`AbortController` is not available. Please pass in `AbortController` as an option or have it globally available when using timeout.'
     )
 
   if (!fetcher)
@@ -79,6 +84,17 @@ export default function createHttpMiddleware({
 
     // eslint-disable-next-line
     fetcher = fetch
+
+  let abortController
+  if (timeout || _AbortController)
+    // eslint-disable-next-line
+    abortController = _AbortController || new AbortController()
+
+  let timer
+  if (timeout)
+    timer = setTimeout(() => {
+      abortController.abort()
+    }, timeout)
 
   return (next: Next): Next => (
     request: MiddlewareRequest,
@@ -101,116 +117,120 @@ export default function createHttpMiddleware({
       method: request.method,
       headers: requestHeader,
       ...(credentialsMode ? { credentials: credentialsMode } : {}),
-      ...(signal ? { signal } : {}),
+      ...(timeout || abortController ? { signal: abortController.signal } : {}),
       ...(body ? { body } : null),
     }
     let retryCount = 0
     // wrap in a fn so we can retry if error occur
     function executeFetch() {
       // $FlowFixMe
-      fetcher(url, fetchOptions).then(
-        (res: Response) => {
-          if (res.ok) {
-            if (fetchOptions.method === 'HEAD') {
-              next(request, {
-                ...response,
-                statusCode: res.status,
+      fetcher(url, fetchOptions)
+        .then(
+          (res: Response) => {
+            if (res.ok) {
+              if (fetchOptions.method === 'HEAD') {
+                next(request, {
+                  ...response,
+                  statusCode: res.status,
+                })
+                return
+              }
+
+              res.json().then((result: Object) => {
+                const parsedResponse: Object = {
+                  ...response,
+                  body: result,
+                  statusCode: res.status,
+                }
+
+                if (includeResponseHeaders)
+                  parsedResponse.headers = parseHeaders(res.headers)
+
+                if (includeOriginalRequest) {
+                  parsedResponse.request = {
+                    ...fetchOptions,
+                  }
+                  maskAuthData(parsedResponse.request, maskSensitiveHeaderData)
+                }
+                next(request, parsedResponse)
               })
               return
             }
-
-            res.json().then((result: Object) => {
-              const parsedResponse: Object = {
-                ...response,
-                body: result,
-                statusCode: res.status,
+            if (res.status === 503 && enableRetry)
+              if (retryCount < maxRetries) {
+                setTimeout(
+                  executeFetch,
+                  calcDelayDuration(
+                    retryCount,
+                    retryDelay,
+                    maxRetries,
+                    backoff,
+                    maxDelay
+                  )
+                )
+                retryCount += 1
+                return
               }
 
-              if (includeResponseHeaders)
-                parsedResponse.headers = parseHeaders(res.headers)
+            // Server responded with an error. Try to parse it as JSON, then
+            // return a proper error type with all necessary meta information.
+            res.text().then((text: any) => {
+              // Try to parse the error response as JSON
+              let parsed
+              try {
+                parsed = JSON.parse(text)
+              } catch (error) {
+                parsed = text
+              }
 
-              if (includeOriginalRequest) {
-                parsedResponse.request = {
-                  ...fetchOptions,
-                }
-                maskAuthData(parsedResponse.request, maskSensitiveHeaderData)
+              const error: HttpErrorType = createError({
+                statusCode: res.status,
+                originalRequest: request,
+                retryCount,
+                headers: parseHeaders(res.headers),
+                ...(typeof parsed === 'object'
+                  ? { message: parsed.message, body: parsed }
+                  : { message: parsed, body: parsed }),
+              })
+              maskAuthData(error.originalRequest, maskSensitiveHeaderData)
+              // Let the final resolver to reject the promise
+              const parsedResponse = {
+                ...response,
+                error,
+                statusCode: res.status,
               }
               next(request, parsedResponse)
             })
-            return
-          }
-          if (res.status === 503 && enableRetry)
-            if (retryCount < maxRetries) {
-              setTimeout(
-                executeFetch,
-                calcDelayDuration(
-                  retryCount,
-                  retryDelay,
-                  maxRetries,
-                  backoff,
-                  maxDelay
+          },
+          // We know that this is a "network" error thrown by the `fetch` library
+          (e: Error) => {
+            if (enableRetry)
+              if (retryCount < maxRetries) {
+                setTimeout(
+                  executeFetch,
+                  calcDelayDuration(
+                    retryCount,
+                    retryDelay,
+                    maxRetries,
+                    backoff,
+                    maxDelay
+                  )
                 )
-              )
-              retryCount += 1
-              return
-            }
+                retryCount += 1
+                return
+              }
 
-          // Server responded with an error. Try to parse it as JSON, then
-          // return a proper error type with all necessary meta information.
-          res.text().then((text: any) => {
-            // Try to parse the error response as JSON
-            let parsed
-            try {
-              parsed = JSON.parse(text)
-            } catch (error) {
-              parsed = text
-            }
-
-            const error: HttpErrorType = createError({
-              statusCode: res.status,
+            const error = new NetworkError(e.message, {
               originalRequest: request,
               retryCount,
-              headers: parseHeaders(res.headers),
-              ...(typeof parsed === 'object'
-                ? { message: parsed.message, body: parsed }
-                : { message: parsed, body: parsed }),
             })
             maskAuthData(error.originalRequest, maskSensitiveHeaderData)
-            // Let the final resolver to reject the promise
-            const parsedResponse = {
-              ...response,
-              error,
-              statusCode: res.status,
-            }
-            next(request, parsedResponse)
-          })
-        },
-        // We know that this is a "network" error thrown by the `fetch` library
-        (e: Error) => {
-          if (enableRetry)
-            if (retryCount < maxRetries) {
-              setTimeout(
-                executeFetch,
-                calcDelayDuration(
-                  retryCount,
-                  retryDelay,
-                  maxRetries,
-                  backoff,
-                  maxDelay
-                )
-              )
-              retryCount += 1
-              return
-            }
-
-          const error = new NetworkError(e.message, {
-            originalRequest: request,
-            retryCount,
-          })
-          maskAuthData(error.originalRequest, maskSensitiveHeaderData)
-          next(request, { ...response, error, statusCode: 0 })
-        }
-      )
+            next(request, { ...response, error, statusCode: 0 })
+          }
+        )
+        .finally(() => {
+          clearTimeout(timer)
+        })
     }
     executeFetch()
   }

--- a/packages/sdk-middleware-http/src/http.js
+++ b/packages/sdk-middleware-http/src/http.js
@@ -72,7 +72,7 @@ export default function createHttpMiddleware({
     throw new Error(
       '`fetch` is not available. Please pass in `fetch` as an option or have it globally available.'
     )
-  if (timeout && !_AbortController && !AbortController)
+  if (timeout && !_AbortController && typeof AbortController === 'undefined')
     throw new Error(
       '`AbortController` is not available. Please pass in `AbortController` as an option or have it globally available when using timeout.'
     )

--- a/packages/sdk-middleware-http/test/http.spec.js
+++ b/packages/sdk-middleware-http/test/http.spec.js
@@ -59,6 +59,37 @@ describe('Http', () => {
       httpMiddleware(next)(request, response)
     }))
 
+  test('execute a get request with short timeout (fail)', () =>
+    new Promise((resolve, reject) => {
+      const request = createTestRequest({
+        uri: '/foo/bar',
+      })
+      const response = { resolve, reject }
+      const next = (req, res) => {
+        expect(res).toEqual({
+          ...response,
+          error: expect.any(Error),
+          statusCode: 0,
+        })
+        resolve()
+      }
+      // Use default options
+      const httpMiddleware = createHttpMiddleware({
+        host: testHost,
+        signal: 1, // time out after 1ms
+        fetch,
+      })
+      nock(testHost)
+        .defaultReplyHeaders({
+          'Content-Type': 'application/json',
+        })
+        .get('/foo/bar')
+        .delay(100) // delay response with 100ms
+        .reply(200, { foo: 'bar' })
+
+      httpMiddleware(next)(request, response)
+    }))
+
   test('should accept HEAD request and return without response body', () =>
     new Promise((resolve, reject) => {
       const request = createTestRequest({ uri: '/foo', method: 'HEAD' })

--- a/packages/sdk-middleware-http/test/http.spec.js
+++ b/packages/sdk-middleware-http/test/http.spec.js
@@ -31,6 +31,16 @@ describe('Http', () => {
     )
   })
 
+  test('throw without `AbortController` passed or globally available when using timeout', () => {
+    expect(() => {
+      createHttpMiddleware({ host: testHost, timeout: 100, fetch })
+    }).toThrow(
+      new Error(
+        '`AbortController` is not available. Please pass in `AbortController` as an option or have it globally available when using timeout.'
+      )
+    )
+  })
+
   test('execute a get request (success)', () =>
     new Promise((resolve, reject) => {
       const request = createTestRequest({

--- a/types/sdk.js
+++ b/types/sdk.js
@@ -220,6 +220,16 @@ export type PasswordAuthMiddlewareOptions = {
   fetch?: (url: string, args?: Object) => Promise<any>,
 }
 
+// translation of https://dom.spec.whatwg.org/#abortcontroller
+interface AbortSignal extends EventTarget {
+  +aborted: boolean;
+  onabort: EventHandler;
+}
+class AbortController {
+  +signal: AbortSignal
+  abort: () => void
+}
+
 export type HttpMiddlewareOptions = {
   host: string,
   credentialsMode?: 'omit' | 'same-origin' | 'include',
@@ -227,7 +237,7 @@ export type HttpMiddlewareOptions = {
   includeResponseHeaders?: boolean,
   includeOriginalRequest?: boolean,
   maskSensitiveHeaderData?: boolean,
-  signal?: number,
+  timeout?: number,
   enableRetry?: boolean,
   retryConfig?: {
     maxRetries?: number,
@@ -236,6 +246,7 @@ export type HttpMiddlewareOptions = {
     maxDelay?: number,
   },
   fetch?: (url: string, options?: Object) => Promise<any>,
+  abortController?: AbortController,
 }
 export type QueueMiddlewareOptions = {
   concurrency: number,

--- a/types/sdk.js
+++ b/types/sdk.js
@@ -227,6 +227,7 @@ export type HttpMiddlewareOptions = {
   includeResponseHeaders?: boolean,
   includeOriginalRequest?: boolean,
   maskSensitiveHeaderData?: boolean,
+  signal?: number,
   enableRetry?: boolean,
   retryConfig?: {
     maxRetries?: number,

--- a/yarn.lock
+++ b/yarn.lock
@@ -2315,6 +2315,13 @@ abbrev@~1.0.9:
   resolved "https://registry.yarnpkg.com/abbrev/-/abbrev-1.0.9.tgz#91b4792588a7738c25f35dd6f63752a2f8776135"
   integrity sha1-kbR5JYinc4wl813W9jdSovh3YTU=
 
+abort-controller@3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/abort-controller/-/abort-controller-3.0.0.tgz#eaf54d53b62bae4138e809ca225c8439a6efb392"
+  integrity sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==
+  dependencies:
+    event-target-shim "^5.0.0"
+
 acorn-globals@^4.1.0:
   version "4.3.4"
   resolved "https://registry.yarnpkg.com/acorn-globals/-/acorn-globals-4.3.4.tgz#9fa1926addc11c97308c4e66d7add0d40c3272e7"
@@ -5544,6 +5551,11 @@ esutils@^2.0.2:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/esutils/-/esutils-2.0.3.tgz#74d2eb4de0b8da1293711910d50775b9b710ef64"
   integrity sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==
+
+event-target-shim@^5.0.0:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/event-target-shim/-/event-target-shim-5.0.1.tgz#5d4d3ebdf9583d63a5333ce2deb7480ab2b05789"
+  integrity sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==
 
 eventemitter3@^3.1.0:
   version "3.1.2"


### PR DESCRIPTION
#### Summary

PR adds `timeout` and `AbortController` options to the http middleware. When using the timeout option, we opted for using the controller over the `timeout` option which is available on some fetch implementations. This decision was based on the fact that `timeout` is getting deprecated in most common fetchers, including [node-fetch](https://www.npmjs.com/package/node-fetch#options). Instead, they are following the guidelines from the [Fetch Standard](https://fetch.spec.whatwg.org/) where `timeout` does not exist.

More reading and info here https://github.com/bitinn/node-fetch/issues/523

In addition, this allows users to implement their own abort mechanisms by simply passing in the controller without using the timeout.

#### Todo

- Tests
  - [x] Unit
- [x] Documentation

resolves #190 