### PR TITLE
feat(sync-actions): publish product actions

### DIFF
--- a/packages/sync-actions/src/products.js
+++ b/packages/sync-actions/src/products.js
@@ -43,6 +43,7 @@ function createProductMapActions(
   ): Array<UpdateAction> {
     const allActions = []
     const { sameForAllAttributeNames } = options
+    const { publish } = newObj
 
     const variantHashMap = findMatchingPairs(
       diff.variants,
@@ -128,6 +129,9 @@ function createProductMapActions(
         productActions.actionsMapAssets(diff, oldObj, newObj, variantHashMap)
       )
     )
+
+    if (publish === true)
+      return flatten(allActions).map((action) => ({ ...action, staged: false }))
 
     return flatten(allActions)
   }

--- a/packages/sync-actions/test/product-sync-base.spec.js
+++ b/packages/sync-actions/test/product-sync-base.spec.js
@@ -102,6 +102,26 @@ describe('Actions', () => {
     expect(actions).toEqual([{ action: 'changeName', ...now }])
   })
 
+  test('should build action with `staged` flag as false', () => {
+    const before = { name: { en: 'Car', de: 'Auto' } }
+    const now = { name: { en: 'Sport car' }, publish: true }
+    const actions = productsSync.buildActions(now, before)
+
+    expect(actions).toEqual([
+      { action: 'changeName', name: { en: 'Sport car' }, staged: false },
+    ])
+  })
+
+  test('should build action without `staged` flag', () => {
+    const before = { name: { en: 'Car', de: 'Auto' } }
+    const now = { name: { en: 'Sport car' }, publish: false }
+    const actions = productsSync.buildActions(now, before)
+
+    expect(actions).toEqual([
+      { action: 'changeName', name: { en: 'Sport car' } },
+    ])
+  })
+
   test('should build `setSearchKeywords` action', () => {
     /* eslint-disable max-len */
     const before = {


### PR DESCRIPTION
#### Description

Give the ability to publish product actions directly by simply mark `staged` flag to false.

One use case for this, it would make it easy for package user to just publish the updates instead of sending update actions then send another action to publish product updates plus this feature would shorten the platform calls

