### PR TITLE
chore(typescript): move typescript check at package level from root

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "docs:publish": "npm run docs:clean && npm run docs:build && ./scripts/publish-docs",
     "typecheck": "yarn typecheck:flow && yarn typecheck:ts",
     "typecheck:flow": "flow check --include-warnings",
-    "typecheck:ts": "tsc --noEmit",
+    "typecheck:ts": "lerna run typecheck:ts",
     "package-readme-entry": "./scripts/package-readme-entry.sh"
   },
   "workspaces": [

--- a/packages/sdk-types/package.json
+++ b/packages/sdk-types/package.json
@@ -25,6 +25,7 @@
     "index.ts"
   ],
   "scripts": {
-    "build": "exit 0"
+    "build": "exit 0",
+    "typecheck:ts": "tsc --noEmit"
   }
 }

--- a/packages/sdk-types/tsconfig.json
+++ b/packages/sdk-types/tsconfig.json
@@ -1,4 +1,4 @@
 {
   "extends": "../../tsconfig.json",
-  "files": ["src/index.ts"]
+  "files": ["index.ts"]
 }

--- a/packages/typescript-sdk/package.json
+++ b/packages/typescript-sdk/package.json
@@ -28,6 +28,7 @@
     "dist"
   ],
   "scripts": {
+    "typecheck:ts": "tsc --noEmit",
     "prebuild": "rimraf dist/**",
     "build": "yarn build:bundles && yarn build:typings && yarn build:paths",
     "build:bundles": "cross-env NODE_ENV=production rollup -c ../../rollup.config.js -n TypescriptSdk -i ./src/index.ts",


### PR DESCRIPTION
#### Move typescript check at packages level from root

Lerna provide a way to call script from root project.
```
lerna run some-command
```
Lerna will look for  some-command inside all the package and if found will run.
