### PR TITLE
feat(api-request-builder): adding stores to the package

### DIFF
--- a/packages/api-request-builder/src/default-services.js
+++ b/packages/api-request-builder/src/default-services.js
@@ -345,6 +345,18 @@ export default {
       features.queryExpand,
     ],
   },
+  stores: {
+    type: 'stores',
+    endpoint: '/stores',
+    features: [
+      features.create,
+      features.update,
+      features.del,
+      features.query,
+      features.queryOne,
+      features.queryExpand,
+    ],
+  },
   subscriptions: {
     type: 'subscriptions',
     endpoint: '/subscriptions',

--- a/packages/api-request-builder/test/create-request-builder.spec.js
+++ b/packages/api-request-builder/test/create-request-builder.spec.js
@@ -37,6 +37,7 @@ const expectedServiceKeys = [
   'shippingMethods',
   'shoppingLists',
   'states',
+  'stores',
   'subscriptions',
   'taxCategories',
   'types',


### PR DESCRIPTION
#### Summary

Adding `stores` to `api-request-builder` package

#### Description

Currently the package does not support  `stores`  endpoint, this PR intends to add that coverage.