### PR TITLE
feat(SyncActions): Add CustomType actions in inventory entries

### DIFF
--- a/packages/sync-actions/src/customers.js
+++ b/packages/sync-actions/src/customers.js
@@ -80,7 +80,7 @@ export default (
   // this resulting function mapActionGroup will call the callback function
   // for whitelisted action groups and return the return value of the callback
   // It will return an empty array for blacklisted action groups
-  const mapActionGroup = createMapActionGroup(syncActionConfig)
+  const mapActionGroup = createMapActionGroup(actionGroupList)
   const doMapActions = createCustomerMapActions(
     mapActionGroup,
     syncActionConfig

--- a/packages/sync-actions/src/inventories.js
+++ b/packages/sync-actions/src/inventories.js
@@ -4,10 +4,11 @@ import type {
   SyncAction,
   SyncActionConfig,
   UpdateAction,
-  ActionGroup,
+  ActionGroup
 } from 'types/sdk'
 import createBuildActions from './utils/create-build-actions'
 import createMapActionGroup from './utils/create-map-action-group'
+import actionsMapCustom from './utils/action-map-custom'
 import * as inventoryActions from './inventory-actions'
 import * as diffpatcher from './utils/diffpatcher'
 
@@ -31,6 +32,11 @@ function createInventoryMapActions(
     allActions.push(
       mapActionGroup('references', (): Array<UpdateAction> =>
         inventoryActions.actionsMapReferences(diff, oldObj, newObj)
+      )
+    )
+    allActions.push(
+      mapActionGroup('custom', (): Array<UpdateAction> =>
+        actionsMapCustom(diff, newObj, oldObj)
       )
     )
     return flatten(allActions)

--- a/packages/sync-actions/test/inventory-sync.spec.js
+++ b/packages/sync-actions/test/inventory-sync.spec.js
@@ -43,4 +43,68 @@ describe('Actions', () => {
     const expected = [{ action: 'changeQuantity', quantity: 2 }]
     expect(actual).toEqual(expected)
   })
+
+  describe('custom fields', () => {
+    test('should build `setCustomType` action', () => {
+      const before = {
+        custom: {
+          type: {
+            typeId: 'type',
+            id: 'customType1',
+          },
+          fields: {
+            customField1: true,
+          },
+        },
+      }
+      const now = {
+        custom: {
+          type: {
+            typeId: 'type',
+            id: 'customType2',
+          },
+          fields: {
+            customField1: true,
+          },
+        },
+      }
+      const actual = inventorySync.buildActions(now, before)
+      const expected = [{ action: 'setCustomType', ...now.custom }]
+      expect(actual).toEqual(expected)
+    })
+  })
+
+  test('should build `setCustomField` action', () => {
+    const before = {
+      custom: {
+        type: {
+          typeId: 'type',
+          id: 'customType1',
+        },
+        fields: {
+          customField1: false,
+        },
+      },
+    }
+    const now = {
+      custom: {
+        type: {
+          typeId: 'type',
+          id: 'customType1',
+        },
+        fields: {
+          customField1: true,
+        },
+      },
+    }
+    const actual = inventorySync.buildActions(now, before)
+    const expected = [
+      {
+        action: 'setCustomField',
+        name: 'customField1',
+        value: true,
+      },
+    ]
+    expect(actual).toEqual(expected)
+  })
 })


### PR DESCRIPTION
#### CustomType actions in inventory entries
Currently changes over `CustomType` and `CustomField` are not being detected by the sync actions

#### Description

Adding the group of custom actions and the corresponding tests