### PR TITLE
Queue middleware misplaced in resource deleter

### DIFF
--- a/packages/resource-deleter/src/main.js
+++ b/packages/resource-deleter/src/main.js
@@ -53,10 +53,10 @@ export default class ResourceDeleter {
           libraryName: pkg.name,
           libraryVersion: pkg.version,
         }),
-        createHttpMiddleware({ host: this.apiConfig.apiUrl, fetch }),
         createQueueMiddleware({
           concurrency: 20,
         }),
+        createHttpMiddleware({ host: this.apiConfig.apiUrl, fetch }),
       ],
     })
     this.logger = {


### PR DESCRIPTION
#### Summary

The queue middleware was not working in the resource deleter

#### Description

<!-- Describe the changes in this PR here and provide some context -->

#### Todo

- Tests
  - [ ] Unit
  - [ ] Integration
  - [ ] Acceptance
- [ ] Documentation
- [ ] `Type` label for the PR <!-- Used to automatically generate the changelog -->
  <!-- Two persons should review a PR, don't forget to assign them. -->
  <!-- Please remember to squash merge. -->
  <!-- All contribution guidelines can be found here: https://github.com/commercetools/nodejs/blob/master/CONTRIBUTING.md -->
