### PR TITLE
feat(sync-actions/stores): add support custom fields actions on store level

### DIFF
--- a/packages/sync-actions/src/stores.js
+++ b/packages/sync-actions/src/stores.js
@@ -3,6 +3,7 @@ import flatten from 'lodash.flatten'
 import type { SyncAction, UpdateAction, ActionGroup } from 'types/sdk'
 import createBuildActions from './utils/create-build-actions'
 import createMapActionGroup from './utils/create-map-action-group'
+import actionsMapCustom from './utils/action-map-custom'
 import * as storesActions from './stores-actions'
 import * as diffpatcher from './utils/diffpatcher'
 
@@ -24,11 +25,19 @@ function createStoresMapActions(
     next: Object,
     previous: Object
   ): Array<UpdateAction> {
-    return flatten([
+    const allActions = []
+    allActions.push(
       mapActionGroup('base', (): Array<UpdateAction> =>
         storesActions.actionsMapBase(diff, previous, next)
-      ),
-    ])
+      )
+    )
+    allActions.push(
+      mapActionGroup('custom', (): Array<UpdateAction> =>
+        actionsMapCustom(diff, next, previous)
+      )
+    )
+
+    return flatten(allActions)
   }
 }
 

--- a/packages/sync-actions/test/stores-sync.spec.js
+++ b/packages/sync-actions/test/stores-sync.spec.js
@@ -108,4 +108,68 @@ describe('Actions', () => {
       },
     ])
   })
+
+  describe('custom fields', () => {
+    test('should build `setCustomType` action', () => {
+      const before = {
+        custom: {
+          type: {
+            typeId: 'type',
+            id: 'customType1',
+          },
+          fields: {
+            customField1: true,
+          },
+        },
+      }
+      const now = {
+        custom: {
+          type: {
+            typeId: 'type',
+            id: 'customType2',
+          },
+          fields: {
+            customField1: true,
+          },
+        },
+      }
+      const actual = storesSync.buildActions(now, before)
+      const expected = [{ action: 'setCustomType', ...now.custom }]
+      expect(actual).toEqual(expected)
+    })
+  })
+
+  test('should build `setCustomField` action', () => {
+    const before = {
+      custom: {
+        type: {
+          typeId: 'type',
+          id: 'customType1',
+        },
+        fields: {
+          customField1: false,
+        },
+      },
+    }
+    const now = {
+      custom: {
+        type: {
+          typeId: 'type',
+          id: 'customType1',
+        },
+        fields: {
+          customField1: true,
+        },
+      },
+    }
+    const actual = storesSync.buildActions(now, before)
+    const expected = [
+      {
+        action: 'setCustomField',
+        name: 'customField1',
+        value: true,
+      },
+    ]
+    expect(actual).toEqual(expected)
+  })
 })


### PR DESCRIPTION
#### Summary

- `sync-actions/stores` => The CTP GraphQL API supports custom fields on Store type. Therefore, this PR enables the `nodejs` sdk users to update/add custom fields to Store.

#### Description
- CTP GraphQL has added custom field support on Store type.
_Creating store graphql input draft_
<img width="452" alt="Screenshot 2020-11-10 at 12 08 37" src="https://user-images.githubusercontent.com/22475427/98667031-27f94180-234e-11eb-8149-40eee5fe15c5.png">

_Updating store graphql input draft_
<img width="450" alt="Screenshot 2020-11-10 at 12 09 19" src="https://user-images.githubusercontent.com/22475427/98667057-2fb8e600-234e-11eb-9360-18b8721d0c24.png">

This PR updates the nodejs sdk to support these actions.
