### PR TITLE
Get rid of Buffer.from polyfill requirement

### DIFF
--- a/packages/sdk-auth/src/auth.js
+++ b/packages/sdk-auth/src/auth.js
@@ -87,7 +87,8 @@ export default class SdkAuth {
     clientId,
     clientSecret,
   }: ClientAuthOptions): string {
-    return Buffer.from(`${clientId}:${clientSecret}`).toString('base64')
+    const targetStr = `${clientId}:${clientSecret}`;
+    return typeof Buffer === 'undefined' ? btoa(targetStr) : Buffer.from(targetStr).toString('base64');
   }
 
   static _getScopes(scopes: ?Array<string>, projectKey: ?string): string {


### PR DESCRIPTION
#### Summary

IE10+ browsers support btoa function. Do we really need 50kb Buffer polyfill in the browser?
With this pull request https://github.com/commercetools/nodejs/pull/1650 we can just get rid of the entire Buffer's polyfill


#### Todo

- Tests
  - [ ] Unit
  - [ ] Integration
  - [ ] Acceptance
- [ ] Documentation
- [ ] `Type` label for the PR <!-- Used to automatically generate the changelog -->
  <!-- Two persons should review a PR, don't forget to assign them. -->
  <!-- Please remember to squash merge. -->
  <!-- All contribution guidelines can be found here: https://github.com/commercetools/nodejs/blob/master/CONTRIBUTING.md -->
