### PR TITLE
fix(packages): pump flow version on .flowconfig

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -1,5 +1,5 @@
 [version]
-^0.119.1
+^0.126.0
 
 [ignore]
 <PROJECT_ROOT>/_book/.*


### PR DESCRIPTION
#### Summary

Pump flow version on .flowconfig

#### Description

Fix this error which generate while trying to commit

`
✖ flow focus-check:
[2020-06-02 17:16:02.034] Checking 2 files
Wrong version of Flow. The config specifies version ^0.119.1 but this is version 0.126.0
husky > pre-commit hook failed (add --no-verify to bypass)
`