### PR TITLE
fix(api-request-builder): Add expand for custom object API

### DIFF
--- a/packages/api-request-builder/src/default-services.js
+++ b/packages/api-request-builder/src/default-services.js
@@ -112,6 +112,7 @@ export default {
       features.del,
       features.query,
       features.queryOne,
+      features.queryExpand,
     ],
   },
   discountCodes: {


### PR DESCRIPTION
#### Add expand for custom object API
 
Fixes: #1590 