### PR TITLE
refactor(api-request-builder): rename createService argument

### DIFF
--- a/packages/api-request-builder/src/create-service.js
+++ b/packages/api-request-builder/src/create-service.js
@@ -44,7 +44,7 @@ function getIdOrKey(params: Object): string {
 
 export default function createService(
   definition: ServiceBuilderDefinition,
-  options: string = ''
+  projectKey: string = ''
 ): ServiceBuilder {
   if (!definition)
     throw new Error('Cannot create a service without its definition.')
@@ -57,7 +57,7 @@ export default function createService(
   if (!Array.isArray(definition.features) || !definition.features.length)
     throw new Error('Definition requires `features` to be a non empty array.')
 
-  if (!options)
+  if (!projectKey)
     throw new Error('No project defined. Please enter a project key')
 
   const { type, endpoint, features } = definition
@@ -132,7 +132,7 @@ export default function createService(
       const queryParams = buildQueryString(this.params)
 
       const uri =
-        (withProjectKey ? `/${options}` : '') +
+        (withProjectKey ? `/${projectKey}` : '') +
         endpoint +
         // TODO this can lead to invalid URIs as getIdOrKey can return
         //   "/?customerId", so there can be multiple question marks,


### PR DESCRIPTION
#### Summary

Renamed `options` to `projectKey`

#### Description

Changed the 2nd argument to `createService` function to `projectKey`. This makes it easy to read the code and understand, as against `options` which means an object.
affects: @commercetools/api-request-builder