### PR TITLE
fix(sdk-auth): to encode request body

### DIFF
--- a/packages/sdk-auth/package.json
+++ b/packages/sdk-auth/package.json
@@ -33,7 +33,8 @@
   },
   "dependencies": {
     "@commercetools/sdk-middleware-http": "^6.0.7",
-    "lodash.defaultsdeep": "^4.6.0"
+    "lodash.defaultsdeep": "^4.6.0",
+    "qss": "2.0.3"
   },
   "devDependencies": {
     "nock": "12.0.3",

--- a/packages/sdk-auth/src/auth.js
+++ b/packages/sdk-auth/src/auth.js
@@ -122,11 +122,11 @@ export default class SdkAuth {
     toAppend: Object
   ): AuthRequest {
     const previousDecodedRequestBody = request.body ? decode(request.body) : {}
-    const nextEncdedRequestBody = encode({
+    const nextEncodedRequestBody = encode({
       ...previousDecodedRequestBody,
       ...toAppend,
     })
-    request.body = nextEncdedRequestBody
+    request.body = nextEncodedRequestBody
 
     return request
   }
@@ -290,24 +290,24 @@ export default class SdkAuth {
 
   refreshTokenFlow(token: string, config: CustomAuthOptions = {}) {
     if (!token) throw new Error('Missing required token value')
-    const _config = this._getRequestConfig(config)
 
-    let request = SdkAuth._buildRequest(
-      _config,
-      this.BASE_AUTH_FLOW_URI,
-      'refresh_token'
+    const _config = this._getRequestConfig(config)
+    const request = SdkAuth._appendToRequestBody(
+      SdkAuth._buildRequest(_config, this.BASE_AUTH_FLOW_URI, 'refresh_token'),
+      { refresh_token: token }
     )
-    request = SdkAuth._appendToRequestBody(request, { refresh_token: token })
 
     return this._process(request)
   }
 
   introspectToken(token: string, config: CustomAuthOptions = {}) {
-    const _config = this._getRequestConfig(config)
     if (!token) throw new Error('Missing required token value')
 
-    let request = SdkAuth._buildRequest(_config, this.INTROSPECT_URI)
-    request = SdkAuth._appendToRequestBody(request, { token })
+    const _config = this._getRequestConfig(config)
+    const request = SdkAuth._appendToRequestBody(
+      SdkAuth._buildRequest(_config, this.INTROSPECT_URI),
+      { token }
+    )
 
     return this._process(request)
   }

--- a/packages/sdk-auth/test/client-password-flow.spec.js
+++ b/packages/sdk-auth/test/client-password-flow.spec.js
@@ -1,5 +1,5 @@
 import nock from 'nock'
-import { encode } from 'qss'
+import querystring from 'querystring'
 import Auth from '../src/auth'
 import config from './resources/sample-config'
 import response from './resources/sample-response.json'
@@ -14,7 +14,7 @@ describe('Client Password flow', () => {
     const scope = nock(config.host)
       .post(
         `/oauth/token`,
-        encode({
+        querystring.encode({
           grant_type: 'password',
           scope: `manage_project:${config.projectKey}`,
           username: 'user123',
@@ -44,7 +44,7 @@ describe('Client Password flow', () => {
       .post(
         `/oauth/token`,
         // expected body
-        encode({
+        querystring.encode({
           grant_type: 'password',
           scope: `manage_project:${config.projectKey}`,
           username: userCredentials.username,
@@ -70,7 +70,7 @@ describe('Client Password flow', () => {
     const scope = nock(config.host)
       .post(
         `/oauth/token`,
-        encode({
+        querystring.encode({
           grant_type: 'password',
           refresh_token: false,
           scope: `manage_project:${config.projectKey}`,

--- a/packages/sdk-auth/test/client-password-flow.spec.js
+++ b/packages/sdk-auth/test/client-password-flow.spec.js
@@ -1,4 +1,5 @@
 import nock from 'nock'
+import { encode } from 'qss'
 import Auth from '../src/auth'
 import config from './resources/sample-config'
 import response from './resources/sample-response.json'
@@ -11,12 +12,15 @@ describe('Client Password flow', () => {
 
   test('should authenticate with correct user credentials', async () => {
     const scope = nock(config.host)
-      .post(`/oauth/token`, {
-        grant_type: 'password',
-        scope: `manage_project:${config.projectKey}`,
-        username: 'user123',
-        password: 'pass123',
-      })
+      .post(
+        `/oauth/token`,
+        encode({
+          grant_type: 'password',
+          scope: `manage_project:${config.projectKey}`,
+          username: 'user123',
+          password: 'pass123',
+        })
+      )
       .reply(200, JSON.stringify(response))
 
     expect(scope.isDone()).toBe(false)
@@ -40,9 +44,12 @@ describe('Client Password flow', () => {
       .post(
         `/oauth/token`,
         // expected body
-        `grant_type=password&scope=manage_project:${config.projectKey}` +
-        `&username=user%204%5El*aJ%40ETso%2B%2F%5CHdE1!x0u4q5` + // encoded
-          `&password=pass%204%5El*aJ%40ETso%2B%2F%5CHdE1!x0u4q5` // encoded
+        encode({
+          grant_type: 'password',
+          scope: `manage_project:${config.projectKey}`,
+          username: userCredentials.username,
+          password: userCredentials.password,
+        })
       )
       .reply(200, JSON.stringify(response))
 
@@ -63,9 +70,13 @@ describe('Client Password flow', () => {
     const scope = nock(config.host)
       .post(
         `/oauth/token`,
-        // expected body
-        `grant_type=password&scope=manage_project:${config.projectKey}` +
-          `&refresh_token=false&username=user&password=pass`
+        encode({
+          grant_type: 'password',
+          refresh_token: false,
+          scope: `manage_project:${config.projectKey}`,
+          username: 'user',
+          password: 'pass',
+        })
       )
       .reply(200, JSON.stringify(response))
 

--- a/packages/sdk-auth/test/common.spec.js
+++ b/packages/sdk-auth/test/common.spec.js
@@ -1,5 +1,6 @@
 import nock from 'nock'
 import fetch from 'node-fetch'
+import { encode } from 'qss'
 import { getErrorByCode } from '@commercetools/sdk-middleware-http'
 import Auth from '../src/auth'
 import config from './resources/sample-config'
@@ -14,7 +15,10 @@ describe('Common processes', () => {
   const request = {
     basicAuth,
     uri: 'https://auth.commercetools.com/api-endpoint',
-    body: 'grant_type=client_credentials&scope=manage_project:project-key',
+    body: encode({
+      grant_type: 'client_credentials',
+      scope: 'manage_project:project-key',
+    }),
   }
 
   beforeEach(() => nock.cleanAll())
@@ -220,8 +224,10 @@ describe('Common processes', () => {
         basicAuth,
         authType: 'Basic',
         uri: 'https://auth.commercetools.com/api-endpoint',
-        body:
-          'grant_type=client_credentials&scope=view_products:sample-project manage_types:sample-project',
+        body: encode({
+          grant_type: 'client_credentials',
+          scope: 'view_products:sample-project manage_types:sample-project',
+        }),
       })
     })
   })

--- a/packages/sdk-auth/test/common.spec.js
+++ b/packages/sdk-auth/test/common.spec.js
@@ -1,6 +1,6 @@
 import nock from 'nock'
 import fetch from 'node-fetch'
-import { encode } from 'qss'
+import querystring from 'querystring'
 import { getErrorByCode } from '@commercetools/sdk-middleware-http'
 import Auth from '../src/auth'
 import config from './resources/sample-config'
@@ -15,7 +15,7 @@ describe('Common processes', () => {
   const request = {
     basicAuth,
     uri: 'https://auth.commercetools.com/api-endpoint',
-    body: encode({
+    body: querystring.encode({
       grant_type: 'client_credentials',
       scope: 'manage_project:project-key',
     }),
@@ -224,7 +224,7 @@ describe('Common processes', () => {
         basicAuth,
         authType: 'Basic',
         uri: 'https://auth.commercetools.com/api-endpoint',
-        body: encode({
+        body: querystring.encode({
           grant_type: 'client_credentials',
           scope: 'view_products:sample-project manage_types:sample-project',
         }),

--- a/packages/sdk-auth/test/customer-password-flow.spec.js
+++ b/packages/sdk-auth/test/customer-password-flow.spec.js
@@ -1,4 +1,5 @@
 import nock from 'nock'
+import { encode } from 'qss'
 import Auth from '../src/auth'
 import config from './resources/sample-config'
 import response from './resources/sample-response.json'
@@ -11,12 +12,15 @@ describe('Customer Password flow', () => {
 
   test('should authenticate with correct user credentials', async () => {
     const scope = nock(config.host)
-      .post(`/oauth/${config.projectKey}/customers/token`, {
-        grant_type: 'password',
-        scope: `manage_project:${config.projectKey}`,
-        username: 'user123',
-        password: 'pass123',
-      })
+      .post(
+        `/oauth/${config.projectKey}/customers/token`,
+        encode({
+          grant_type: 'password',
+          scope: `manage_project:${config.projectKey}`,
+          username: 'user123',
+          password: 'pass123',
+        })
+      )
       .reply(200, JSON.stringify(response))
 
     expect(scope.isDone()).toBe(false)
@@ -39,10 +43,12 @@ describe('Customer Password flow', () => {
     const scope = nock(config.host)
       .post(
         `/oauth/${config.projectKey}/customers/token`,
-        // expected body
-        `grant_type=password&scope=manage_project:${config.projectKey}` +
-        `&username=user%204%5El*aJ%40ETso%2B%2F%5CHdE1!x0u4q5` + // encoded
-          `&password=pass%204%5El*aJ%40ETso%2B%2F%5CHdE1!x0u4q5` // encoded
+        encode({
+          grant_type: 'password',
+          scope: `manage_project:${config.projectKey}`,
+          username: userCredentials.username,
+          password: userCredentials.password,
+        })
       )
       .reply(200, JSON.stringify(response))
 

--- a/packages/sdk-auth/test/customer-password-flow.spec.js
+++ b/packages/sdk-auth/test/customer-password-flow.spec.js
@@ -1,5 +1,5 @@
 import nock from 'nock'
-import { encode } from 'qss'
+import querystring from 'querystring'
 import Auth from '../src/auth'
 import config from './resources/sample-config'
 import response from './resources/sample-response.json'
@@ -14,7 +14,7 @@ describe('Customer Password flow', () => {
     const scope = nock(config.host)
       .post(
         `/oauth/${config.projectKey}/customers/token`,
-        encode({
+        querystring.encode({
           grant_type: 'password',
           scope: `manage_project:${config.projectKey}`,
           username: 'user123',
@@ -43,7 +43,7 @@ describe('Customer Password flow', () => {
     const scope = nock(config.host)
       .post(
         `/oauth/${config.projectKey}/customers/token`,
-        encode({
+        querystring.encode({
           grant_type: 'password',
           scope: `manage_project:${config.projectKey}`,
           username: userCredentials.username,

--- a/packages/sdk-auth/test/token-introspection.spec.js
+++ b/packages/sdk-auth/test/token-introspection.spec.js
@@ -1,4 +1,5 @@
 import nock from 'nock'
+import { encode } from 'qss'
 import Auth from '../src/auth'
 import config from './resources/sample-config'
 
@@ -15,9 +16,14 @@ describe('Token Introspection', () => {
 
   test('should introspect token', async () => {
     const scope = nock(config.host)
-      .post('/oauth/introspect', {
-        token: 'tokenValue',
-      })
+      .post(
+        '/oauth/introspect',
+        encode({
+          grant_type: 'client_credentials',
+          scope: 'manage_project:sample-project',
+          token: 'tokenValue',
+        })
+      )
       .reply(200, JSON.stringify(response))
 
     expect(scope.isDone()).toBe(false)

--- a/packages/sdk-auth/test/token-introspection.spec.js
+++ b/packages/sdk-auth/test/token-introspection.spec.js
@@ -1,5 +1,5 @@
 import nock from 'nock'
-import { encode } from 'qss'
+import querystring from 'querystring'
 import Auth from '../src/auth'
 import config from './resources/sample-config'
 
@@ -18,7 +18,7 @@ describe('Token Introspection', () => {
     const scope = nock(config.host)
       .post(
         '/oauth/introspect',
-        encode({
+        querystring.encode({
           grant_type: 'client_credentials',
           scope: 'manage_project:sample-project',
           token: 'tokenValue',

--- a/yarn.lock
+++ b/yarn.lock
@@ -5218,7 +5218,7 @@ debug@^3.0.1, debug@^3.1.0:
   dependencies:
     ms "^2.1.1"
 
-debuglog@*, debuglog@^1.0.1:
+debuglog@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/debuglog/-/debuglog-1.0.1.tgz#aa24ffb9ac3df9a2351837cfb2d279360cd78492"
   integrity sha1-qiT/uaw9+aI1GDfPstJ5NgzXhJI=
@@ -7529,7 +7529,7 @@ import-local@^3.0.2:
     pkg-dir "^4.2.0"
     resolve-cwd "^3.0.0"
 
-imurmurhash@*, imurmurhash@^0.1.4:
+imurmurhash@^0.1.4:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/imurmurhash/-/imurmurhash-0.1.4.tgz#9218b9b2b928a238b13dc4fb6b6d576f231453ea"
   integrity sha1-khi5srkoojixPcT7a21XbyMUU+o=
@@ -9310,11 +9310,6 @@ lodash._basecreate@^3.0.0:
   resolved "https://registry.yarnpkg.com/lodash._basecreate/-/lodash._basecreate-3.0.3.tgz#1bc661614daa7fc311b7d03bf16806a0213cf821"
   integrity sha1-G8ZhYU2qf8MRt9A78WgGoCE8+CE=
 
-lodash._baseindexof@*:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/lodash._baseindexof/-/lodash._baseindexof-3.1.0.tgz#fe52b53a1c6761e42618d654e4a25789ed61822c"
-  integrity sha1-/lK1OhxnYeQmGNZU5KJXie1hgiw=
-
 lodash._baseuniq@~4.6.0:
   version "4.6.0"
   resolved "https://registry.yarnpkg.com/lodash._baseuniq/-/lodash._baseuniq-4.6.0.tgz#0ebb44e456814af7905c6212fa2c9b2d51b841e8"
@@ -9323,29 +9318,12 @@ lodash._baseuniq@~4.6.0:
     lodash._createset "~4.0.0"
     lodash._root "~3.0.0"
 
-lodash._bindcallback@*:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/lodash._bindcallback/-/lodash._bindcallback-3.0.1.tgz#e531c27644cf8b57a99e17ed95b35c748789392e"
-  integrity sha1-5THCdkTPi1epnhftlbNcdIeJOS4=
-
-lodash._cacheindexof@*:
-  version "3.0.2"
-  resolved "https://registry.yarnpkg.com/lodash._cacheindexof/-/lodash._cacheindexof-3.0.2.tgz#3dc69ac82498d2ee5e3ce56091bafd2adc7bde92"
-  integrity sha1-PcaayCSY0u5ePOVgkbr9Ktx73pI=
-
-lodash._createcache@*:
-  version "3.1.2"
-  resolved "https://registry.yarnpkg.com/lodash._createcache/-/lodash._createcache-3.1.2.tgz#56d6a064017625e79ebca6b8018e17440bdcf093"
-  integrity sha1-VtagZAF2JeeevKa4AY4XRAvc8JM=
-  dependencies:
-    lodash._getnative "^3.0.0"
-
 lodash._createset@~4.0.0:
   version "4.0.3"
   resolved "https://registry.yarnpkg.com/lodash._createset/-/lodash._createset-4.0.3.tgz#0f4659fbb09d75194fa9e2b88a6644d363c9fe26"
   integrity sha1-D0ZZ+7CddRlPqeK4imZE02PJ/iY=
 
-lodash._getnative@*, lodash._getnative@^3.0.0:
+lodash._getnative@^3.0.0:
   version "3.9.1"
   resolved "https://registry.yarnpkg.com/lodash._getnative/-/lodash._getnative-3.9.1.tgz#570bc7dede46d61cdcde687d65d3eecbaa3aaff5"
   integrity sha1-VwvH3t5G1hzc3mh9ZdPuy6o6r/U=
@@ -9532,11 +9510,6 @@ lodash.reject@^4.4.0:
   version "4.6.0"
   resolved "https://registry.yarnpkg.com/lodash.reject/-/lodash.reject-4.6.0.tgz#80d6492dc1470864bbf583533b651f42a9f52415"
   integrity sha1-gNZJLcFHCGS79YNTO2UfQqn1JBU=
-
-lodash.restparam@*:
-  version "3.6.1"
-  resolved "https://registry.yarnpkg.com/lodash.restparam/-/lodash.restparam-3.6.1.tgz#936a4e309ef330a7645ed4145986c85ae5b20805"
-  integrity sha1-k2pOMJ7zMKdkXtQUWYbIWuWyCAU=
 
 lodash.set@^4.3.2:
   version "4.3.2"
@@ -12112,6 +12085,11 @@ qs@~6.5.2:
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.5.2.tgz#cb3ae806e8740444584ef154ce8ee98d403f3e36"
   integrity sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==
 
+qss@2.0.3:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/qss/-/qss-2.0.3.tgz#630b38b120931b52d04704f3abfb0f861604a9ec"
+  integrity sha512-j48ZBT5IZbSqJiSU8EX4XrN8nXiflHvmMvv2XpFc31gh7n6EpSs75bNr6+oj3FOLWyT8m09pTmqLNl34L7/uPQ==
+
 query-string@^6.1.0:
   version "6.13.1"
   resolved "https://registry.yarnpkg.com/query-string/-/query-string-6.13.1.tgz#d913ccfce3b4b3a713989fe6d39466d92e71ccad"
@@ -12343,7 +12321,7 @@ readable-stream@~1.1.10:
     isarray "0.0.1"
     string_decoder "~0.10.x"
 
-readdir-scoped-modules@*, readdir-scoped-modules@^1.0.0, readdir-scoped-modules@^1.1.0:
+readdir-scoped-modules@^1.0.0, readdir-scoped-modules@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/readdir-scoped-modules/-/readdir-scoped-modules-1.1.0.tgz#8d45407b4f870a0dcaebc0e28670d18e74514309"
   integrity sha512-asaikDeqAQg7JifRsZn1NJZXo9E+VwlyCfbkZhwyISinqk5zNS6266HS5kah6P0SaQKGF6SkNnZVHUzHFYxYDw==


### PR DESCRIPTION
#### Summary

This pull request fixes the `sdk-auth` package to encode the request's body at all times.

#### Description

The `sdk-auth` is used to perform request authorization in our Node.js SDK. For that it often uses parameters such as `scope`, `refresh_token` or `grant_type` among others.

The parameters mentioned above can often contain strings which need encoding. This holds true for e.g. the `<scope>:<projectKey>` or also the `token` itself.

So far the `sdk-auth` just concatinated strings to build up the request. For example as `body += `&scope=${scope}`. Then sometimes it encodes a parameter as `request.body += `&refresh_token=${encodeURIComponent(token)}`. Our APIs can deal with this inconsistency but it can also cause problems when a string is not rightfully detected as not encoded. This is what I think @cneijenhuis noticed when having problems with token encoding and investigating it.

As a result of this this pull request suggests to always encode the body's paramters as it's send as `      'Content-Type': 'application/x-www-form-urlencoded'`.

There are usually two options going about it:

1. Use a library
2. Use `URLSearchParams` (web standard)

I propose to use [qss](https://github.com/lukeed/qss/blob/master/src/index.js) which is a tiny library which works both in Node.js and the browser. We have good experience with it in the Merchant Center.
Using `URLSearchParams` would need a polyfill as it's not supported in all browsers. Usually leading to larger bundles while we do not need most of it's functionality/API surface.

The pull request also updates the tests affected by this which outlines the change.

This overall instead of for example:

```
grant_type=client_credentials&scope=view_products:sample-project manage_types:sample-project
```

gives us

```
grant_type=client_credentials&scope=view_products%3Asample-project%20manage_types%3Asample-project
```