### PR TITLE
fix(sync-actions): bug where we throw on empty assets in categories

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -1,5 +1,5 @@
 [version]
-^0.115.0
+^0.119.1
 
 [ignore]
 <PROJECT_ROOT>/_book/.*

--- a/packages/sync-actions/src/categories.js
+++ b/packages/sync-actions/src/categories.js
@@ -12,6 +12,7 @@ import actionsMapCustom from './utils/action-map-custom'
 import actionsMapAssets from './assets-actions'
 import * as categoryActions from './category-actions'
 import * as diffpatcher from './utils/diffpatcher'
+import copyEmptyArrayProps from './utils/copy-empty-array-props'
 
 export const actionGroups = ['base', 'references', 'meta', 'custom', 'assets']
 
@@ -80,6 +81,10 @@ export default (
     mapActionGroup,
     syncActionConfig
   )
-  const buildActions = createBuildActions(diffpatcher.diff, doMapActions)
+  const buildActions = createBuildActions(
+    diffpatcher.diff,
+    doMapActions,
+    copyEmptyArrayProps
+  )
   return { buildActions }
 }

--- a/packages/sync-actions/src/utils/copy-empty-array-props.js
+++ b/packages/sync-actions/src/utils/copy-empty-array-props.js
@@ -1,0 +1,23 @@
+/**
+ * @function copyEmptyArrayProps
+ * @deprecated Takes two objects and if there is Array props in oldObj which doesnt exist in newObj then it Copy name with empty value
+ * @param {Object} oldObj
+ * @param {Object} newObj
+ * @returns {Array} Inorder Array [oldObj, newObj]
+ */
+
+export default function copyEmptyArrayProps(oldObj, newObj) {
+  Object.entries(oldObj).forEach(([key, value]) => {
+    if (Array.isArray(value)) {
+      const foundKey = Object.keys(newObj).findIndex(
+        newObjKey => JSON.stringify(newObjKey) === JSON.stringify(key)
+      )
+
+      if (foundKey === -1) {
+        newObj[key] = [] // eslint-disable-line no-param-reassign
+      }
+    }
+  })
+
+  return [oldObj, newObj]
+}

--- a/packages/sync-actions/src/utils/copy-empty-array-props.js
+++ b/packages/sync-actions/src/utils/copy-empty-array-props.js
@@ -1,6 +1,6 @@
 /**
  * @function copyEmptyArrayProps
- * @deprecated Takes two objects and if there is Array props in oldObj which doesnt exist in newObj then it Copy name with empty value
+ * @description Takes two objects and if there is Array props in oldObj which doesnt exist in newObj then it Copy name with empty value
  * @param {Object} oldObj
  * @param {Object} newObj
  * @returns {Array} Inorder Array [oldObj, newObj]

--- a/packages/sync-actions/src/utils/copy-empty-array-props.js
+++ b/packages/sync-actions/src/utils/copy-empty-array-props.js
@@ -1,9 +1,9 @@
 /**
  * @function copyEmptyArrayProps
- * @description Takes two objects and if there is Array props in oldObj which doesnt exist in newObj then it Copy name with empty value
+ * @description Takes two objects and if there are Array props in oldObj which doesn't exist in newObj, then copy it with an empty value.
  * @param {Object} oldObj
  * @param {Object} newObj
- * @returns {Array} Inorder Array [oldObj, newObj]
+ * @returns {Array} Ordered Array [oldObj, newObj]
  */
 
 export default function copyEmptyArrayProps(oldObj, newObj) {

--- a/packages/sync-actions/test/category-sync.spec.js
+++ b/packages/sync-actions/test/category-sync.spec.js
@@ -233,7 +233,7 @@ describe('Actions', () => {
       expect(actual).toEqual(expected)
     })
 
-    test('should return empty array', () => {
+    test('should throw no exception on missing assets', () => {
       const before = {
         assets: [],
       }

--- a/packages/sync-actions/test/category-sync.spec.js
+++ b/packages/sync-actions/test/category-sync.spec.js
@@ -232,6 +232,16 @@ describe('Actions', () => {
       ]
       expect(actual).toEqual(expected)
     })
+
+    test('should return empty array', () => {
+      const before = {
+        assets: [],
+      }
+      const now = {}
+      const actual = categorySync.buildActions(now, before)
+      const expected = []
+      expect(actual).toEqual(expected)
+    })
   })
 
   test('should build "removeAsset" and "addAsset" action when asset is changed', () => {


### PR DESCRIPTION
#### Summary

Fix and Test sync-action 

#### Description

Fixing issue which happen with the below code
`
      const before = {
        assets: [],
      }
      const now = {
      }
      const actual = categorySync.buildActions(now, before)
`
the following error is thrown:
`
Cannot read property '0' of undefined
`

#### Todo

- Tests
  - [ x] Unit
  - [ ] Integration
  - [ ] Acceptance
- [ x] Documentation
  <!-- Two persons should review a PR, don't forget to assign them. -->
