### PR TITLE
feat(sync-actions/stores): add `setDistributionChannels`

### DIFF
--- a/packages/sync-actions/src/stores-actions.js
+++ b/packages/sync-actions/src/stores-actions.js
@@ -3,6 +3,7 @@ import { buildBaseAttributesActions } from './utils/common-actions'
 export const baseActionsList = [
   { action: 'setName', key: 'name' },
   { action: 'setLanguages', key: 'languages' },
+  { action: 'setDistributionChannels', key: 'distributionChannels' },
 ]
 
 export function actionsMapBase(diff, oldObj, newObj) {

--- a/packages/sync-actions/test/stores-sync.spec.js
+++ b/packages/sync-actions/test/stores-sync.spec.js
@@ -10,6 +10,7 @@ describe('Exports', () => {
     expect(baseActionsList).toEqual([
       { action: 'setName', key: 'name' },
       { action: 'setLanguages', key: 'languages' },
+      { action: 'setDistributionChannels', key: 'distributionChannels' },
     ])
   })
 })
@@ -44,5 +45,36 @@ describe('Actions', () => {
     const actual = storesSync.buildActions(now, before)
     const expected = [{ action: 'setLanguages', languages: now.languages }]
     expect(actual).toEqual(expected)
+  })
+
+  test('should build `setDistributionsChannels` action', () => {
+    const before = {
+      distributionChannels: [
+        {
+          typeId: 'product-distribution',
+          id: 'pd-001',
+        },
+      ],
+    }
+    const now = {
+      distributionChannels: [
+        {
+          typeId: 'product-distribution',
+          id: 'pd-001',
+        },
+        {
+          typeId: 'product-distribution',
+          key: 'pd-002',
+        },
+      ],
+    }
+
+    const actual = storesSync.buildActions(now, before)
+    expect(actual).toEqual([
+      {
+        action: 'setDistributionChannels',
+        distributionChannels: now.distributionChannels,
+      },
+    ])
   })
 })


### PR DESCRIPTION
#### Summary

- adds support `setDistributionChannels` 

#### Description

Context added this update-action recently to the Stores API.
It may look like it is not documented. It is documented, however we are waiting for the MC feature to be released before we release the documentation.

please view.