### PR TITLE
chore: update emails commercetools.de -> commercetools.com

### DIFF
--- a/packages/category-exporter/package.json
+++ b/packages/category-exporter/package.json
@@ -30,7 +30,7 @@
   ],
   "author": {
     "name": "Babajide Williams",
-    "email": "babajide.williams@commercetools.de"
+    "email": "babajide.williams@commercetools.com"
   },
   "license": "MIT",
   "dependencies": {

--- a/packages/csv-parser-state/package.json
+++ b/packages/csv-parser-state/package.json
@@ -27,7 +27,7 @@
   ],
   "author": {
     "name": "Williams Omayuku",
-    "email": "williams.omayuku@commercetools.de"
+    "email": "williams.omayuku@commercetools.com"
   },
   "license": "MIT",
   "bin": {

--- a/packages/custom-objects-exporter/package.json
+++ b/packages/custom-objects-exporter/package.json
@@ -31,7 +31,7 @@
   ],
   "author": {
     "name": "Daniel Eriksson",
-    "email": "daniel.eriksson@commercetools.de"
+    "email": "daniel.eriksson@commercetools.com"
   },
   "license": "MIT",
   "dependencies": {

--- a/packages/custom-objects-importer/package.json
+++ b/packages/custom-objects-importer/package.json
@@ -27,7 +27,7 @@
   ],
   "author": {
     "name": "Daniel Eriksson",
-    "email": "daniel.eriksson@commercetools.de",
+    "email": "daniel.eriksson@commercetools.com",
     "url": "https://github.com/daern91"
   },
   "license": "MIT",

--- a/packages/customer-groups-exporter/package.json
+++ b/packages/customer-groups-exporter/package.json
@@ -31,7 +31,7 @@
   ],
   "author": {
     "name": "Daniel Eriksson",
-    "email": "daniel.eriksson@commercetools.de",
+    "email": "daniel.eriksson@commercetools.com",
     "url": "https://github.com/daern91"
   },
   "license": "MIT",

--- a/packages/inventories-exporter/package.json
+++ b/packages/inventories-exporter/package.json
@@ -24,7 +24,7 @@
   "license": "MIT",
   "author": {
     "name": "Abimbola Idowu",
-    "email": "abimbola.idowu@commercetools.de",
+    "email": "abimbola.idowu@commercetools.com",
     "url": "hisabimbola.com"
   },
   "bin": {

--- a/packages/personal-data-erasure/package.json
+++ b/packages/personal-data-erasure/package.json
@@ -30,7 +30,7 @@
   ],
   "author": {
     "name": "Daniel Eriksson",
-    "email": "daniel.eriksson@commercetools.de"
+    "email": "daniel.eriksson@commercetools.com"
   },
   "license": "MIT",
   "dependencies": {

--- a/packages/price-exporter/package.json
+++ b/packages/price-exporter/package.json
@@ -23,7 +23,7 @@
   "license": "MIT",
   "author": {
     "name": "Williams Omayuku",
-    "email": "williams.omayuku@commercetools.de"
+    "email": "williams.omayuku@commercetools.com"
   },
   "main": "lib/index.js",
   "bin": {

--- a/packages/product-exporter/package.json
+++ b/packages/product-exporter/package.json
@@ -22,7 +22,7 @@
   "license": "MIT",
   "author": {
     "name": "Williams Omayuku",
-    "email": "williams.omayuku@commercetools.de"
+    "email": "williams.omayuku@commercetools.com"
   },
   "main": "lib/index.js",
   "bin": {

--- a/packages/product-json-to-csv/package.json
+++ b/packages/product-json-to-csv/package.json
@@ -25,7 +25,7 @@
   "license": "MIT",
   "author": {
     "name": "Williams Omayuku",
-    "email": "williams.omayuku@commercetools.de"
+    "email": "williams.omayuku@commercetools.com"
   },
   "main": "lib/index.js",
   "bin": {

--- a/packages/product-json-to-xlsx/package.json
+++ b/packages/product-json-to-xlsx/package.json
@@ -25,7 +25,7 @@
   "license": "MIT",
   "author": {
     "name": "Jan Juna",
-    "email": "jan.juna-ext@commercetools.de"
+    "email": "jan.juna-ext@commercetools.com"
   },
   "main": "lib/index.js",
   "bin": {

--- a/packages/resource-deleter/package.json
+++ b/packages/resource-deleter/package.json
@@ -28,7 +28,7 @@
   ],
   "author": {
     "name": "Babajide Williams",
-    "email": "babajide.williams@commercetools.de"
+    "email": "babajide.williams@commercetools.com"
   },
   "license": "MIT",
   "dependencies": {

--- a/packages/state-importer/package.json
+++ b/packages/state-importer/package.json
@@ -30,7 +30,7 @@
   ],
   "author": {
     "name": "Williams Omayuku",
-    "email": "williams.omayuku@commercetools.de"
+    "email": "williams.omayuku@commercetools.com"
   },
   "license": "MIT",
   "dependencies": {


### PR DESCRIPTION
#### Summary

- update emails from `*.de -> *.com`

I saw some older emails of people who no longer are in the company. if you want ownership to change, leave a **suggestion** that can be commited on the PR. 