### PR TITLE
fix: use reduce instead of fromPairs

### DIFF
--- a/packages/sync-actions/src/utils/copy-empty-array-props.js
+++ b/packages/sync-actions/src/utils/copy-empty-array-props.js
@@ -6,7 +6,7 @@
  * @returns {Array} Ordered Array [oldObj, newObj]
  */
 export default function copyEmptyArrayProps(oldObj, newObj) {
-  const entriesWithEmptyArrays = Object.entries(oldObj).reduce(
+  const newObjWithFixedEmptyArray = Object.entries(oldObj).reduce(
     (acc, [key, value]) => {
       const replaceWithEmptyArray =
         Array.isArray(value) && newObj[key] === undefined
@@ -16,5 +16,5 @@ export default function copyEmptyArrayProps(oldObj, newObj) {
     {}
   )
 
-  return [oldObj, entriesWithEmptyArrays]
+  return [oldObj, newObjWithFixedEmptyArray]
 }

--- a/packages/sync-actions/src/utils/copy-empty-array-props.js
+++ b/packages/sync-actions/src/utils/copy-empty-array-props.js
@@ -6,11 +6,15 @@
  * @returns {Array} Ordered Array [oldObj, newObj]
  */
 export default function copyEmptyArrayProps(oldObj, newObj) {
-  const entriesWithEmptyArrays = Object.entries(oldObj).map(([key, value]) => {
-    const replaceWithEmptyArray =
-      Array.isArray(value) && newObj[key] === undefined
-    return [key, replaceWithEmptyArray ? [] : newObj[key]]
-  })
+  const entriesWithEmptyArrays = Object.entries(oldObj).reduce(
+    (acc, [key, value]) => {
+      const replaceWithEmptyArray =
+        Array.isArray(value) && newObj[key] === undefined
+      acc[key] = replaceWithEmptyArray ? [] : newObj[key]
+      return acc
+    },
+    {}
+  )
 
-  return [oldObj, Object.fromEntries(entriesWithEmptyArrays)]
+  return [oldObj, entriesWithEmptyArrays]
 }


### PR DESCRIPTION
I saw that the tests failed since node 10 didn't support `fromEntries`. PR stops relying on this function and instead builds the object with help of reduce.