### PR TITLE
feat(sync-actions): create more order update actions

### DIFF
--- a/packages/sync-actions/src/order-actions.js
+++ b/packages/sync-actions/src/order-actions.js
@@ -84,7 +84,6 @@ function _buildDeliveryParcelsAction(
     }
 
     if (isRemoveAction(key, parcel)) {
-      // parcel removed
       removeParcelActions.push({
         action: 'removeParcelFromDelivery',
         parcelId: oldObj.id,
@@ -138,12 +137,14 @@ export function actionsMapReturnsInfo(diff, oldObj, newObj) {
   const handler = createBuildArrayActions('returnInfo', {
     [ADD_ACTIONS]: (newReturnInfo) => {
       if (newReturnInfo.items) {
-        return {
-          action: 'addReturnInfo',
-          ...newReturnInfo,
-        }
+        return [
+          {
+            action: 'addReturnInfo',
+            ...newReturnInfo,
+          },
+        ]
       }
-      return {}
+      return []
     },
     [CHANGE_ACTIONS]: (oldSReturnInfo, newReturnInfo) => {
       const updateActions = Object.keys(returnInfoDiff).reduce(

--- a/packages/sync-actions/src/order-actions.js
+++ b/packages/sync-actions/src/order-actions.js
@@ -1,8 +1,21 @@
+import forEach from 'lodash.foreach'
+import * as diffpatcher from './utils/diffpatcher'
 import { buildBaseAttributesActions } from './utils/common-actions'
 import createBuildArrayActions, {
   ADD_ACTIONS,
   CHANGE_ACTIONS,
 } from './utils/create-build-array-actions'
+import extractMatchingPairs from './utils/extract-matching-pairs'
+import findMatchingPairs from './utils/find-matching-pairs'
+
+const REGEX_NUMBER = new RegExp(/^\d+$/)
+const REGEX_UNDERSCORE_NUMBER = new RegExp(/^_\d+$/)
+
+const isAddAction = (key, resource) =>
+  REGEX_NUMBER.test(key) && Array.isArray(resource) && resource.length
+
+const isRemoveAction = (key, resource) =>
+  REGEX_UNDERSCORE_NUMBER.test(key) && Number(resource[2]) === 0
 
 export const baseActionsList = [
   { action: 'changeOrderState', key: 'orderState' },
@@ -39,11 +52,99 @@ export function actionsMapDeliveries(diff, oldObj, newObj) {
   return handler(deliveriesDiff, oldObj.shippingInfo, newObj.shippingInfo)
 }
 
+function _buildDeliveryParcelsAction(
+  diffedParcels,
+  oldDelivery = {},
+  newDelivery = {}
+) {
+  const addParcelActions = []
+  const removeParcelActions = []
+
+  // generate a hashMap to be able to reference the right image from both ends
+  const matchingParcelPairs = findMatchingPairs(
+    diffedParcels,
+    oldDelivery.parcels,
+    newDelivery.parcels
+  )
+  forEach(diffedParcels, (parcel, key) => {
+    const { oldObj } = extractMatchingPairs(
+      matchingParcelPairs,
+      key,
+      oldDelivery.parcels,
+      newDelivery.parcels
+    )
+
+    if (isAddAction(key, parcel)) {
+      addParcelActions.push({
+        action: 'addParcelToDelivery',
+        deliveryId: oldDelivery.id,
+        ...diffpatcher.getDeltaValue(parcel),
+      })
+      return
+    }
+
+    if (isRemoveAction(key, parcel)) {
+      // parcel removed
+      removeParcelActions.push({
+        action: 'removeParcelFromDelivery',
+        parcelId: oldObj.id,
+      })
+    }
+  })
+
+  return [addParcelActions, removeParcelActions]
+}
+
+export function actionsMapParcels(diff, oldObj, newObj, deliveryHashMap) {
+  const shippingInfo = diff.shippingInfo
+  if (!shippingInfo) return []
+
+  const deliveries = shippingInfo.deliveries
+  if (!deliveries) return []
+
+  let addParcelActions = []
+  let removeParcelActions = []
+
+  if (deliveries)
+    forEach(deliveries, (delivery, key) => {
+      const { oldObj: oldDelivery, newObj: newDelivery } = extractMatchingPairs(
+        deliveryHashMap,
+        key,
+        oldObj.shippingInfo.deliveries,
+        newObj.shippingInfo.deliveries
+      )
+      if (REGEX_UNDERSCORE_NUMBER.test(key) || REGEX_NUMBER.test(key)) {
+        const [
+          addParcelAction,
+          removeParcelAction,
+        ] = _buildDeliveryParcelsAction(
+          delivery.parcels,
+          oldDelivery,
+          newDelivery
+        )
+
+        addParcelActions = addParcelActions.concat(addParcelAction)
+        removeParcelActions = removeParcelActions.concat(removeParcelAction)
+      }
+    })
+
+  return removeParcelActions.concat(addParcelActions)
+}
+
 export function actionsMapReturnsInfo(diff, oldObj, newObj) {
   const returnInfoDiff = diff.returnInfo
   if (!returnInfoDiff) return []
 
   const handler = createBuildArrayActions('returnInfo', {
+    [ADD_ACTIONS]: (newReturnInfo) => {
+      if (newReturnInfo.items) {
+        return {
+          action: 'addReturnInfo',
+          ...newReturnInfo,
+        }
+      }
+      return {}
+    },
     [CHANGE_ACTIONS]: (oldSReturnInfo, newReturnInfo) => {
       const updateActions = Object.keys(returnInfoDiff).reduce(
         (itemActions, key) => {

--- a/packages/sync-actions/src/orders.js
+++ b/packages/sync-actions/src/orders.js
@@ -11,6 +11,7 @@ import createMapActionGroup from './utils/create-map-action-group'
 import actionsMapCustom from './utils/action-map-custom'
 import * as orderActions from './order-actions'
 import * as diffpatcher from './utils/diffpatcher'
+import findMatchingPairs from './utils/find-matching-pairs'
 
 export const actionGroups = ['base', 'deliveries']
 
@@ -24,6 +25,15 @@ function createOrderMapActions(
     oldObj: Object /* , options */
   ): Array<UpdateAction> {
     const allActions = []
+    let deliveryHashMap
+
+    if (diff.shippingInfo && diff.shippingInfo.deliveries) {
+      deliveryHashMap = findMatchingPairs(
+        diff.shippingInfo.deliveries,
+        oldObj.shippingInfo.deliveries,
+        newObj.shippingInfo.deliveries
+      )
+    }
 
     allActions.push(
       mapActionGroup('base', (): Array<UpdateAction> =>
@@ -34,6 +44,12 @@ function createOrderMapActions(
     allActions.push(
       mapActionGroup('deliveries', (): Array<UpdateAction> =>
         orderActions.actionsMapDeliveries(diff, oldObj, newObj)
+      )
+    )
+
+    allActions.push(
+      mapActionGroup('parcels', (): Array<UpdateAction> =>
+        orderActions.actionsMapParcels(diff, oldObj, newObj, deliveryHashMap)
       )
     )
 

--- a/packages/sync-actions/test/order-sync.spec.js
+++ b/packages/sync-actions/test/order-sync.spec.js
@@ -212,6 +212,25 @@ describe('Actions', () => {
   })
 
   describe('returnInfo', () => {
+    test('should not build `returnInfo` action if items are not set', () => {
+      const before = {
+        returnInfo: [],
+      }
+
+      const now = {
+        returnInfo: [
+          {
+            returnTrackingId: 'tracking-id-1',
+            returnDate: '21-04-30T09:21:15.003Z',
+          },
+        ],
+      }
+
+      const actual = orderSync.buildActions(now, before)
+      const expected = []
+      expect(actual).toEqual(expected)
+    })
+
     test('should add `returnInfo` action', () => {
       const before = {
         returnInfo: [],

--- a/packages/sync-actions/test/order-sync.spec.js
+++ b/packages/sync-actions/test/order-sync.spec.js
@@ -89,7 +89,190 @@ describe('Actions', () => {
     })
   })
 
+  describe('parcels', () => {
+    test('should add `parcel` action', () => {
+      const before = {
+        shippingInfo: {
+          deliveries: [
+            {
+              id: 'id-1',
+              parcels: [
+                {
+                  id: 'unique-id-1',
+                  measurements: {
+                    heightInMillimeter: 20,
+                    lengthInMillimeter: 40,
+                    widthInMillimeter: 5,
+                    weightInGram: 10,
+                  },
+                  trackingData: {
+                    trackingId: 'tracking-id-1',
+                  },
+                },
+              ],
+            },
+          ],
+        },
+      }
+
+      const now = {
+        shippingInfo: {
+          deliveries: [
+            {
+              id: 'id-1',
+              parcels: [
+                {
+                  id: 'unique-id-1',
+                  measurements: {
+                    heightInMillimeter: 20,
+                    lengthInMillimeter: 40,
+                    widthInMillimeter: 5,
+                    weightInGram: 10,
+                  },
+                  trackingData: {
+                    trackingId: 'tracking-id-1',
+                  },
+                },
+                {
+                  measurements: {
+                    heightInMillimeter: 10,
+                    lengthInMillimeter: 20,
+                    widthInMillimeter: 2,
+                    weightInGram: 5,
+                  },
+                  trackingData: {
+                    trackingId: 'tracking-id-2',
+                  },
+                },
+              ],
+            },
+          ],
+        },
+      }
+
+      const actual = orderSync.buildActions(now, before)
+      const expected = [
+        {
+          action: 'addParcelToDelivery',
+          deliveryId: now.shippingInfo.deliveries[0].id,
+          measurements: now.shippingInfo.deliveries[0].parcels[1].measurements,
+          trackingData: now.shippingInfo.deliveries[0].parcels[1].trackingData,
+        },
+      ]
+
+      expect(actual).toEqual(expected)
+    })
+
+    test('should create remove `parcel` action', () => {
+      const before = {
+        shippingInfo: {
+          deliveries: [
+            {
+              id: 'id-1',
+              parcels: [
+                {
+                  id: 'unique-id-1',
+                  measurements: {
+                    heightInMillimeter: 20,
+                    lengthInMillimeter: 40,
+                    widthInMillimeter: 5,
+                    weightInGram: 10,
+                  },
+                  trackingData: {
+                    trackingId: 'tracking-id-1',
+                  },
+                },
+              ],
+            },
+          ],
+        },
+      }
+
+      const now = {
+        shippingInfo: {
+          deliveries: [
+            {
+              id: 'id-1',
+              parcels: [],
+            },
+          ],
+        },
+      }
+
+      const actual = orderSync.buildActions(now, before)
+      const expected = [
+        {
+          action: 'removeParcelFromDelivery',
+          parcelId: before.shippingInfo.deliveries[0].parcels[0].id,
+        },
+      ]
+
+      expect(actual).toEqual(expected)
+    })
+  })
+
   describe('returnInfo', () => {
+    test('should add `returnInfo` action', () => {
+      const before = {
+        returnInfo: [],
+      }
+
+      const now = {
+        returnInfo: [
+          {
+            returnTrackingId: 'tracking-id-1',
+            items: [
+              {
+                id: 'test-1',
+                type: 'LineItemReturnItem',
+                quantity: 1,
+                lineItemId: '1',
+                shipmentState: 'Advised',
+                paymentState: 'Initial',
+              },
+              {
+                id: 'test-2',
+                type: 'LineItemReturnItem',
+                quantity: 1,
+                lineItemId: '1',
+                shipmentState: 'Advised',
+                paymentState: 'Initial',
+              },
+            ],
+          },
+          {
+            returnTrackingId: 'tracking-id-2',
+            items: [
+              {
+                id: 'test-3',
+                type: 'LineItemReturnItem',
+                quantity: 2,
+                lineItemId: '2',
+                shipmentState: 'Advised',
+                paymentState: 'Initial',
+              },
+            ],
+          },
+        ],
+      }
+
+      const actual = orderSync.buildActions(now, before)
+      const expected = [
+        {
+          action: 'addReturnInfo',
+          returnTrackingId: now.returnInfo[0].returnTrackingId,
+          items: now.returnInfo[0].items,
+        },
+        {
+          action: 'addReturnInfo',
+          returnTrackingId: now.returnInfo[1].returnTrackingId,
+          items: now.returnInfo[1].items,
+        },
+      ]
+
+      expect(actual).toEqual(expected)
+    })
+
     test('should build `setReturnShipmentState` action', () => {
       const before = {
         returnInfo: [


### PR DESCRIPTION
#### Summary
Adds functionality to create update actions for order's `returnInfo` and `delivery parcel`.

#### Description
- add `returnInfo` update actions
- add `parcel` update actions
- write tests for both update actions

#### Todo

- Tests
  - [x] Unit
  - [ ] Integration
  - [ ] Acceptance
- [ ] Documentation
- [x] `Type` label for the PR <!-- Used to automatically generate the changelog -->
  <!-- Two persons should review a PR, don't forget to assign them. -->
  <!-- Please remember to squash merge. -->
  <!-- All contribution guidelines can be found here: https://github.com/commercetools/nodejs/blob/master/CONTRIBUTING.md -->
