### PR TITLE
fix(api-request-builder): reset key

### DIFF
--- a/packages/api-request-builder/src/default-params.js
+++ b/packages/api-request-builder/src/default-params.js
@@ -68,6 +68,8 @@ export function getDefaultSearchParams(): ServiceBuilderDefaultParams {
  */
 export function setDefaultParams() {
   this.params.expand = getDefaultQueryParams().expand
+  
+  this.params.key = null
 
   if (this.features.includes(features.queryOne))
     this.params.id = getDefaultQueryParams().id

--- a/packages/api-request-builder/test/create-request-builder.spec.js
+++ b/packages/api-request-builder/test/create-request-builder.spec.js
@@ -65,8 +65,7 @@ describe('createRequestBuilder', () => {
     )
   })
 
-
-  test('calling build resets all paramas', () => {
+  test('calling build resets all params', () => {
     const requestBuilder = createRequestBuilder({
       projectKey: 'foo'
     })

--- a/packages/api-request-builder/test/create-request-builder.spec.js
+++ b/packages/api-request-builder/test/create-request-builder.spec.js
@@ -64,4 +64,17 @@ describe('createRequestBuilder', () => {
       expectedServiceKeys.concat('foo').sort()
     )
   })
+
+
+  test('calling build resets all paramas', () => {
+    const requestBuilder = createRequestBuilder({
+      projectKey: 'foo'
+    })
+    requestBuilder.categories.byKey('Test').build();
+    const nextRequest = requestBuilder.categories.parse({ where: ['bar']}).build();
+    expect(nextRequest).toEqual(
+      "/foo/categories?where=bar"
+    )
+  })
+
 })

--- a/packages/api-request-builder/test/default-params.spec.js
+++ b/packages/api-request-builder/test/default-params.spec.js
@@ -8,6 +8,7 @@ describe('defaultParams', () => {
     setDefaultParams.call({ features: serviceFeatures, params })
     expect(params).toEqual({
       id: null,
+      key: null,
       expand: [],
       pagination: {
         page: null,
@@ -32,6 +33,7 @@ describe('defaultParams', () => {
     setDefaultParams.call({ features: serviceFeatures, params })
     expect(params).toEqual({
       id: null,
+      key: null,
       expand: [],
       pagination: {
         page: null,
@@ -57,6 +59,7 @@ describe('defaultParams', () => {
     setDefaultParams.call({ features: serviceFeatures, params })
     expect(params).toEqual({
       id: null,
+      key: null,
       expand: [],
       pagination: {
         page: null,
@@ -77,6 +80,7 @@ describe('defaultParams', () => {
     const params = {}
     setDefaultParams.call({ features: serviceFeatures, params })
     expect(params).toEqual({
+      key: null,
       expand: [],
       pagination: {
         page: null,


### PR DESCRIPTION
#### Summary

Closes #1446

#### Description

The key param is not a query parameter and it thus wasn't properly handled. I added reseting of the key param to our `setDefaultParams` function and added a test to make sure that it works.

#### Todo

- Tests
  - [ ] Unit
  - [x] Integration
  - [ ] Acceptance
- [ ] Documentation
