### PR TITLE
chore: align renovate config with other repos

### DIFF
--- a/.renovaterc.json
+++ b/.renovaterc.json
@@ -2,12 +2,27 @@
   "extends": [
     "config:base",
     ":pinOnlyDevDependencies",
-    ":prHourlyLimitNone",
-    ":prConcurrentLimitNone",
-    ":automergeMinor",
-    "group:allNonMajor",
-    ":automergeBranchMergeCommit",
     ":enableVulnerabilityAlerts",
+    ":automergeMinor",
     "schedule:weekly"
-  ]
+  ],
+  "separateMajorMinor": true,
+  "groupName": "all dependencies",
+  "groupSlug": "all",
+  "packageRules": [
+    {
+      "packagePatterns": [
+        "*"
+      ],
+      "groupName": "all dependencies",
+      "groupSlug": "all"
+    }
+  ],
+  "lockFileMaintenance": {
+    "enabled": true
+  },
+  "labels": [
+    "Type: Maintenance"
+  ],
+  "ignoreDeps": []
 }


### PR DESCRIPTION
This aligns the renovate config with what we use in other repos. Basically we get every Monday up  to 3 PRs:
- lockfile maintenance
- all deps (non major)
- all deps (major)

Example from appkit:
<img width="629" alt="image" src="https://user-images.githubusercontent.com/1110551/72156040-c0343c00-33b4-11ea-9be5-fcb6ea93d102.png">
