### PR TITLE
fix(sync-actions): copy empty array props for products and variants

### DIFF
--- a/packages/sync-actions/src/products.js
+++ b/packages/sync-actions/src/products.js
@@ -125,8 +125,7 @@ function moveMasterVariantsIntoVariants(
   before: Object,
   now: Object
 ): Array<Object> {
-  /* eslint-disable no-param-reassign */
-  ;[before, now] = copyEmptyArrayProps(before, now)
+  const [beforeCopy, nowCopy] = copyEmptyArrayProps(before, now)
   const move = (obj: Object): Object => ({
     ...obj,
     masterVariant: undefined,
@@ -135,8 +134,8 @@ function moveMasterVariantsIntoVariants(
   const hasMasterVariant = (obj: Object): Object => obj && obj.masterVariant
 
   return [
-    hasMasterVariant(before) ? move(before) : before,
-    hasMasterVariant(now) ? move(now) : now,
+    hasMasterVariant(beforeCopy) ? move(beforeCopy) : beforeCopy,
+    hasMasterVariant(nowCopy) ? move(nowCopy) : nowCopy,
   ]
 }
 

--- a/packages/sync-actions/src/products.js
+++ b/packages/sync-actions/src/products.js
@@ -122,10 +122,11 @@ function createProductMapActions(
 }
 
 function moveMasterVariantsIntoVariants(
-  objectBefore: Object,
-  objectNow: Object
+  before: Object,
+  now: Object
 ): Array<Object> {
-  const [before, now] = copyEmptyArrayProps(objectBefore, objectNow)
+  /* eslint-disable no-param-reassign */
+  ;[before, now] = copyEmptyArrayProps(before, now)
   const move = (obj: Object): Object => ({
     ...obj,
     masterVariant: undefined,

--- a/packages/sync-actions/src/products.js
+++ b/packages/sync-actions/src/products.js
@@ -11,6 +11,7 @@ import createMapActionGroup from './utils/create-map-action-group'
 import * as productActions from './product-actions'
 import * as diffpatcher from './utils/diffpatcher'
 import findMatchingPairs from './utils/find-matching-pairs'
+import copyEmptyArrayProps from './utils/copy-empty-array-props'
 
 const actionGroups = [
   'base',
@@ -121,9 +122,10 @@ function createProductMapActions(
 }
 
 function moveMasterVariantsIntoVariants(
-  before: Object,
-  now: Object
+  objectBefore: Object,
+  objectNow: Object
 ): Array<Object> {
+  const [before, now] = copyEmptyArrayProps(objectBefore, objectNow)
   const move = (obj: Object): Object => ({
     ...obj,
     masterVariant: undefined,

--- a/packages/sync-actions/src/utils/copy-empty-array-props.js
+++ b/packages/sync-actions/src/utils/copy-empty-array-props.js
@@ -9,18 +9,15 @@ export default function copyEmptyArrayProps(oldObj, newObj) {
   const newObjWithFixedEmptyArray = Object.entries(oldObj).reduce(
     (acc, [key, value]) => {
       const isArray = Array.isArray(value)
+      const newObjectValueIsUndefined = newObj[key] === undefined
 
-      // check if the value is array on `oldObj` and the key not found in `acc` (newObjWithFixedEmptyArray)
-      if (isArray && acc[key] === undefined) {
-        // init `key` with empty array
+      if (isArray && newObjectValueIsUndefined) {
         return { ...acc, [key]: [] }
       }
 
-      // note that `typeof value === 'object'` returns true also in case of array
-      // check if its not array and its object
-      if (!isArray && typeof value === 'object' && acc[key]) {
+      if (!isArray && typeof value === 'object' && newObj[key]) {
         // recursion, so we could check for nested objects
-        const returnedNewObjCopy = copyEmptyArrayProps(value, acc[key])[1]
+        const returnedNewObjCopy = copyEmptyArrayProps(value, newObj[key])[1]
         return { ...acc, [key]: returnedNewObjCopy }
       }
 

--- a/packages/sync-actions/src/utils/copy-empty-array-props.js
+++ b/packages/sync-actions/src/utils/copy-empty-array-props.js
@@ -17,6 +17,7 @@ export default function copyEmptyArrayProps(oldObj, newObj) {
         newObj[key] = [] // eslint-disable-line no-param-reassign
       }
     } else if (typeof value === 'object' && oldObj[key] && newObj[key]) {
+      // recursion, so we could check for nested objects
       copyEmptyArrayProps(oldObj[key], newObj[key])
     }
   })

--- a/packages/sync-actions/src/utils/copy-empty-array-props.js
+++ b/packages/sync-actions/src/utils/copy-empty-array-props.js
@@ -1,35 +1,3 @@
-const deepCopyObj = (obj) => JSON.parse(JSON.stringify(obj))
-
-const copyEmptyArrayPropsRecursion = (oldObjCopy, newObjCopy) => {
-  const newObjCopyOne = Object.entries(oldObjCopy).reduce(
-    (acc, [key, value]) => {
-      // check if the value is array on `oldObjCopy`
-      if (Array.isArray(value)) {
-        const foundKey = Object.keys(acc).findIndex(
-          (accKey) => JSON.stringify(accKey) === JSON.stringify(key)
-        )
-
-        // if the key not found in `acc` (newObjectCopy)
-        if (foundKey === -1) {
-          return { ...acc, [key]: [] }
-        }
-      } else if (typeof value === 'object' && acc[key]) {
-        // recursion, so we could check for nested objects
-        const returnedNewObjCopy = copyEmptyArrayPropsRecursion(
-          value,
-          acc[key]
-        )[1]
-        return { ...acc, [key]: returnedNewObjCopy }
-      }
-
-      return acc
-    },
-    { ...newObjCopy }
-  )
-
-  return [oldObjCopy, newObjCopyOne]
-}
-
 /**
  * @function copyEmptyArrayProps
  * @description Takes two objects and if there are Array props in oldObj which doesn't exist in newObj, then copy it with an empty value.
@@ -39,8 +7,28 @@ const copyEmptyArrayPropsRecursion = (oldObjCopy, newObjCopy) => {
  */
 
 export default function copyEmptyArrayProps(oldObj, newObj) {
-  const oldObjCopy = deepCopyObj(oldObj)
-  const newObjCopy = deepCopyObj(newObj)
+  const newObjCopy = Object.entries(oldObj).reduce(
+    (acc, [key, value]) => {
+      // check if the value is array on `oldObj`
+      if (Array.isArray(value)) {
+        const foundKey = Object.keys(acc).findIndex(
+          (accKey) => JSON.stringify(accKey) === JSON.stringify(key)
+        )
 
-  return copyEmptyArrayPropsRecursion(oldObjCopy, newObjCopy)
+        // if the key not found in `acc` (newObjectCopy), init `key` with empty array
+        if (foundKey === -1) {
+          return { ...acc, [key]: [] }
+        }
+      } else if (typeof value === 'object' && acc[key]) {
+        // recursion, so we could check for nested objects
+        const returnedNewObjCopy = copyEmptyArrayProps(value, acc[key])[1]
+        return { ...acc, [key]: returnedNewObjCopy }
+      }
+
+      return acc
+    },
+    { ...newObj }
+  )
+
+  return [oldObj, newObjCopy]
 }

--- a/packages/sync-actions/src/utils/copy-empty-array-props.js
+++ b/packages/sync-actions/src/utils/copy-empty-array-props.js
@@ -16,6 +16,8 @@ export default function copyEmptyArrayProps(oldObj, newObj) {
       if (foundKey === -1) {
         newObj[key] = [] // eslint-disable-line no-param-reassign
       }
+    } else if (typeof value === 'object' && oldObj[key] && newObj[key]) {
+      copyEmptyArrayProps(oldObj[key], newObj[key])
     }
   })
 

--- a/packages/sync-actions/src/utils/copy-empty-array-props.js
+++ b/packages/sync-actions/src/utils/copy-empty-array-props.js
@@ -1,3 +1,28 @@
+const deepCopyObj = (obj) => JSON.parse(JSON.stringify(obj))
+
+const copyEmptyArrayPropsRecursion = (oldObjCopy, newObjCopy) => {
+  Object.entries(oldObjCopy).forEach(([key, value]) => {
+    if (Array.isArray(value)) {
+      const foundKey = Object.keys(newObjCopy).findIndex(
+        (newObjCopyKey) => JSON.stringify(newObjCopyKey) === JSON.stringify(key)
+      )
+
+      if (foundKey === -1) {
+        newObjCopy[key] = [] // eslint-disable-line no-param-reassign
+      }
+    } else if (
+      typeof value === 'object' &&
+      oldObjCopy[key] &&
+      newObjCopy[key]
+    ) {
+      // recursion, so we could check for nested objects
+      copyEmptyArrayPropsRecursion(oldObjCopy[key], newObjCopy[key])
+    }
+  })
+
+  return [oldObjCopy, newObjCopy]
+}
+
 /**
  * @function copyEmptyArrayProps
  * @description Takes two objects and if there are Array props in oldObj which doesn't exist in newObj, then copy it with an empty value.
@@ -7,20 +32,8 @@
  */
 
 export default function copyEmptyArrayProps(oldObj, newObj) {
-  Object.entries(oldObj).forEach(([key, value]) => {
-    if (Array.isArray(value)) {
-      const foundKey = Object.keys(newObj).findIndex(
-        (newObjKey) => JSON.stringify(newObjKey) === JSON.stringify(key)
-      )
+  const oldObjCopy = deepCopyObj(oldObj)
+  const newObjCopy = deepCopyObj(newObj)
 
-      if (foundKey === -1) {
-        newObj[key] = [] // eslint-disable-line no-param-reassign
-      }
-    } else if (typeof value === 'object' && oldObj[key] && newObj[key]) {
-      // recursion, so we could check for nested objects
-      copyEmptyArrayProps(oldObj[key], newObj[key])
-    }
-  })
-
-  return [oldObj, newObj]
+  return copyEmptyArrayPropsRecursion(oldObjCopy, newObjCopy)
 }

--- a/packages/sync-actions/src/utils/copy-empty-array-props.js
+++ b/packages/sync-actions/src/utils/copy-empty-array-props.js
@@ -7,19 +7,19 @@
  */
 
 export default function copyEmptyArrayProps(oldObj, newObj) {
-  const newObjCopy = Object.entries(oldObj).reduce(
+  const newObjWithFixedEmptyArray = Object.entries(oldObj).reduce(
     (acc, [key, value]) => {
-      // check if the value is array on `oldObj`
-      if (Array.isArray(value)) {
-        const foundKey = Object.keys(acc).findIndex(
-          (accKey) => JSON.stringify(accKey) === JSON.stringify(key)
-        )
+      const isArray = Array.isArray(value)
 
-        // if the key not found in `acc` (newObjectCopy), init `key` with empty array
-        if (foundKey === -1) {
-          return { ...acc, [key]: [] }
-        }
-      } else if (typeof value === 'object' && acc[key]) {
+      // check if the value is array on `oldObj` and the key not found in `acc` (newObjWithFixedEmptyArray)
+      if (isArray && acc[key] === undefined) {
+        // init `key` with empty array
+        return { ...acc, [key]: [] }
+      }
+
+      // note that `typeof value === 'object'` returns true also in case of array
+      // check if its not array and its object
+      if (!isArray && typeof value === 'object' && acc[key]) {
         // recursion, so we could check for nested objects
         const returnedNewObjCopy = copyEmptyArrayProps(value, acc[key])[1]
         return { ...acc, [key]: returnedNewObjCopy }
@@ -30,5 +30,5 @@ export default function copyEmptyArrayProps(oldObj, newObj) {
     { ...newObj }
   )
 
-  return [oldObj, newObjCopy]
+  return [oldObj, newObjWithFixedEmptyArray]
 }

--- a/packages/sync-actions/src/utils/copy-empty-array-props.js
+++ b/packages/sync-actions/src/utils/copy-empty-array-props.js
@@ -1,26 +1,33 @@
 const deepCopyObj = (obj) => JSON.parse(JSON.stringify(obj))
 
 const copyEmptyArrayPropsRecursion = (oldObjCopy, newObjCopy) => {
-  Object.entries(oldObjCopy).forEach(([key, value]) => {
-    if (Array.isArray(value)) {
-      const foundKey = Object.keys(newObjCopy).findIndex(
-        (newObjCopyKey) => JSON.stringify(newObjCopyKey) === JSON.stringify(key)
-      )
+  const newObjCopyOne = Object.entries(oldObjCopy).reduce(
+    (acc, [key, value]) => {
+      // check if the value is array on `oldObjCopy`
+      if (Array.isArray(value)) {
+        const foundKey = Object.keys(acc).findIndex(
+          (accKey) => JSON.stringify(accKey) === JSON.stringify(key)
+        )
 
-      if (foundKey === -1) {
-        newObjCopy[key] = [] // eslint-disable-line no-param-reassign
+        // if the key not found in `acc` (newObjectCopy)
+        if (foundKey === -1) {
+          return { ...acc, [key]: [] }
+        }
+      } else if (typeof value === 'object' && acc[key]) {
+        // recursion, so we could check for nested objects
+        const returnedNewObjCopy = copyEmptyArrayPropsRecursion(
+          value,
+          acc[key]
+        )[1]
+        return { ...acc, [key]: returnedNewObjCopy }
       }
-    } else if (
-      typeof value === 'object' &&
-      oldObjCopy[key] &&
-      newObjCopy[key]
-    ) {
-      // recursion, so we could check for nested objects
-      copyEmptyArrayPropsRecursion(oldObjCopy[key], newObjCopy[key])
-    }
-  })
 
-  return [oldObjCopy, newObjCopy]
+      return acc
+    },
+    { ...newObjCopy }
+  )
+
+  return [oldObjCopy, newObjCopyOne]
 }
 
 /**

--- a/packages/sync-actions/test/product-sync-variants.spec.js
+++ b/packages/sync-actions/test/product-sync-variants.spec.js
@@ -988,6 +988,7 @@ describe('Actions', () => {
       masterVariant: {
         id: 1,
         key: 'default-masterVariant-key-de07e9bc-e352-422f-abe6-910d9879b995',
+        isMasterVariant: true,
         prices: [],
         images: [],
         attributes: [],
@@ -1000,25 +1001,12 @@ describe('Actions', () => {
         id: 1,
         key: 'default-masterVariant-key-de07e9bc-e352-422f-abe6-910d9879b995',
         isMasterVariant: true,
-        attributes: [
-          {
-            name: 'ct-imp-bool',
-            value: true,
-          },
-        ],
       },
     }
 
-    const actions = productsSync.buildActions(now, before)
+    productsSync.buildActions(now, before)
 
-    expect(actions).toEqual([
-      {
-        action: 'setAttribute',
-        variantId: 1,
-        name: 'ct-imp-bool',
-        value: true,
-      },
-    ])
+    expect(before).toMatchObject(now)
   })
 
   describe('assets', () => {

--- a/packages/sync-actions/test/product-sync-variants.spec.js
+++ b/packages/sync-actions/test/product-sync-variants.spec.js
@@ -982,57 +982,9 @@ describe('Actions', () => {
     ])
   })
 
-  test('update product-variant', async () => {
-    const now = {
-      name: {
-        en: 'Default Product d58a25cf-30d3-4988-bc3a-42ec7c22723d',
-      },
-      categories: [],
-      categoryOrderHints: {},
-      slug: {
-        en: 'product-d58a25cf-30d3-4988-bc3a-42ec7c22723d-slug',
-      },
-      masterVariant: {
-        attributes: [
-          {
-            name: 'ct-imp-bool',
-            value: true,
-          },
-        ],
-        id: 1,
-        key: 'default-masterVariant-key-de07e9bc-e352-422f-abe6-910d9879b995',
-        isMasterVariant: true,
-      },
-      variants: [
-        {
-          id: 2,
-          key: 'default-firstVariant-key-474276e6-56e1-467b-a67a-2c4494a848fa',
-          prices: [],
-          images: [],
-          attributes: [],
-          assets: [],
-        },
-        {
-          id: 3,
-          key: 'default-secondVariant-key-d490cbd6-4236-4928-92c5-79e9ff5962c7',
-          prices: [],
-          images: [],
-          attributes: [],
-          assets: [],
-        },
-      ],
-      searchKeywords: {},
-    }
-
+  test('shouldnt thow `TypeError: Cannot read property 0 of undefined` if array props exist on before and doesnt exist on now object', async () => {
     const before = {
-      name: {
-        en: 'Default Product d58a25cf-30d3-4988-bc3a-42ec7c22723d',
-      },
       categories: [],
-      categoryOrderHints: {},
-      slug: {
-        en: 'product-d58a25cf-30d3-4988-bc3a-42ec7c22723d-slug',
-      },
       masterVariant: {
         id: 1,
         key: 'default-masterVariant-key-de07e9bc-e352-422f-abe6-910d9879b995',
@@ -1041,28 +993,22 @@ describe('Actions', () => {
         attributes: [],
         assets: [],
       },
-      variants: [
-        {
-          id: 2,
-          key: 'default-firstVariant-key-474276e6-56e1-467b-a67a-2c4494a848fa',
-          prices: [],
-          images: [],
-          attributes: [],
-          assets: [],
-        },
-        {
-          id: 3,
-          key: 'default-secondVariant-key-d490cbd6-4236-4928-92c5-79e9ff5962c7',
-          prices: [],
-          images: [],
-          attributes: [],
-          assets: [],
-        },
-      ],
-      searchKeywords: {},
     }
 
-    /* eslint-enable max-len */
+    const now = {
+      masterVariant: {
+        id: 1,
+        key: 'default-masterVariant-key-de07e9bc-e352-422f-abe6-910d9879b995',
+        isMasterVariant: true,
+        attributes: [
+          {
+            name: 'ct-imp-bool',
+            value: true,
+          },
+        ],
+      },
+    }
+
     const actions = productsSync.buildActions(now, before)
 
     expect(actions).toEqual([

--- a/packages/sync-actions/test/product-sync-variants.spec.js
+++ b/packages/sync-actions/test/product-sync-variants.spec.js
@@ -982,7 +982,7 @@ describe('Actions', () => {
     ])
   })
 
-  test('shouldnt thow `TypeError: Cannot read property 0 of undefined` if array props exist on before and doesnt exist on now object', async () => {
+  test('should build `setAttribute` action', async () => {
     const before = {
       categories: [],
       masterVariant: {
@@ -1001,12 +1001,25 @@ describe('Actions', () => {
         id: 1,
         key: 'default-masterVariant-key-de07e9bc-e352-422f-abe6-910d9879b995',
         isMasterVariant: true,
+        attributes: [
+          {
+            name: 'ct-imp-bool',
+            value: true,
+          },
+        ],
       },
     }
 
-    productsSync.buildActions(now, before)
+    const actions = productsSync.buildActions(now, before)
 
-    expect(before).toMatchObject(now)
+    expect(actions).toEqual([
+      {
+        action: 'setAttribute',
+        variantId: 1,
+        name: 'ct-imp-bool',
+        value: true,
+      },
+    ])
   })
 
   describe('assets', () => {

--- a/packages/sync-actions/test/product-sync-variants.spec.js
+++ b/packages/sync-actions/test/product-sync-variants.spec.js
@@ -982,6 +982,99 @@ describe('Actions', () => {
     ])
   })
 
+  test('update product-variant', async () => {
+    const now = {
+      name: {
+        en: 'Default Product d58a25cf-30d3-4988-bc3a-42ec7c22723d',
+      },
+      categories: [],
+      categoryOrderHints: {},
+      slug: {
+        en: 'product-d58a25cf-30d3-4988-bc3a-42ec7c22723d-slug',
+      },
+      masterVariant: {
+        attributes: [
+          {
+            name: 'ct-imp-bool',
+            value: true,
+          },
+        ],
+        id: 1,
+        key: 'default-masterVariant-key-de07e9bc-e352-422f-abe6-910d9879b995',
+        isMasterVariant: true,
+      },
+      variants: [
+        {
+          id: 2,
+          key: 'default-firstVariant-key-474276e6-56e1-467b-a67a-2c4494a848fa',
+          prices: [],
+          images: [],
+          attributes: [],
+          assets: [],
+        },
+        {
+          id: 3,
+          key: 'default-secondVariant-key-d490cbd6-4236-4928-92c5-79e9ff5962c7',
+          prices: [],
+          images: [],
+          attributes: [],
+          assets: [],
+        },
+      ],
+      searchKeywords: {},
+    }
+
+    const before = {
+      name: {
+        en: 'Default Product d58a25cf-30d3-4988-bc3a-42ec7c22723d',
+      },
+      categories: [],
+      categoryOrderHints: {},
+      slug: {
+        en: 'product-d58a25cf-30d3-4988-bc3a-42ec7c22723d-slug',
+      },
+      masterVariant: {
+        id: 1,
+        key: 'default-masterVariant-key-de07e9bc-e352-422f-abe6-910d9879b995',
+        prices: [],
+        images: [],
+        attributes: [],
+        assets: [],
+      },
+      variants: [
+        {
+          id: 2,
+          key: 'default-firstVariant-key-474276e6-56e1-467b-a67a-2c4494a848fa',
+          prices: [],
+          images: [],
+          attributes: [],
+          assets: [],
+        },
+        {
+          id: 3,
+          key: 'default-secondVariant-key-d490cbd6-4236-4928-92c5-79e9ff5962c7',
+          prices: [],
+          images: [],
+          attributes: [],
+          assets: [],
+        },
+      ],
+      searchKeywords: {},
+    }
+
+    /* eslint-enable max-len */
+    const actions = productsSync.buildActions(now, before)
+
+    expect(actions).toEqual([
+      {
+        action: 'setAttribute',
+        variantId: 1,
+        name: 'ct-imp-bool',
+        value: true,
+      },
+    ])
+  })
+
   describe('assets', () => {
     test('should build "addAsset" action with empty assets', () => {
       const before = {

--- a/packages/sync-actions/test/utils/copy-empty-array-props.spec.js
+++ b/packages/sync-actions/test/utils/copy-empty-array-props.spec.js
@@ -7,9 +7,114 @@ test('should add empty array for undefined prop', () => {
   }
   const newObj = {
     anotherProp: 2,
+    newObjProp: true,
   }
   const [old, fixedNewObj] = copyEmptyArrayProps(oldObj, newObj)
 
   expect(old).toEqual(oldObj)
   expect(fixedNewObj).toEqual({ ...newObj, emptyArray: [] })
+})
+
+test('should add empty array for `nestedObject`', () => {
+  const oldObj = {
+    emptyArray: [],
+    nestedObject: {
+      anotherProp: 1,
+      nestedEmptyArray: [],
+    },
+    anotherProp: 1,
+  }
+
+  const newObj = {
+    nestedObject: {},
+    anotherProp: 2,
+  }
+
+  const [old, fixedNewObj] = copyEmptyArrayProps(oldObj, newObj)
+
+  expect(old).toEqual(oldObj)
+  expect(fixedNewObj).toEqual({
+    ...newObj,
+    emptyArray: [],
+    nestedObject: {
+      nestedEmptyArray: [],
+    },
+  })
+})
+
+test('shouldnt copy `nestedEmptyArrayOne` since parent key not found on `newObj`', () => {
+  const oldObj = {
+    nestedObject: {
+      anotherProp: 1,
+      nestedObjectOne: {
+        anotherPropOne: 1,
+        nestedEmptyArrayOne: [],
+      },
+    },
+    anotherProp: 1,
+  }
+
+  const newObj = {
+    nestedObject: {},
+    anotherProp: 2,
+  }
+  const [old, fixedNewObj] = copyEmptyArrayProps(oldObj, newObj)
+
+  expect(old).toEqual(oldObj)
+  expect(fixedNewObj).toEqual(newObj)
+})
+
+test('should add empty array for `nestedObject`, `nestedObjectOne`', () => {
+  const oldObj = {
+    emptyArray: [],
+    nestedObject: {
+      anotherProp: 1,
+      nestedEmptyArray: [],
+      nestedObjectOne: {
+        anotherPropOne: 1,
+        nestedEmptyArrayOne: [],
+      },
+    },
+    anotherProp: 1,
+  }
+
+  const newObj = {
+    nestedObject: {
+      nestedObjectOne: {
+        anotherPropOne: 2,
+      },
+    },
+    anotherProp: 2,
+  }
+  const [old, fixedNewObj] = copyEmptyArrayProps(oldObj, newObj)
+
+  expect(old).toEqual(oldObj)
+  expect(fixedNewObj).toEqual({
+    ...newObj,
+    emptyArray: [],
+    nestedObject: {
+      nestedEmptyArray: [],
+      nestedObjectOne: {
+        anotherPropOne: 2,
+        nestedEmptyArrayOne: [],
+      },
+    },
+  })
+})
+
+test('shouldnt mutate `newObj`', () => {
+  const oldObj = {
+    emptyArray: [],
+    anotherProp: 1,
+  }
+
+  const newObj = {
+    anotherProp: 2,
+  }
+
+  const [old, fixedNewObj] = copyEmptyArrayProps(oldObj, newObj)
+
+  expect(old).toEqual(oldObj)
+  expect(fixedNewObj).toEqual({ ...newObj, emptyArray: [] })
+  expect(newObj).toEqual({ anotherProp: 2 })
 })


### PR DESCRIPTION
#### Summary
Fix sync actions (products and variants)

#### Description

Make sure to copy empty array props for products and variants between old object and new object while updating to avoid this error `TypeError: Cannot read property '0' of undefined` 


