### PR TITLE
feat(sync-actions): add localized description for shipping methods

### DIFF
--- a/packages/sync-actions/src/shipping-methods-actions.js
+++ b/packages/sync-actions/src/shipping-methods-actions.js
@@ -10,6 +10,7 @@ export const baseActionsList = [
   { action: 'setKey', key: 'key' },
   { action: 'changeName', key: 'name' },
   { action: 'setDescription', key: 'description' },
+  { action: 'setLocalizedDescription', key: 'localizedDescription' },
   { action: 'changeIsDefault', key: 'isDefault' },
   { action: 'setPredicate', key: 'predicate' },
   { action: 'changeTaxCategory', key: 'taxCategory' },

--- a/packages/sync-actions/test/shipping-methods.spec.js
+++ b/packages/sync-actions/test/shipping-methods.spec.js
@@ -11,6 +11,7 @@ describe('Exports', () => {
       { action: 'setKey', key: 'key' },
       { action: 'changeName', key: 'name' },
       { action: 'setDescription', key: 'description' },
+      { action: 'setLocalizedDescription', key: 'localizedDescription' },
       { action: 'changeIsDefault', key: 'isDefault' },
       { action: 'setPredicate', key: 'predicate' },
       { action: 'changeTaxCategory', key: 'taxCategory' },
@@ -68,6 +69,29 @@ describe('Actions', () => {
         {
           action: 'setDescription',
           description: now.description,
+        },
+      ]
+      expect(actual).toEqual(expected)
+    })
+
+    test('should build `setLocalizedDescription` action', () => {
+      const before = {
+        localizedDescription: {
+          en: 'Custom description',
+        },
+      }
+      const now = {
+        localizedDescription: {
+          fr: 'Description personnalisée',
+          en: 'Custom description',
+        },
+      }
+
+      const actual = shippingMethodsSync.buildActions(now, before)
+      const expected = [
+        {
+          action: 'setLocalizedDescription',
+          localizedDescription: now.localizedDescription,
         },
       ]
       expect(actual).toEqual(expected)


### PR DESCRIPTION
#### Summary

Shipping methods now support a localized description. This decription is planned to eventually replace the non-localized description. As we intend to add this as a field to the MC we also need it in the sync-actions.

API Documentation: https://docs.commercetools.com/http-api-projects-shippingMethods#set-localized-description

The PR is fairly self explanatory I think. I just followed what's there and added a field.