### PR TITLE
Remove dependence on content in ok result when executeFetch

### DIFF
--- a/packages/sdk-middleware-http/src/http.js
+++ b/packages/sdk-middleware-http/src/http.js
@@ -146,10 +146,10 @@ export default function createHttpMiddleware({
                 return
               }
 
-              res.json().then((result: Object) => {
+              res.text().then((result: Object) => {
                 const parsedResponse: Object = {
                   ...response,
-                  body: result,
+                  body: result.length > 0 ? JSON.parse(result) : {},
                   statusCode: res.status,
                 }
 

--- a/packages/sdk-middleware-http/test/http.spec.js
+++ b/packages/sdk-middleware-http/test/http.spec.js
@@ -952,4 +952,34 @@ describe('Http', () => {
 
       httpMiddleware(next)(request, response)
     }))
+
+  test('execute a post request with empty 202 response', () =>
+    new Promise((resolve, reject) => {
+      const request = createTestRequest({
+        uri: '/foo/bar',
+        method: 'POST',
+      })
+      const response = { resolve, reject }
+      const next = (req, res) => {
+        expect(res).toEqual({
+          ...response,
+          body: {},
+          statusCode: 202,
+        })
+        resolve()
+      }
+      // Use default options
+      const httpMiddleware = createHttpMiddleware({
+        host: testHost,
+        fetch,
+      })
+      nock(testHost)
+        .defaultReplyHeaders({
+          'Content-Type': 'application/json',
+        })
+        .post('/foo/bar')
+        .reply(202, undefined)
+
+      httpMiddleware(next)(request, response)
+    }))
 })


### PR DESCRIPTION
#### Summary

When returning empty 200,202,204 etc from external api the sdk throws. This change catches the exception from res.json() and continues with a default empty object in case the parsing fails, as long as the response status is ok. 

#### Description

It's not uncommon to use 'return Accepted()` or return `Ok()` in asp core and even though specifying the content type as json the return will be empty making json() throw. The content length header seems to be stripped in the proxy so the simplest solution for handling a common server solution for empty 202, 204, and 200 seems to be to catch the exception and continue with an empty body.

#### Testing solution

- Make a post to an external api from a custom application. 
- Have the server respond with an empty 202. (i.e asp core `return Accepted()` or `return Ok()`)

#### Todo

- Tests
  - [ ] Unit
  - [ ] Integration
  - [ ] Acceptance
- [ ] Documentation
- [ ] `Type` label for the PR <!-- Used to automatically generate the changelog -->
  <!-- Two persons should review a PR, don't forget to assign them. -->
  <!-- Please remember to squash merge. -->
  <!-- All contribution guidelines can be found here: https://github.com/commercetools/nodejs/blob/master/CONTRIBUTING.md -->
