### PR TITLE
feat(sync-actions): add set key actions

### DIFF
--- a/packages/sync-actions/src/customer-actions.js
+++ b/packages/sync-actions/src/customer-actions.js
@@ -35,6 +35,7 @@ export const baseActionsList = [
     action: 'setStores',
     key: 'stores',
   },
+  { action: 'setKey', key: 'key' },
 ]
 
 export const referenceActionsList = [

--- a/packages/sync-actions/src/product-discounts-actions.js
+++ b/packages/sync-actions/src/product-discounts-actions.js
@@ -9,6 +9,7 @@ export const baseActionsList = [
   { action: 'setDescription', key: 'description' },
   { action: 'setValidFrom', key: 'validFrom' },
   { action: 'setValidUntil', key: 'validUntil' },
+  { action: 'setKey', key: 'key' },
 ]
 
 export function actionsMapBase(diff, oldObj, newObj, config = {}) {

--- a/packages/sync-actions/src/zones-actions.js
+++ b/packages/sync-actions/src/zones-actions.js
@@ -8,6 +8,7 @@ import { buildBaseAttributesActions } from './utils/common-actions'
 export const baseActionsList = [
   { action: 'changeName', key: 'name' },
   { action: 'setDescription', key: 'description' },
+  { action: 'setKey', key: 'key' },
 ]
 
 const hasLocation = (locations, otherLocation) =>

--- a/packages/sync-actions/test/cart-discounts-sync.spec.js
+++ b/packages/sync-actions/test/cart-discounts-sync.spec.js
@@ -430,17 +430,17 @@ describe('Cart Discounts Actions', () => {
 
   test('should build the `setKey` action', () => {
     const before = {
-      key: 'key-before'
+      key: 'key-before',
     }
 
     const now = {
-      key: 'key-now'
+      key: 'key-now',
     }
 
     const expected = [
       {
         action: 'setKey',
-        key: 'key-now'
+        key: 'key-now',
       }
     ]
     const actual = cartDiscountsSync.buildActions(now, before)

--- a/packages/sync-actions/test/customer-sync.spec.js
+++ b/packages/sync-actions/test/customer-sync.spec.js
@@ -34,6 +34,10 @@ describe('Exports', () => {
         action: 'setStores',
         key: 'stores',
       },
+      {
+        action: 'setKey',
+        key: 'key',
+      },
     ])
   })
 
@@ -457,6 +461,23 @@ describe('Actions', () => {
             key: 'usa',
           },
         ],
+      },
+    ])
+  })
+
+  test('should build `setKey` action', () => {
+    const before = {
+      key: 'key-before',
+    }
+
+    const now = {
+      key: 'key-now',
+    }
+    const actual = customerSync.buildActions(now, before)
+    expect(actual).toEqual([
+      {
+        action: 'setKey',
+        key: 'key-now',
       },
     ])
   })

--- a/packages/sync-actions/test/product-discounts-sync.spec.js
+++ b/packages/sync-actions/test/product-discounts-sync.spec.js
@@ -66,6 +66,12 @@ describe('Exports', () => {
         expect.arrayContaining([{ action: 'setValidUntil', key: 'validUntil' }])
       )
     })
+
+    test('should contain `setKey` action', () => {
+      expect(baseActionsList).toEqual(
+        expect.arrayContaining([{ action: 'setKey', key: 'key' }])
+      )
+    })
   })
 })
 
@@ -252,6 +258,25 @@ describe('Actions', () => {
         validFrom: 'date-2-From',
         validUntil: 'date-2-Until',
       },
+    ]
+    const actual = productDiscountsSync.buildActions(now, before)
+    expect(actual).toEqual(expected)
+  })
+
+  test('should build the `setKey` action', () => {
+    const before = {
+      key: 'key-before',
+    }
+
+    const now = {
+      key: 'key-now',
+    }
+
+    const expected = [
+      {
+        action: 'setKey',
+        key: 'key-now',
+      }
     ]
     const actual = productDiscountsSync.buildActions(now, before)
     expect(actual).toEqual(expected)

--- a/packages/sync-actions/test/zones.spec.js
+++ b/packages/sync-actions/test/zones.spec.js
@@ -10,6 +10,7 @@ describe('Exports', () => {
     expect(baseActionsList).toEqual([
       { action: 'changeName', key: 'name' },
       { action: 'setDescription', key: 'description' },
+      { action: 'setKey', key: 'key' },
     ])
   })
 })
@@ -47,6 +48,25 @@ describe('Actions', () => {
         action: 'setDescription',
         description: now.description,
       },
+    ]
+    expect(actual).toEqual(expected)
+  })
+
+  test('should build `setKey` action', () => {
+    const before = {
+      key: 'key-before',
+    }
+
+    const now = {
+      key: 'key-now',
+    }
+
+    const actual = zonesSync.buildActions(now, before)
+    const expected = [
+      {
+        action: 'setKey',
+        key: 'key-now',
+      }
     ]
     expect(actual).toEqual(expected)
   })


### PR DESCRIPTION
#### Summary

Adding `setkey` to `Product Discount`, `Customer` and `Zone`

#### Description

Adding the detection of the `setKey` action for the following resources:
- `Product Discount`
- `Customer` 
- `Zone`

Adding the corresponding tests for each resource type.