### PR TITLE
feat(sync-actions): adding set key action for cart-discounts

### DIFF
--- a/packages/sync-actions/src/cart-discounts-actions.js
+++ b/packages/sync-actions/src/cart-discounts-actions.js
@@ -12,6 +12,7 @@ export const baseActionsList = [
   { action: 'setValidFrom', key: 'validFrom' },
   { action: 'setValidUntil', key: 'validUntil' },
   { action: 'changeStackingMode', key: 'stackingMode' },
+  { action: 'setKey', key: 'key' },
 ]
 
 export function actionsMapBase(diff, oldObj, newObj, config = {}) {

--- a/packages/sync-actions/test/cart-discounts-sync.spec.js
+++ b/packages/sync-actions/test/cart-discounts-sync.spec.js
@@ -94,6 +94,17 @@ describe('Cart Discounts Exports', () => {
         ])
       )
     })
+
+    test('should contain `setKey` action', () => {
+      expect(baseActionsList).toEqual(
+        expect.arrayContaining([
+          {
+            action: 'setKey',
+            key: 'key'
+          }
+        ])
+      )
+    })
   })
 })
 
@@ -414,6 +425,25 @@ describe('Cart Discounts Actions', () => {
         value: true,
       },
     ]
+    expect(actual).toEqual(expected)
+  })
+
+  test('should build the `setKey` action', () => {
+    const before = {
+      key: 'key-before'
+    }
+
+    const now = {
+      key: 'key-now'
+    }
+
+    const expected = [
+      {
+        action: 'setKey',
+        key: 'key-now'
+      }
+    ]
+    const actual = cartDiscountsSync.buildActions(now, before)
     expect(actual).toEqual(expected)
   })
 })


### PR DESCRIPTION
#### Summary
Add `setKey` to CartDiscounts list of actions

#### Description
Adding coverage to the cart discounts sync actions by detecting the `setKey` update action.
