### PR TITLE
feat(sync/customers): add `setStores`

### DIFF
--- a/packages/sync-actions/src/customer-actions.js
+++ b/packages/sync-actions/src/customer-actions.js
@@ -31,6 +31,10 @@ export const baseActionsList = [
     key: 'defaultShippingAddressId',
     actionKey: 'addressId',
   },
+  {
+    action: 'setStores',
+    key: 'stores',
+  },
 ]
 
 export const referenceActionsList = [

--- a/packages/sync-actions/test/customer-sync.spec.js
+++ b/packages/sync-actions/test/customer-sync.spec.js
@@ -30,6 +30,10 @@ describe('Exports', () => {
         key: 'defaultShippingAddressId',
         actionKey: 'addressId',
       },
+      {
+        action: 'setStores',
+        key: 'stores',
+      },
     ])
   })
 
@@ -416,5 +420,44 @@ describe('Actions', () => {
       },
     ]
     expect(actual).toEqual(expected)
+  })
+
+  test('should build `setStores` action', () => {
+    const before = {
+      stores: [
+        {
+          typeId: 'store',
+          key: 'canada',
+        },
+      ],
+    }
+    const now = {
+      stores: [
+        {
+          typeId: 'store',
+          key: 'canada',
+        },
+        {
+          typeId: 'store',
+          key: 'usa',
+        },
+      ],
+    }
+    const actual = customerSync.buildActions(now, before)
+    expect(actual).toEqual([
+      {
+        action: 'setStores',
+        stores: [
+          {
+            typeId: 'store',
+            key: 'canada',
+          },
+          {
+            typeId: 'store',
+            key: 'usa',
+          },
+        ],
+      },
+    ])
   })
 })


### PR DESCRIPTION
#### Summary

- adds `setStores`. ref https://docs.commercetools.com/http-api-projects-customers#set-stores-beta
This is to prepare for a feature in the MC
