### PR TITLE
fix(sync-actions): generate PriceCustom actions before changePrice

### DIFF
--- a/packages/sync-actions/src/products.js
+++ b/packages/sync-actions/src/products.js
@@ -95,12 +95,6 @@ function createProductMapActions(
     )
 
     allActions.push(
-      mapActionGroup('prices', (): Array<UpdateAction> =>
-        productActions.actionsMapPrices(diff, oldObj, newObj, variantHashMap)
-      )
-    )
-
-    allActions.push(
       mapActionGroup('pricesCustom', (): Array<UpdateAction> =>
         productActions.actionsMapPricesCustom(
           diff,
@@ -108,6 +102,12 @@ function createProductMapActions(
           newObj,
           variantHashMap
         )
+      )
+    )
+
+    allActions.push(
+      mapActionGroup('prices', (): Array<UpdateAction> =>
+        productActions.actionsMapPrices(diff, oldObj, newObj, variantHashMap)
       )
     )
 

--- a/packages/sync-actions/test/product-sync-prices.spec.js
+++ b/packages/sync-actions/test/product-sync-prices.spec.js
@@ -169,6 +169,101 @@ describe('Actions', () => {
     expect(actions).toEqual([])
   })
 
+  test('should generate PriceCustom actions before changePrice action', () => {
+    const before = {
+      id: '123',
+      masterVariant: {
+        prices: [
+          {
+            value: {
+              type: 'centPrecision',
+              currencyCode: 'EUR',
+              centAmount: 1900,
+              fractionDigits: 2,
+            },
+            id: '9fe6610f',
+            country: 'DE',
+            custom: {
+              type: {
+                typeId: 'type',
+                id: '218d8068',
+              },
+              fields: {
+                touchpoints: ['value'],
+              },
+            },
+          },
+        ],
+      },
+    }
+
+    const now = {
+      id: '123',
+      masterVariant: {
+        prices: [
+          {
+            value: {
+              type: 'centPrecision',
+              currencyCode: 'EUR',
+              centAmount: 5678,
+              fractionDigits: 2,
+            },
+            id: '9fe6610f',
+            country: 'DE',
+            custom: {
+              type: {
+                typeId: 'type',
+                id: '218d8068',
+              },
+              fields: {
+                published: false,
+              },
+            },
+          },
+        ],
+      },
+    }
+
+    const actions = productsSync.buildActions(now, before)
+    expect(actions).toEqual([
+      {
+        action: 'setProductPriceCustomField',
+        name: 'touchpoints',
+        priceId: '9fe6610f',
+        value: undefined,
+      },
+      {
+        action: 'setProductPriceCustomField',
+        name: 'published',
+        priceId: '9fe6610f',
+        value: false,
+      },
+      {
+        action: 'changePrice',
+        price: {
+          country: 'DE',
+          custom: {
+            fields: {
+              published: false,
+            },
+            type: {
+              id: '218d8068',
+              typeId: 'type',
+            },
+          },
+          id: '9fe6610f',
+          value: {
+            centAmount: 5678,
+            currencyCode: 'EUR',
+            fractionDigits: 2,
+            type: 'centPrecision',
+          },
+        },
+        priceId: '9fe6610f',
+      },
+    ])
+  })
+
   describe('without `priceID`', () => {
     let actions
     const dateNow = new Date()


### PR DESCRIPTION
#### Summary

Fix for issue [1561](https://github.com/commercetools/nodejs/issues/1561)

#### Description

Generating `PriceCustom` actions before `changePrice` to fix actions overloading each other.
The ordering of the actions tested via Impex
