### PR TITLE
fix(csv-parser-price): handle UTF-8 with BOM encoding while price import

### DIFF
--- a/packages/csv-parser-price/package.json
+++ b/packages/csv-parser-price/package.json
@@ -55,7 +55,8 @@
     "node-fetch": "^2.3.0",
     "npmlog": "^4.1.2",
     "pretty-error": "^2.1.1",
-    "yargs": "^15.0.0"
+    "yargs": "^15.0.0",
+    "strip-bom-stream": "^4.0.0"
   },
   "devDependencies": {
     "sinon": "9.0.0",

--- a/packages/csv-parser-price/src/main.js
+++ b/packages/csv-parser-price/src/main.js
@@ -7,6 +7,7 @@ import memoize from 'lodash.memoize'
 import isNil from 'lodash.isnil'
 import { unflatten } from 'flat'
 import fetch from 'node-fetch'
+import stripBom from 'strip-bom-stream'
 
 import { createAuthMiddlewareForClientCredentialsFlow } from '@commercetools/sdk-middleware-auth'
 import { createClient } from '@commercetools/sdk-client'
@@ -55,6 +56,7 @@ export default class CsvParserPrice {
 
     highland(input)
       // Parse CSV return each row as object
+      .through(stripBom())
       .through(
         csv({
           separator: this.delimiter,

--- a/packages/csv-parser-price/test/helpers/utf-bom.csv
+++ b/packages/csv-parser-price/test/helpers/utf-bom.csv
@@ -1,0 +1,3 @@
+﻿variant-sku,value.currencyCode,value.centAmount
+first_testing,EUR,1000
+last_testing,EUR,1000

--- a/packages/csv-parser-price/test/main.spec.js
+++ b/packages/csv-parser-price/test/main.spec.js
@@ -71,6 +71,31 @@ describe('CsvParserPrice::parse', () => {
     })
   })
 
+  test('should parse the UTF-8 BOM encoding file', () => {
+    return new Promise((done) => {
+      const csvParserPrice = new CsvParserPrice({ apiConfig, logger })
+      const readStream = fs.createReadStream(
+        path.join(__dirname, 'helpers/utf-bom.csv')
+      )
+
+      sinon
+        .stub(csvParserPrice, 'getCustomTypeDefinition')
+        .returns(Promise.resolve(customTypeSample))
+
+      const outputStream = streamtest.v2.toText((error, result) => {
+        const prices = JSON.parse(result).prices
+        const price = prices[0].prices[0]
+        expect(prices).toHaveLength(2)
+        expect(prices[0].sku).toBeTruthy()
+        expect(price.value.centAmount).toBeTruthy()
+        expect(price.value.currencyCode).toBeTruthy()
+        done()
+      })
+      csvParserPrice.parse(readStream, outputStream)
+      csvParserPrice.parse(readStream, outputStream)
+    })
+  })
+
   test('should group prices by variants sku', () => {
     return new Promise((done) => {
       const csvParserPrice = new CsvParserPrice({ apiConfig, logger })


### PR DESCRIPTION
#### UTF-8 with BOM encoding while doing price import

Fixes: #1534 