### PR TITLE
feat(products): create update actions for `staged` flag

### DIFF
--- a/packages/sync-actions/src/products.js
+++ b/packages/sync-actions/src/products.js
@@ -43,7 +43,7 @@ function createProductMapActions(
   ): Array<UpdateAction> {
     const allActions = []
     const { sameForAllAttributeNames, enableDiscounted } = options
-    const { publish } = newObj
+    const { publish, staged } = newObj
 
     const variantHashMap = findMatchingPairs(
       diff.variants,
@@ -142,7 +142,7 @@ function createProductMapActions(
       )
     )
 
-    if (publish === true)
+    if (publish === true || staged === false)
       return flatten(allActions).map((action) => ({ ...action, staged: false }))
 
     return flatten(allActions)

--- a/packages/sync-actions/test/product-sync-base.spec.js
+++ b/packages/sync-actions/test/product-sync-base.spec.js
@@ -112,6 +112,16 @@ describe('Actions', () => {
     ])
   })
 
+  test('should build action with `staged` flag as false when `staged` is set to false', () => {
+    const before = { name: { en: 'Car', de: 'Auto' } }
+    const now = { name: { en: 'New sport car' }, staged: false }
+    const actions = productsSync.buildActions(now, before)
+
+    expect(actions).toEqual([
+      { action: 'changeName', name: { en: 'New sport car' }, staged: false },
+    ])
+  })
+
   test('should build action without `staged` flag', () => {
     const before = { name: { en: 'Car', de: 'Auto' } }
     const now = { name: { en: 'Sport car' }, publish: false }


### PR DESCRIPTION
#### Summary
For product variants, users can add a `staged` flag which only sets the `staged` projection to `current`. This adds the functionality.

#### Description

<!-- Describe the changes in this PR here and provide some context -->
- include check in `doMapActions` fn
- add test

- Tests
  - [x] Unit
  - [ ] Integration
  - [ ] Acceptance
- [ ] Documentation
- [x] `Type` label for the PR <!-- Used to automatically generate the changelog -->
  <!-- Two persons should review a PR, don't forget to assign them. -->
  <!-- Please remember to squash merge. -->
  <!-- All contribution guidelines can be found here: https://github.com/commercetools/nodejs/blob/master/CONTRIBUTING.md -->
