### PR TITLE
feat(product): add support for dimensions in image url

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -1,5 +1,5 @@
 [version]
-^0.112.0
+^0.115.0
 
 [ignore]
 <PROJECT_ROOT>/_book/.*

--- a/packages/product-json-to-csv/src/map-product-data.js
+++ b/packages/product-json-to-csv/src/map-product-data.js
@@ -402,8 +402,8 @@ export default class ProductMapping {
   _mapImagesToString(images: Array<Image>): string {
     return images
       .map((image: Image): string => {
-        const { url, label } = image
-        return label ? `${url}|${label}` : url
+        const { url, label, dimensions = { w: 0, h: 0 } } = image
+        return `${url}|${label || ''}|${dimensions.w}x${dimensions.h}`
       })
       .join(this.multiValDel)
   }

--- a/packages/product-json-to-csv/test/__snapshots__/map-product-data.spec.js.snap
+++ b/packages/product-json-to-csv/test/__snapshots__/map-product-data.spec.js.snap
@@ -8,7 +8,7 @@ Object {
   "state": "my-resolved-state",
   "variant": Object {
     "id": 1,
-    "images": "https://example.com/foobar/commer.jpg;https://example-2.com/demo/tools.jpg|image-label",
+    "images": "https://example.com/foobar/commer.jpg||3x4;https://example-2.com/demo/tools.jpg|image-label|1x5",
     "sku": "A0E200000001YKI",
   },
 }
@@ -106,7 +106,7 @@ Array [
     "taxCategory": "resolved-tax-name",
     "variant.availability": 10,
     "variant.id": 1,
-    "variant.images": "https://example.com/foobar/commer.jpg;https://example-2.com/demo/tools.jpg|image-label",
+    "variant.images": "https://example.com/foobar/commer.jpg||3x4;https://example-2.com/demo/tools.jpg|image-label|1x5",
     "variant.sku": "A0E200000001YKI",
   },
 ]
@@ -162,7 +162,7 @@ Array [
     "taxCategory": "resolved-tax-name",
     "variant.availability": 10,
     "variant.id": 1,
-    "variant.images": "https://example.com/foobar/commer.jpg;https://example-2.com/demo/tools.jpg|image-label",
+    "variant.images": "https://example.com/foobar/commer.jpg||3x4;https://example-2.com/demo/tools.jpg|image-label|1x5",
     "variant.sku": "A0E200000001YKI",
   },
   Object {
@@ -179,7 +179,7 @@ Array [
     "setLenums-2.en": "myLenums-2-en",
     "setLenums-2.es": "myLenums-2-es",
     "variant.id": 2,
-    "variant.images": "https://example.com/foobar/commer234.jpg;https://example-2.com/demo/tools67.jpg",
+    "variant.images": "https://example.com/foobar/commer234.jpg||3x3;https://example-2.com/demo/tools67.jpg||1x1",
     "variant.sku": "A0E200001YKI123",
   },
 ]


### PR DESCRIPTION
#### Summary
Add support for Dimensions in image url when export the products

below is example
https://jeanscentre-static.joggroup.net/sys-master/images/ha9/hf0/9027232661534/871821258791|ProductImage|100x100

closes #1460 
