### PR TITLE
fix(sync-actions): remove side effect from copyEmptyArrayProps function

### DIFF
--- a/packages/sync-actions/src/utils/copy-empty-array-props.js
+++ b/packages/sync-actions/src/utils/copy-empty-array-props.js
@@ -5,19 +5,12 @@
  * @param {Object} newObj
  * @returns {Array} Ordered Array [oldObj, newObj]
  */
-
 export default function copyEmptyArrayProps(oldObj, newObj) {
-  Object.entries(oldObj).forEach(([key, value]) => {
-    if (Array.isArray(value)) {
-      const foundKey = Object.keys(newObj).findIndex(
-        (newObjKey) => JSON.stringify(newObjKey) === JSON.stringify(key)
-      )
-
-      if (foundKey === -1) {
-        newObj[key] = [] // eslint-disable-line no-param-reassign
-      }
-    }
+  const entriesWithEmptyArrays = Object.entries(oldObj).map(([key, value]) => {
+    const replaceWithEmptyArray =
+      Array.isArray(value) && newObj[key] === undefined
+    return [key, replaceWithEmptyArray ? [] : newObj[key]]
   })
 
-  return [oldObj, newObj]
+  return [oldObj, Object.fromEntries(entriesWithEmptyArrays)]
 }

--- a/packages/sync-actions/src/utils/copy-empty-array-props.js
+++ b/packages/sync-actions/src/utils/copy-empty-array-props.js
@@ -6,7 +6,7 @@
  * @returns {Array} Ordered Array [oldObj, newObj]
  */
 export default function copyEmptyArrayProps(oldObj, newObj) {
-  const entriesWithEmptyArrays = Object.entries(oldObj).reduce(
+  const newObjWithFixedEmptyArray = Object.entries(oldObj).reduce(
     (acc, [key, value]) => {
       const replaceWithEmptyArray =
         Array.isArray(value) && newObj[key] === undefined
@@ -16,5 +16,5 @@ export default function copyEmptyArrayProps(oldObj, newObj) {
     {}
   )
 
-  return [oldObj, entriesWithEmptyArrays]
+  return [oldObj, newObjWithFixedEmptyArray]
 }

--- a/packages/sync-actions/src/utils/copy-empty-array-props.js
+++ b/packages/sync-actions/src/utils/copy-empty-array-props.js
@@ -6,11 +6,15 @@
  * @returns {Array} Ordered Array [oldObj, newObj]
  */
 export default function copyEmptyArrayProps(oldObj, newObj) {
-  const entriesWithEmptyArrays = Object.entries(oldObj).map(([key, value]) => {
-    const replaceWithEmptyArray =
-      Array.isArray(value) && newObj[key] === undefined
-    return [key, replaceWithEmptyArray ? [] : newObj[key]]
-  })
+  const entriesWithEmptyArrays = Object.entries(oldObj).reduce(
+    (acc, [key, value]) => {
+      const replaceWithEmptyArray =
+        Array.isArray(value) && newObj[key] === undefined
+      acc[key] = replaceWithEmptyArray ? [] : newObj[key]
+      return acc
+    },
+    {}
+  )
 
-  return [oldObj, Object.fromEntries(entriesWithEmptyArrays)]
+  return [oldObj, entriesWithEmptyArrays]
 }

--- a/packages/sync-actions/test/utils/copy-empty-array-props.spec.js
+++ b/packages/sync-actions/test/utils/copy-empty-array-props.spec.js
@@ -1,0 +1,15 @@
+import copyEmptyArrayProps from '../../src/utils/copy-empty-array-props'
+
+test('should add empty array for undefined prop', () => {
+  const oldObj = {
+    emptyArray: [],
+    anotherProp: 1,
+  }
+  const newObj = {
+    anotherProp: 2,
+  }
+  const [old, fixedNewObj] = copyEmptyArrayProps(oldObj, newObj)
+
+  expect(old).toEqual(oldObj)
+  expect(fixedNewObj).toEqual({ ...newObj, emptyArray: [] })
+})


### PR DESCRIPTION
#### Summary

This PR removes the side effect from our `copyEmptyArrayProps` function.
