### PR TITLE
fix(sync-actions): removing changeattributeorder remove or add is per…

### DIFF
--- a/packages/sync-actions/src/product-types-actions.js
+++ b/packages/sync-actions/src/product-types-actions.js
@@ -263,7 +263,6 @@ const generateChangeAttributeOrderAction = (
   updateActions = []
 ) => {
   if (!attrsOld.length || !attrsNew.length) return null
-
   const newAttributesOrder = attrsNew.map((attribute) => attribute.name)
 
   const removedAttributeNames = updateActions
@@ -300,13 +299,15 @@ export const actionsMapForHints = (nestedValuesChanges = {}, ptOld, ptNew) => {
     ),
   ]
 
-  const changeAttributeOrderAction = generateChangeAttributeOrderAction(
-    ptOld.attributes,
-    ptNew.attributes,
-    updateActions
-  )
-
-  if (changeAttributeOrderAction) updateActions.push(changeAttributeOrderAction)
+  if (!updateActions.length) {
+    const changeAttributeOrderAction = generateChangeAttributeOrderAction(
+      ptOld.attributes,
+      ptNew.attributes,
+      updateActions
+    )
+    if (changeAttributeOrderAction)
+      updateActions.push(changeAttributeOrderAction)
+  }
 
   return updateActions
 }

--- a/packages/sync-actions/test/product-types-sync-base.spec.js
+++ b/packages/sync-actions/test/product-types-sync-base.spec.js
@@ -225,7 +225,7 @@ describe('Actions', () => {
       ])
     })
 
-    test('should remove, add and change order of attributes', () => {
+    test('should remove, add but should not change order of attributes', () => {
       before = {
         name: 'Product Type',
         attributes: [
@@ -270,10 +270,6 @@ describe('Actions', () => {
           attribute: {
             name: 'attr4',
           },
-        },
-        {
-          action: 'changeAttributeOrderByName',
-          attributeNames: ['attr3', 'attr4', 'attr1'],
         },
       ])
     })


### PR DESCRIPTION
…formed

#### Summary

Removing the changeAttributeOrderByName action when remove or add action is previously performed. 

#### Description

This is related to the issue #1492 .

#### Todo

- Tests
- [ ] Unit
- [ ] Integration
- [ ] Acceptance
- [x] Documentation

