### PR TITLE
fix(ts-sdk): serialization of array query parameters

### DIFF
--- a/packages/typescript-sdk/src/generated/base/requests-utils.ts
+++ b/packages/typescript-sdk/src/generated/base/requests-utils.ts
@@ -65,8 +65,8 @@ function reduceMiddleware(op1: Middleware, op2: Middleware): Middleware {
   }
 }
 
-function isDefined<T>(value: T | undefined): value is T {
-  return typeof value !== "undefined"
+function isDefined<T>(value: T | undefined | null): value is T {
+  return typeof value !== "undefined" && value !== null
 }
 
 function cleanObject<T extends VariableMap>(obj: T): T {

--- a/packages/typescript-sdk/src/generated/base/requests-utils.ts
+++ b/packages/typescript-sdk/src/generated/base/requests-utils.ts
@@ -1,5 +1,6 @@
-import { Middleware, MiddlewareArg, ClientResponse } from './common-types'
+import { Middleware, MiddlewareArg, ClientResponse, VariableMap } from './common-types'
 import { CommonRequest } from './local-common-types'
+import { stringify } from "querystring"
 
 export class ApiRequestExecutor {
   private middleware: Middleware
@@ -42,7 +43,7 @@ export class ApiRequest<O> {
   constructor(
     private readonly commonRequest: CommonRequest,
     private readonly apiRequestExecutor: ApiRequestExecutor
-  ) {}
+  ) { }
 
   public execute(): Promise<ClientResponse<O>> {
     return this.apiRequestExecutor.execute(this.commonRequest)
@@ -64,36 +65,39 @@ function reduceMiddleware(op1: Middleware, op2: Middleware): Middleware {
   }
 }
 
+function isDefined<T>(value: T | undefined): value is T {
+  return typeof value !== "undefined"
+}
+
+function cleanObject<T extends VariableMap>(obj: T): T {
+  return Object.keys(obj).reduce<T>((result, key) => {
+    const value = obj[key]
+    if (isDefined(value)) {
+      return { ...result, [key]: value };
+    }
+    return result;
+  }, {} as T)
+}
+
+function formatQueryString(variableMap: VariableMap) {
+  const map = cleanObject(variableMap);
+  const result = stringify(map)
+  if (result === '') {
+    return ''
+  }
+  return `?${result}`
+}
+
 function getURI(commonRequest: CommonRequest): string {
   const pathMap = commonRequest.pathVariables
-  const queryMap = commonRequest.queryParams
   var uri: String = commonRequest.uriTemplate
-  var queryParams: string[] = []
+
   for (const param in pathMap) {
     uri = uri.replace(`{${param}}`, `${pathMap[param]}`)
   }
-  for (const query in queryMap) {
-    const queryParameter = queryMap[query]
-    if (queryParameter === null || queryParameter === undefined) {
-      continue
-    }
-    if (queryParameter instanceof Array) {
-      ;(queryParameter as [])
-        .filter(value => value !== null && value !== undefined)
-        .forEach(value =>
-          queryParams.push(
-            `${query}=${encodeURIComponent(`${queryParameter[value]}`)}`
-          )
-        )
-    } else {
-      queryParams.push(`${query}=${encodeURIComponent(`${queryParameter}`)}`)
-    }
-  }
-  const resQuery = queryParams.join('&')
-  if (resQuery == '') {
-    return `${commonRequest.baseURL}${uri}`
-  }
-  return `${commonRequest.baseURL}${uri}?${resQuery}`
+
+  const resQuery = formatQueryString(commonRequest.queryParams || {})
+  return `${commonRequest.baseURL}${uri}${resQuery}`
 }
 
 const noOpMiddleware = async (x: MiddlewareArg) => x

--- a/packages/typescript-sdk/src/generated/base/requests-utils.ts
+++ b/packages/typescript-sdk/src/generated/base/requests-utils.ts
@@ -60,7 +60,7 @@ function reduceMiddleware(op1: Middleware, op2: Middleware): Middleware {
 
     return op1({
       ...rest,
-      next: intermediateOp,
+      next: intermediateOp
     })
   }
 }
@@ -72,10 +72,19 @@ function isDefined<T>(value: T | undefined | null): value is T {
 function cleanObject<T extends VariableMap>(obj: T): T {
   return Object.keys(obj).reduce<T>((result, key) => {
     const value = obj[key]
-    if (isDefined(value)) {
-      return { ...result, [key]: value };
+
+    if (Array.isArray(value)) {
+      return {
+        ...result,
+        [key]: (value as unknown[]).filter(isDefined)
+      }
     }
-    return result;
+
+    if (isDefined(value)) {
+      return { ...result, [key]: value }
+    }
+
+    return result
   }, {} as T)
 }
 

--- a/packages/typescript-sdk/test/generated/base/request-utils.spec.ts
+++ b/packages/typescript-sdk/test/generated/base/request-utils.spec.ts
@@ -1,0 +1,62 @@
+import { ApiRequestExecutor } from '../../../src/generated/base/requests-utils'
+import { MiddlewareArg, VariableMap } from '../../../src/generated/base/common-types';
+import * as url from "url";
+
+describe('ApiRequestExecutor', () => {
+  describe('query parameters', () => {
+    async function testQuery(params: VariableMap | undefined) {
+      const middleware = jest.fn(async (args: MiddlewareArg) => {
+        return {
+          ...args,
+          response: { body: undefined, statusCode: 200 }
+        }
+      })
+
+      const executor = new ApiRequestExecutor([middleware])
+
+      const args = {
+        baseURL: "http://base-url",
+        method: "GET" as const,
+        uriTemplate: "",
+        queryParams: params
+      }
+
+      await executor.execute(args)
+
+      expect(middleware).toHaveBeenCalledTimes(1)
+      return url.parse(middleware.mock.calls[0][0].request.uri).query
+    }
+
+    test('handle single element array query parameters', async () => {
+      expect(await testQuery({ foo: ["bar"] })).toEqual("foo=bar")
+    })
+
+    test('handle array query parameters', async () => {
+      expect(await testQuery({ foo: ["bar", "baz"] })).toEqual("foo=bar&foo=baz")
+    })
+
+    test('handle number query parameters', async () => {
+      expect(await testQuery({ foo: 123 })).toEqual("foo=123")
+    })
+
+    test('handle boolean query parameters', async () => {
+      expect(await testQuery({ foo: true, bar: false })).toEqual("foo=true&bar=false")
+    })
+
+    test('handle invalid characters', async () => {
+      expect(await testQuery({ foo: '<>abc /' })).toEqual("foo=%3C%3Eabc%20%2F")
+    })
+
+    test('remove undefined and null', async () => {
+      expect(await testQuery({ nullValue: null as any, undefinedValue: undefined, value: "bar" })).toEqual("value=bar")
+    })
+
+    test('remove undefined and null values in array', async () => {
+      expect(await testQuery({ foo: [null as any, "bar", undefined, "baz"] })).toEqual("foo=bar&foo=baz")
+    })
+
+    test('handle undefined variable map', async () => {
+      expect(await testQuery(undefined)).toBeNull()
+    })
+  })
+})


### PR DESCRIPTION
#### Summary

This PR fixes the serialization of Array query parameters and simplifies it by using the build in `querystring.stringify` function.

#### Description

Fixes #1462 

#### Todo

I tried to find a place where tests for this is written, but couldn't find any. Do you have a plan for unit testing the typescript-sdk? It would be helpful to prevent these sort of bugs. I know this bit is generated, but that doesn't mean it cannot contain bugs.

- Tests
  - [x] Unit
  - [ ] Integration
  - [ ] Acceptance
- [ ] Documentation
  <!-- Two persons should review a PR, don't forget to assign them. -->
