### PR TITLE
feat(sync-actions/stores): add set supply channels

### DIFF
--- a/packages/sync-actions/src/stores-actions.js
+++ b/packages/sync-actions/src/stores-actions.js
@@ -4,6 +4,7 @@ export const baseActionsList = [
   { action: 'setName', key: 'name' },
   { action: 'setLanguages', key: 'languages' },
   { action: 'setDistributionChannels', key: 'distributionChannels' },
+  { action: 'setSupplyChannels', key: 'supplyChannels' },
 ]
 
 export function actionsMapBase(diff, oldObj, newObj) {

--- a/packages/sync-actions/test/stores-sync.spec.js
+++ b/packages/sync-actions/test/stores-sync.spec.js
@@ -11,6 +11,7 @@ describe('Exports', () => {
       { action: 'setName', key: 'name' },
       { action: 'setLanguages', key: 'languages' },
       { action: 'setDistributionChannels', key: 'distributionChannels' },
+      { action: 'setSupplyChannels', key: 'supplyChannels' },
     ])
   })
 })
@@ -74,6 +75,36 @@ describe('Actions', () => {
       {
         action: 'setDistributionChannels',
         distributionChannels: now.distributionChannels,
+      },
+    ])
+  })
+  test('should build `setSupplyChannels` action', () => {
+    const before = {
+      supplyChannels: [
+        {
+          typeId: 'inventory-supply',
+          id: 'pd-001',
+        },
+      ],
+    }
+    const now = {
+      supplyChannels: [
+        {
+          typeId: 'inventory-supply',
+          id: 'pd-001',
+        },
+        {
+          typeId: 'inventory-supply',
+          key: 'pd-002',
+        },
+      ],
+    }
+
+    const actual = storesSync.buildActions(now, before)
+    expect(actual).toEqual([
+      {
+        action: 'setSupplyChannels',
+        supplyChannels: now.supplyChannels,
       },
     ])
   })

--- a/packages/sync-actions/test/stores-sync.spec.js
+++ b/packages/sync-actions/test/stores-sync.spec.js
@@ -52,7 +52,7 @@ describe('Actions', () => {
     const before = {
       distributionChannels: [
         {
-          typeId: 'product-distribution',
+          typeId: 'channel',
           id: 'pd-001',
         },
       ],
@@ -60,11 +60,11 @@ describe('Actions', () => {
     const now = {
       distributionChannels: [
         {
-          typeId: 'product-distribution',
+          typeId: 'channel',
           id: 'pd-001',
         },
         {
-          typeId: 'product-distribution',
+          typeId: 'channel',
           key: 'pd-002',
         },
       ],
@@ -82,7 +82,7 @@ describe('Actions', () => {
     const before = {
       supplyChannels: [
         {
-          typeId: 'inventory-supply',
+          typeId: 'channel',
           id: 'pd-001',
         },
       ],
@@ -90,11 +90,11 @@ describe('Actions', () => {
     const now = {
       supplyChannels: [
         {
-          typeId: 'inventory-supply',
+          typeId: 'channel',
           id: 'pd-001',
         },
         {
-          typeId: 'inventory-supply',
+          typeId: 'channel',
           key: 'pd-002',
         },
       ],

--- a/packages/sync-actions/test/stores-sync.spec.js
+++ b/packages/sync-actions/test/stores-sync.spec.js
@@ -83,7 +83,7 @@ describe('Actions', () => {
       supplyChannels: [
         {
           typeId: 'channel',
-          id: 'pd-001',
+          id: 'inventory-supply-001',
         },
       ],
     }
@@ -91,11 +91,11 @@ describe('Actions', () => {
       supplyChannels: [
         {
           typeId: 'channel',
-          id: 'pd-001',
+          id: 'inventory-supply-001',
         },
         {
           typeId: 'channel',
-          key: 'pd-002',
+          key: 'inventory-supply-002',
         },
       ],
     }


### PR DESCRIPTION
#### Summary

- adds `setSupplyChannels` for stores

#### Description

- same deal as https://github.com/commercetools/nodejs/pull/1530#issue-407171862. It may look like it is missing documentation, but Context team will wait until the MC feature is released before we release the doc update.
