### PR TITLE
fix(api-request-builder): resetting `customerId` and `cartId` params

### DIFF
--- a/packages/api-request-builder/src/default-params.js
+++ b/packages/api-request-builder/src/default-params.js
@@ -71,8 +71,11 @@ export function setDefaultParams() {
 
   this.params.key = null
 
-  if (this.features.includes(features.queryOne))
+  if (this.features.includes(features.queryOne)) {
     this.params.id = getDefaultQueryParams().id
+    this.params.customerId = null
+    this.params.cartId = null
+  }
 
   if (this.features.includes(features.query)) {
     this.params.pagination = getDefaultQueryParams().pagination

--- a/packages/api-request-builder/test/create-request-builder.spec.js
+++ b/packages/api-request-builder/test/create-request-builder.spec.js
@@ -67,7 +67,7 @@ describe('createRequestBuilder', () => {
     )
   })
 
-  test('calling build resets all params', () => {
+  test('calling build resets all params after querying byKey', () => {
     const requestBuilder = createRequestBuilder({
       projectKey: 'foo',
     })
@@ -76,5 +76,29 @@ describe('createRequestBuilder', () => {
       .parse({ where: ['bar'] })
       .build()
     expect(nextRequest).toEqual('/foo/categories?where=bar')
+  })
+
+  test('calling build resets all params after querying byCustomerId', () => {
+    const requestBuilder = createRequestBuilder({
+      projectKey: 'foo',
+    })
+    requestBuilder.carts.byCustomerId('1234').build()
+    const nextRequest = requestBuilder.carts
+      .parse({ where: ['cartState="Active"'] })
+      .build()
+    expect(nextRequest).toEqual('/foo/carts?where=cartState%3D%22Active%22')
+  })
+
+  test('calling build resets all params after querying byCartId', () => {
+    const requestBuilder = createRequestBuilder({
+      projectKey: 'foo',
+    })
+    requestBuilder.orders.byCartId('1234').build()
+    const nextRequest = requestBuilder.orders
+      .parse({ where: ['orderNumber="testOrderNum"'] })
+      .build()
+    expect(nextRequest).toEqual(
+      '/foo/orders?where=orderNumber%3D%22testOrderNum%22'
+    )
   })
 })

--- a/packages/api-request-builder/test/default-params.spec.js
+++ b/packages/api-request-builder/test/default-params.spec.js
@@ -9,6 +9,8 @@ describe('defaultParams', () => {
     expect(params).toEqual({
       id: null,
       key: null,
+      customerId: null,
+      cartId: null,
       expand: [],
       pagination: {
         page: null,
@@ -34,6 +36,8 @@ describe('defaultParams', () => {
     expect(params).toEqual({
       id: null,
       key: null,
+      customerId: null,
+      cartId: null,
       expand: [],
       pagination: {
         page: null,
@@ -60,6 +64,8 @@ describe('defaultParams', () => {
     expect(params).toEqual({
       id: null,
       key: null,
+      customerId: null,
+      cartId: null,
       expand: [],
       pagination: {
         page: null,


### PR DESCRIPTION
Fixes: #1627

Resets the `customerId` and `cartId` params to null after the `build` method has generated a uri.