### PR TITLE
Fix the security Vulnerabilities

### DIFF
--- a/packages/product-exporter/package.json
+++ b/packages/product-exporter/package.json
@@ -49,6 +49,11 @@
     "pretty-error": "^2.1.1",
     "yargs": "^15.0.1"
   },
+  "resolutions": {
+    "y18n": "3.2.2",
+    "hosted-git-info": "2.8.9",
+    "yargs-parser": "13.1.2"
+  },
   "devDependencies": {
     "common-tags": "1.8.0",
     "streamtest": "2.0.0"


### PR DESCRIPTION
#### Summary
Update packages to fix security vulnerabilities, the following packages flagged the Github security warnings:

- yargs-parser
- hosted-git-info
- y18n

#### Description
I updated the above packages to the recommended versions in an attempt to fix the Github security warnings.

- yargs-parser = 2.0.0
- hosted-git-info = 2.8.9
- y18n = 3.2.2


#### Todo

- Tests
  - [ ] Unit
  - [ ] Integration
  - [ ] Acceptance
- [ ] Documentation
- [ ] `Type` label for the PR <!-- Used to automatically generate the changelog -->
  <!-- Two persons should review a PR, don't forget to assign them. -->
  <!-- Please remember to squash merge. -->
  <!-- All contribution guidelines can be found here: https://github.com/commercetools/nodejs/blob/master/CONTRIBUTING.md -->
