### PR TITLE
fix(csv-parser-price): handle error when variant-sku key is missing/mis-spelled

### DIFF
--- a/integration-tests/cli/csv-parser-price.it.js
+++ b/integration-tests/cli/csv-parser-price.it.js
@@ -91,7 +91,7 @@ describe('CSV and CLI Tests', () => {
         )
       } catch (error) {
         expect(error.code).toBe(1)
-        expect(String(error)).toMatch(/\.js:\d+:\d+/)
+        expect(String(error)).toMatch(/Row length does not match headers/)
       }
     })
 

--- a/packages/csv-parser-price/src/cli.js
+++ b/packages/csv-parser-price/src/cli.js
@@ -78,8 +78,9 @@ const logError = error => {
   const errorFormatter = new PrettyError()
 
   if (npmlog.level === 'verbose')
-    process.stderr.write(`ERR: ${errorFormatter.render(error)}`)
-  else process.stderr.write(`ERR: ${error.message || error}`)
+    process.stderr.write(`ERR: ${errorFormatter.render(error)} \n`)
+  // Add new line to make it intuitive
+  else process.stderr.write(`ERR: ${error.message || error} \n`) // Add new line to make it intuitive
 }
 
 const errorHandler = errors => {

--- a/packages/csv-parser-price/src/main.js
+++ b/packages/csv-parser-price/src/main.js
@@ -61,8 +61,25 @@ export default class CsvParserPrice {
           strict: true,
         })
       )
+      .map(a => {
+        if (!a[CONSTANTS.header.sku]) {
+          throw new Error(
+            `${CONSTANTS.header.sku} key is missing/mis-spelled in the csv header.`
+          )
+        }
+        return a
+      })
+      .errors((err, push) => {
+        push(err.message)
+      })
+      .stopOnError(err => {
+        this.logger.error(err)
+        output.emit('error', err)
+      })
       // Sort by SKU so later when reducing prices we can easily group by SKU
-      .sortBy((a, b) => a['variant-sku'].localeCompare(b['variant-sku']))
+      .sortBy((a, b) =>
+        a[CONSTANTS.header.sku].localeCompare(b[CONSTANTS.header.sku])
+      )
       // Limit amount of rows to be handled at the same time
       .batch(this.batchSize)
       .stopOnError(err => {

--- a/packages/csv-parser-price/test/helpers/invalid-sku-sample.csv
+++ b/packages/csv-parser-price/test/helpers/invalid-sku-sample.csv
@@ -1,0 +1,3 @@
+variandt-sku,value.currencyCode,value.centAmount
+123,EUR,4200
+123,EUR,4200

--- a/packages/csv-parser-price/test/main.spec.js
+++ b/packages/csv-parser-price/test/main.spec.js
@@ -240,6 +240,29 @@ describe('CsvParserPrice::parse', () => {
     })
   })
 
+  test('should exit and show appropriate message on missing Sku variant Header in CSV', () => {
+    return new Promise(done => {
+      const csvParserPrice = new CsvParserPrice({ apiConfig, logger })
+      const inputStream = fs.createReadStream(
+        path.join(__dirname, 'helpers/invalid-sku-sample.csv')
+      )
+
+      const spy = sinon.spy(csvParserPrice.logger, 'error')
+
+      const outputStream = streamtest.v2.toText(() => {
+        console.log(spy.args)
+        const errorString = spy.args[0][0].toString()
+        expect(spy.calledOnce).toBeTruthy()
+        expect(errorString).toMatch(
+          'variant-sku key is missing/mis-spelled in the csv header.'
+        )
+        csvParserPrice.logger.error.restore()
+        done()
+      })
+      csvParserPrice.parse(inputStream, outputStream)
+    })
+  })
+
   test('should exit on CSV parsing error', () => {
     return new Promise(done => {
       const csvParserPrice = new CsvParserPrice({ apiConfig, logger })

--- a/packages/csv-parser-price/test/main.spec.js
+++ b/packages/csv-parser-price/test/main.spec.js
@@ -250,7 +250,6 @@ describe('CsvParserPrice::parse', () => {
       const spy = sinon.spy(csvParserPrice.logger, 'error')
 
       const outputStream = streamtest.v2.toText(() => {
-        console.log(spy.args)
         const errorString = spy.args[0][0].toString()
         expect(spy.calledOnce).toBeTruthy()
         expect(errorString).toMatch(


### PR DESCRIPTION
### handle error when variant-sku header key is missing/mis-spelled

closes: #1442
