### PR TITLE
fix: check requestHeader content-type property

### DIFF
--- a/packages/sdk-middleware-http/src/http.js
+++ b/packages/sdk-middleware-http/src/http.js
@@ -113,9 +113,7 @@ export default function createHttpMiddleware({
           JSON.stringify(request.body || undefined)
 
     const requestHeader: HttpHeaders = { ...request.headers }
-    if (
-      !Object.prototype.hasOwnProperty.call(request.headers, 'Content-Type')
-    ) {
+    if (!Object.prototype.hasOwnProperty.call(requestHeader, 'Content-Type')) {
       requestHeader['Content-Type'] = 'application/json'
     }
     if (body) {


### PR DESCRIPTION
#### Summary

It's possible that `request.headers` is `undefined`, which will throw when we then check the properties. PR fixes this by checking `requestHeader` instead as it's will be an empty object `{}` in the case of `request.headers=undefined`

resolves #1673 

#### Todo

- Tests
  - [ ] Unit
  - [ ] Integration
  - [ ] Acceptance
- [ ] Documentation
- [x] `Type` label for the PR <!-- Used to automatically generate the changelog -->
  <!-- Two persons should review a PR, don't forget to assign them. -->
  <!-- Please remember to squash merge. -->
  <!-- All contribution guidelines can be found here: https://github.com/commercetools/nodejs/blob/master/CONTRIBUTING.md -->
