### PR TITLE
fix(sync-actions): organize customer sync actions, ex: addAdress, then setDefaultShippingAddress

### DIFF
--- a/packages/sync-actions/src/customer-actions.js
+++ b/packages/sync-actions/src/customer-actions.js
@@ -22,6 +22,14 @@ export const baseActionsList = [
   { action: 'setLocale', key: 'locale' },
   { action: 'setVatId', key: 'vatId' },
   {
+    action: 'setStores',
+    key: 'stores',
+  },
+  { action: 'setKey', key: 'key' },
+]
+
+export const setDefaultBaseActionsList = [
+  {
     action: 'setDefaultBillingAddress',
     key: 'defaultBillingAddressId',
     actionKey: 'addressId',
@@ -31,11 +39,6 @@ export const baseActionsList = [
     key: 'defaultShippingAddressId',
     actionKey: 'addressId',
   },
-  {
-    action: 'setStores',
-    key: 'stores',
-  },
-  { action: 'setKey', key: 'key' },
 ]
 
 export const referenceActionsList = [
@@ -49,6 +52,16 @@ export const referenceActionsList = [
 export function actionsMapBase(diff, oldObj, newObj, config = {}) {
   return buildBaseAttributesActions({
     actions: baseActionsList,
+    diff,
+    oldObj,
+    newObj,
+    shouldOmitEmptyString: config.shouldOmitEmptyString,
+  })
+}
+
+export function actionsMapSetDefaultBase(diff, oldObj, newObj, config = {}) {
+  return buildBaseAttributesActions({
+    actions: setDefaultBaseActionsList,
     diff,
     oldObj,
     newObj,

--- a/packages/sync-actions/src/customers.js
+++ b/packages/sync-actions/src/customers.js
@@ -45,6 +45,17 @@ function createCustomerMapActions(
     )
 
     allActions.push(
+      mapActionGroup('base', (): Array<UpdateAction> =>
+        customerActions.actionsMapSetDefaultBase(
+          diff,
+          oldObj,
+          newObj,
+          syncActionConfig
+        )
+      )
+    )
+
+    allActions.push(
       mapActionGroup('billingAddressIds', (): Array<UpdateAction> =>
         customerActions.actionsMapBillingAddresses(diff, oldObj, newObj)
       )

--- a/packages/sync-actions/test/customer-sync.spec.js
+++ b/packages/sync-actions/test/customer-sync.spec.js
@@ -1,5 +1,9 @@
 import customerSyncFn, { actionGroups } from '../src/customers'
-import { baseActionsList, referenceActionsList } from '../src/customer-actions'
+import {
+  baseActionsList,
+  setDefaultBaseActionsList,
+  referenceActionsList,
+} from '../src/customer-actions'
 
 describe('Exports', () => {
   test('action group list', () => {
@@ -21,6 +25,19 @@ describe('Exports', () => {
       { action: 'setLocale', key: 'locale' },
       { action: 'setVatId', key: 'vatId' },
       {
+        action: 'setStores',
+        key: 'stores',
+      },
+      {
+        action: 'setKey',
+        key: 'key',
+      },
+    ])
+  })
+
+  test('correctly define base set default actions list', () => {
+    expect(setDefaultBaseActionsList).toEqual([
+      {
         action: 'setDefaultBillingAddress',
         key: 'defaultBillingAddressId',
         actionKey: 'addressId',
@@ -29,14 +46,6 @@ describe('Exports', () => {
         action: 'setDefaultShippingAddress',
         key: 'defaultShippingAddressId',
         actionKey: 'addressId',
-      },
-      {
-        action: 'setStores',
-        key: 'stores',
-      },
-      {
-        action: 'setKey',
-        key: 'key',
       },
     ])
   })
@@ -124,6 +133,24 @@ describe('Actions', () => {
 
     const actual = customerSync.buildActions(now, before)
     const expected = [{ action: 'addAddress', address: now.addresses[0] }]
+    expect(actual).toEqual(expected)
+  })
+
+  test('should build `addAddress` action before `setDefaultShippingAddress`', () => {
+    const before = { addresses: [] }
+    const now = {
+      addresses: [{ streetName: 'some name', streetNumber: '5' }],
+      defaultShippingAddressId: 'def456',
+    }
+
+    const actual = customerSync.buildActions(now, before)
+    const expected = [
+      { action: 'addAddress', address: now.addresses[0] },
+      {
+        action: 'setDefaultShippingAddress',
+        addressId: now.defaultShippingAddressId,
+      },
+    ]
     expect(actual).toEqual(expected)
   })
 


### PR DESCRIPTION
#### Summary

<!-- Provide a short summary of your changes -->
make sure that customer sync-actions are generating in right order.

#### Description

<!-- Describe the changes in this PR here and provide some context -->
this PR, make sure that these two actions `setDefaultShippingAddress` and `setDefaultBillingAddress` will be in order after adding new address, so ctp platform wont fire error complaining that address id not found.

#### Todo

- Tests
  - [x] Unit
  - [ ] Integration
  - [ ] Acceptance
- [ ] Documentation
- [x] `Type` label for the PR <!-- Used to automatically generate the changelog -->
  <!-- Two persons should review a PR, don't forget to assign them. -->
  <!-- Please remember to squash merge. -->
  <!-- All contribution guidelines can be found here: https://github.com/commercetools/nodejs/blob/master/CONTRIBUTING.md -->
