### PR TITLE
Add retryCodes option in HttpMiddlewareOptions

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -1,5 +1,5 @@
 [version]
-^0.141.0
+^0.165.0
 
 [ignore]
 <PROJECT_ROOT>/_book/.*
@@ -63,8 +63,13 @@ deprecated-utility=off
 [options]
 emoji=true
 include_warnings=true
-esproposal.optional_chaining=enable
-esproposal.nullish_coalescing=enable
+
+; these options are deprecated:
+; see https://flow.org/en/docs/config/options/#toc-available-options
+; esproposal.optional_chaining=enable
+; esproposal.nullish_coalescing=enable
+; well_formed_exports=true
+; types_first=true
 
 server.max_workers=2
 
@@ -74,5 +79,3 @@ suppress_type=$FlowIssue
 suppress_type=$FlowFixMe
 
 # https://medium.com/flow-type/types-first-a-scalable-new-architecture-for-flow-3d8c7ba1d4eb
-well_formed_exports=true
-types_first=true

--- a/docs/sdk/api/sdkMiddlewareHttp.md
+++ b/docs/sdk/api/sdkMiddlewareHttp.md
@@ -33,15 +33,16 @@ The HTTP middleware can run in either a browser or Node.js environment. For Node
 4.  `includeOriginalRequest` _(Boolean)_: flag whether to include the original request sent in the response. Can be useful if you want to see the final request being sent.
 5.  `maskSensitiveHeaderData` _(Boolean)_: flag to mask sensitie data in the header. e.g. Authorization token
 6.  `enableRetry` _(Boolean)_: flag to enable retry on network errors and `500` response. (Default: false)
-7.  `retryConfig` _(Object)_: Field required in the object listed below
-8.  `maxRetries` _(Number)_: number of times to retry the request before failing the request. (Default: 50)
-9.  `retryDelay` _(Number)_: amount of milliseconds to wait before retrying the next request. (Default: 200)
-10. `backoff` _(Boolean)_: activates exponential backoff. Recommended to prevent spamming of the server. (Default: true)
-11. `maxDelay` _(Number)_: The maximum duration (milliseconds) to wait before retrying, useful if the delay time grew exponentially more than reasonable
-12. `retryOnAbort` _(Boolean)_: Configure the client to retry an aborted request or not. Defaults to false.
-13. `fetch` _(Function)_: A `fetch` implementation which can be e.g. `node-fetch` or `unfetch` but also the native browser `fetch` function
-14. `timeout` _(Number)_: Request/response timeout in ms. Must be globally available or passed in `AbortController`
-15. `abortController` or `getAbortController` depending on what you chose to handle the timeout (_abortController_): This property accepts the `AbortController` instance. Could be [abort-controller](https://www.npmjs.com/package/abort-controller) or a globally available one.
+7.  `retryCodes` - _(Array)_: array of numbers used to retry requests when the status (error) code matches an entry in the list.
+8.  `retryConfig` _(Object)_: Field required in the object listed below
+9.  `maxRetries` _(Number)_: number of times to retry the request before failing the request. (Default: 50)
+10. `retryDelay` _(Number)_: amount of milliseconds to wait before retrying the next request. (Default: 200)
+11. `backoff` _(Boolean)_: activates exponential backoff. Recommended to prevent spamming of the server. (Default: true)
+12. `maxDelay` _(Number)_: The maximum duration (milliseconds) to wait before retrying, useful if the delay time grew exponentially more than reasonable
+13. `retryOnAbort` _(Boolean)_: Configure the client to retry an aborted request or not. Defaults to false.
+14. `fetch` _(Function)_: A `fetch` implementation which can be e.g. `node-fetch` or `unfetch` but also the native browser `fetch` function
+15. `timeout` _(Number)_: Request/response timeout in ms. Must be globally available or passed in `AbortController`
+16. `abortController` or `getAbortController` depending on what you chose to handle the timeout (_abortController_): This property accepts the `AbortController` instance. Could be [abort-controller](https://www.npmjs.com/package/abort-controller) or a globally available one.
 
 #### Retrying requests
 
@@ -67,6 +68,7 @@ const client = createClient({
       includeOriginalRequest: true,
       maskSensitiveHeaderData: true,
       enableRetry: true,
+      retryCodes: [500, 504],
       retryConfig: {
         maxRetries: 2,
         retryDelay: 300, //milliseconds

--- a/integration-tests/cli/discount-codes.it.js
+++ b/integration-tests/cli/discount-codes.it.js
@@ -51,7 +51,6 @@ describe('DiscountCode tests', () => {
     ])
 
     cartDiscount = data[0].body
-
   }, 15000)
 
   afterAll(async () => {

--- a/integration-tests/cli/product-json-to-csv.it.js
+++ b/integration-tests/cli/product-json-to-csv.it.js
@@ -179,10 +179,8 @@ describe('CSV and CLI Tests', () => {
 
           it('contains `description`', () => {
             const description = {
-              en:
-                'The light jackets of Save the Duck keep us cozy warm. The slight',
-              de:
-                'Die leichten Freizeitjacken von Save the Duck halten uns wohlig',
+              en: 'The light jackets of Save the Duck keep us cozy warm. The slight',
+              de: 'Die leichten Freizeitjacken von Save the Duck halten uns wohlig',
             }
             expect(product[0]).toEqual(expect.objectContaining({ description }))
             expect(product[1]).toEqual(expect.objectContaining({ description }))
@@ -305,8 +303,7 @@ describe('CSV and CLI Tests', () => {
 
           it('contains `description`', () => {
             const description = {
-              en:
-                'Golom Jacop Caesar Icarve the Duck keep us cozy warm. The slight',
+              en: 'Golom Jacop Caesar Icarve the Duck keep us cozy warm. The slight',
               de: 'Lorem Ipsum Text von Save the Duck halten uns wohlig',
             }
             expect(product[0]).toEqual(expect.objectContaining({ description }))
@@ -571,10 +568,8 @@ describe('CSV and CLI Tests', () => {
 
           it('contains `description`', () => {
             const description = {
-              en:
-                'The light jackets of Save the Duck keep us cozy warm. The slight',
-              de:
-                'Die leichten Freizeitjacken von Save the Duck halten uns wohlig',
+              en: 'The light jackets of Save the Duck keep us cozy warm. The slight',
+              de: 'Die leichten Freizeitjacken von Save the Duck halten uns wohlig',
             }
             expect(product[0]).toEqual(expect.objectContaining({ description }))
             expect(product[1]).toEqual(expect.objectContaining({ description }))
@@ -697,8 +692,7 @@ describe('CSV and CLI Tests', () => {
 
           it('contains `description`', () => {
             const description = {
-              en:
-                'Golom Jacop Caesar Icarve the Duck keep us cozy warm. The slight',
+              en: 'Golom Jacop Caesar Icarve the Duck keep us cozy warm. The slight',
               de: 'Lorem Ipsum Text von Save the Duck halten uns wohlig',
             }
             expect(product[0]).toEqual(expect.objectContaining({ description }))

--- a/integration-tests/sdk/channels.it.js
+++ b/integration-tests/sdk/channels.it.js
@@ -61,9 +61,8 @@ describe('Channels', () => {
           },
           fetch,
         }
-        const authMiddleware = createAuthMiddlewareForClientCredentialsFlow(
-          apiConfig
-        )
+        const authMiddleware =
+          createAuthMiddlewareForClientCredentialsFlow(apiConfig)
         client = createClient({
           middlewares: [
             authMiddleware,

--- a/packages/csv-parser-orders/test/deliveries.spec.js
+++ b/packages/csv-parser-orders/test/deliveries.spec.js
@@ -56,7 +56,8 @@ describe('DeliveriesParser', () => {
     test('should return an error with missing headers', () => {
       return new Promise((done) => {
         // eslint-disable-next-line max-len
-        const expectedError = /Required headers missing: 'orderNumber,item\.quantity'/
+        const expectedError =
+          /Required headers missing: 'orderNumber,item\.quantity'/
         const deliveriesParser = new DeliveriesParser()
         const spy = sinon.stub(deliveriesParser.logger, 'error')
         const readStream = streamTestFile('delivery-error-missing-headers.csv')

--- a/packages/csv-parser-price/src/main.js
+++ b/packages/csv-parser-price/src/main.js
@@ -186,10 +186,8 @@ export default class CsvParserPrice {
     const previousPrice = data.prices[data.prices.length - 1]
 
     // remove variant-sku property from price object
-    const {
-      [CONSTANTS.header.sku]: currentSku,
-      ...restOfCurrentPrice
-    } = currentPrice
+    const { [CONSTANTS.header.sku]: currentSku, ...restOfCurrentPrice } =
+      currentPrice
 
     if (previousPrice?.sku === currentSku)
       previousPrice.prices.push(restOfCurrentPrice)

--- a/packages/discount-code-importer/src/main.js
+++ b/packages/discount-code-importer/src/main.js
@@ -129,18 +129,20 @@ export default class DiscountCodeImport {
     // Batch to `batchSize` to reduce necessary fetch API calls
     const batchedList = _.chunk(codes, this.batchSize)
     const functionsList = batchedList.map(
-      (codeObjects: CodeDataArray): Function => (): Promise<void> => {
-        // Build predicate and fetch existing code
-        const predicate = DiscountCodeImport._buildPredicate(codeObjects)
-        const service = this._createService()
-        const uri = service.where(predicate).perPage(this.batchSize).build()
-        const req = this._buildRequest(uri, 'GET')
-        return this.client
-          .execute(req)
-          .then(({ body: { results: existingCodes } }: Object): Promise<void> =>
-            this._createOrUpdate(codeObjects, existingCodes)
-          )
-      }
+      (codeObjects: CodeDataArray): Function =>
+        (): Promise<void> => {
+          // Build predicate and fetch existing code
+          const predicate = DiscountCodeImport._buildPredicate(codeObjects)
+          const service = this._createService()
+          const uri = service.where(predicate).perPage(this.batchSize).build()
+          const req = this._buildRequest(uri, 'GET')
+          return this.client
+            .execute(req)
+            .then(
+              ({ body: { results: existingCodes } }: Object): Promise<void> =>
+                this._createOrUpdate(codeObjects, existingCodes)
+            )
+        }
     )
     return DiscountCodeImport.promiseMapSerially(functionsList)
       .then((): Promise<void> => Promise.resolve())
@@ -272,13 +274,8 @@ export default class DiscountCodeImport {
   }
 
   summaryReport(): Object {
-    const {
-      created,
-      updated,
-      unchanged,
-      createErrorCount,
-      updateErrorCount,
-    } = this._summary
+    const { created, updated, unchanged, createErrorCount, updateErrorCount } =
+      this._summary
     let message = ''
     if (created + updated + createErrorCount + updateErrorCount === 0)
       message = 'Summary: nothing to do, everything is fine'

--- a/packages/inventories-exporter/src/main.js
+++ b/packages/inventories-exporter/src/main.js
@@ -118,10 +118,9 @@ export default class InventoryExporter {
 
   _fetchInventories(outputStream: stream$Writable): Promise<any> {
     if (this.exportConfig.channelKey)
-      return this._resolveChannelKey(
-        this.exportConfig.channelKey
-      ).then((channelId: string): Promise<any> =>
-        this._makeRequest(outputStream, channelId)
+      return this._resolveChannelKey(this.exportConfig.channelKey).then(
+        (channelId: string): Promise<any> =>
+          this._makeRequest(outputStream, channelId)
       )
     return this._makeRequest(outputStream)
   }

--- a/packages/inventories-exporter/test/main.spec.js
+++ b/packages/inventories-exporter/test/main.spec.js
@@ -121,8 +121,7 @@ describe('InventoryExporter', () => {
         expect(processMock).toHaveBeenCalledTimes(1)
         expect(processMock.mock.calls[0][0]).toEqual({
           // eslint-disable-next-line max-len
-          uri:
-            '/foo/inventory?expand=custom.type&expand=supplyChannel&where=descript%3D%22lovely%22%20and%20supplyChannel(id%3D%221234567qwertyuxcv%22)',
+          uri: '/foo/inventory?expand=custom.type&expand=supplyChannel&where=descript%3D%22lovely%22%20and%20supplyChannel(id%3D%221234567qwertyuxcv%22)',
           method: 'GET',
           headers: {
             Authorization: 'Bearer 12345',

--- a/packages/personal-data-erasure/src/main.js
+++ b/packages/personal-data-erasure/src/main.js
@@ -114,32 +114,32 @@ export default class PersonalDataErasure {
           { accumulate: true }
         )
       })
-    ).then(async (responses: Array<Array<AllData>>): Promise<
-      Array<AllData>
-    > => {
-      const flattenedResponses = flatten(responses)
+    ).then(
+      async (responses: Array<Array<AllData>>): Promise<Array<AllData>> => {
+        const flattenedResponses = flatten(responses)
 
-      let results = flatten(
-        flattenedResponses.map(
-          (response: ClientResponse): Array<ClientResult> | void =>
-            response.body?.results
+        let results = flatten(
+          flattenedResponses.map(
+            (response: ClientResponse): Array<ClientResult> | void =>
+              response.body?.results
+          )
         )
-      )
-      const ids = results.map((result: AllData): string => result.id)
+        const ids = results.map((result: AllData): string => result.id)
 
-      if (ids.length > 0) {
-        const reference = PersonalDataErasure.buildReference(ids)
-        const messagesUri = requestBuilder.messages.where(reference).build()
-        const request = PersonalDataErasure.buildRequest(messagesUri, 'GET')
+        if (ids.length > 0) {
+          const reference = PersonalDataErasure.buildReference(ids)
+          const messagesUri = requestBuilder.messages.where(reference).build()
+          const request = PersonalDataErasure.buildRequest(messagesUri, 'GET')
 
-        const messages = await this._getAllMessages(request)
+          const messages = await this._getAllMessages(request)
 
-        results = [...messages, ...results]
+          results = [...messages, ...results]
+        }
+        this.logger.info('Export operation completed successfully')
+
+        return Promise.resolve(results)
       }
-      this.logger.info('Export operation completed successfully')
-
-      return Promise.resolve(results)
-    })
+    )
   }
 
   async _getAllMessages(request: ClientRequest): Promise<Messages> {

--- a/packages/sdk-auth/src/auth.js
+++ b/packages/sdk-auth/src/auth.js
@@ -339,15 +339,8 @@ export default class SdkAuth {
   }
 
   customFlow(requestConfig: Object): Promise<Object> {
-    const {
-      credentials,
-      host,
-      uri,
-      body,
-      token,
-      authType,
-      headers,
-    } = requestConfig
+    const { credentials, host, uri, body, token, authType, headers } =
+      requestConfig
     const _config = this._getRequestConfig({
       host,
       token,

--- a/packages/sdk-client/src/client.js
+++ b/packages/sdk-client/src/client.js
@@ -20,9 +20,9 @@ function compose(...funcs: Array<Function>): Function {
   if (funcs.length === 1) return funcs[0]
 
   return funcs.reduce(
-    (a: Function, b: Function): Function => (
-      ...args: Array<Function>
-    ): Array<Function> => a(b(...args))
+    (a: Function, b: Function): Function =>
+      (...args: Array<Function>): Array<Function> =>
+        a(b(...args))
   )
 }
 
@@ -125,6 +125,7 @@ export default function createClient(options: ClientOptions): Client {
             uri: `${path}?${enhancedQueryString}&${originalQueryString}`,
           }
 
+          // $FlowFixMe
           this.execute(enhancedRequest)
             .then((payload: SuccessResult) => {
               const { results, count: resultsLength } = payload.body

--- a/packages/sdk-client/test/client.spec.js
+++ b/packages/sdk-client/test/client.spec.js
@@ -25,7 +25,11 @@ describe('validate options', () => {
 })
 
 describe('api', () => {
-  const middlewares = [(next) => (...args) => next(...args)]
+  const middlewares = [
+    (next) =>
+      (...args) =>
+        next(...args),
+  ]
   const client = createClient({ middlewares })
   const request = {
     uri: '/foo',
@@ -51,7 +55,11 @@ describe('execute', () => {
   }
 
   test('should throw if request is missing', () => {
-    const middlewares = [(next) => (...args) => next(...args)]
+    const middlewares = [
+      (next) =>
+        (...args) =>
+          next(...args),
+    ]
     const client = createClient({ middlewares })
     expect(() => client.execute()).toThrow(
       /The "exec" function requires a "Request" object/
@@ -59,7 +67,11 @@ describe('execute', () => {
   })
 
   test('should throw if request uri is invalid', () => {
-    const middlewares = [(next) => (...args) => next(...args)]
+    const middlewares = [
+      (next) =>
+        (...args) =>
+          next(...args),
+    ]
     const client = createClient({ middlewares })
     const badRequest = {
       ...request,
@@ -71,7 +83,11 @@ describe('execute', () => {
   })
 
   test('should throw if request method is invalid', () => {
-    const middlewares = [(next) => (...args) => next(...args)]
+    const middlewares = [
+      (next) =>
+        (...args) =>
+          next(...args),
+    ]
     const client = createClient({ middlewares })
     const badRequest = {
       ...request,
@@ -192,7 +208,11 @@ describe('process', () => {
   }
 
   describe('validate arguments', () => {
-    const middlewares = [(next) => (...args) => next(...args)]
+    const middlewares = [
+      (next) =>
+        (...args) =>
+          next(...args),
+    ]
     const client = createClient({ middlewares })
 
     test('should throw if second argument missing', () => {

--- a/packages/sdk-middleware-auth/src/anonymous-session-flow.js
+++ b/packages/sdk-middleware-auth/src/anonymous-session-flow.js
@@ -19,29 +19,27 @@ export default function createAuthMiddlewareForAnonymousSessionFlow(
   const pendingTasks: Array<Task> = []
 
   const requestState = store(false)
-  return (next: Next): Next => (
-    request: MiddlewareRequest,
-    response: MiddlewareResponse
-  ) => {
-    // Check if there is already a `Authorization` header in the request.
-    // If so, then go directly to the next middleware.
-    if (
-      (request.headers && request.headers.authorization) ||
-      (request.headers && request.headers.Authorization)
-    ) {
-      next(request, response)
-      return
+  return (next: Next): Next =>
+    (request: MiddlewareRequest, response: MiddlewareResponse) => {
+      // Check if there is already a `Authorization` header in the request.
+      // If so, then go directly to the next middleware.
+      if (
+        (request.headers && request.headers.authorization) ||
+        (request.headers && request.headers.Authorization)
+      ) {
+        next(request, response)
+        return
+      }
+      const params = {
+        ...options,
+        request,
+        response,
+        ...buildRequestForAnonymousSessionFlow(options),
+        pendingTasks,
+        requestState,
+        tokenCache,
+        fetch: options.fetch,
+      }
+      authMiddlewareBase(params, next, options)
     }
-    const params = {
-      ...options,
-      request,
-      response,
-      ...buildRequestForAnonymousSessionFlow(options),
-      pendingTasks,
-      requestState,
-      tokenCache,
-      fetch: options.fetch,
-    }
-    authMiddlewareBase(params, next, options)
-  }
 }

--- a/packages/sdk-middleware-auth/src/client-credentials-flow.js
+++ b/packages/sdk-middleware-auth/src/client-credentials-flow.js
@@ -25,30 +25,28 @@ export default function createAuthMiddlewareForClientCredentialsFlow(
   const requestState = store(false)
   const pendingTasks: Array<Task> = []
 
-  return (next: Next): Next => (
-    request: MiddlewareRequest,
-    response: MiddlewareResponse
-  ) => {
-    // Check if there is already a `Authorization` header in the request.
-    // If so, then go directly to the next middleware.
-    if (
-      (request.headers && request.headers.authorization) ||
-      (request.headers && request.headers.Authorization)
-    ) {
-      next(request, response)
-      return
+  return (next: Next): Next =>
+    (request: MiddlewareRequest, response: MiddlewareResponse) => {
+      // Check if there is already a `Authorization` header in the request.
+      // If so, then go directly to the next middleware.
+      if (
+        (request.headers && request.headers.authorization) ||
+        (request.headers && request.headers.Authorization)
+      ) {
+        next(request, response)
+        return
+      }
+      const params = {
+        ...options,
+        request,
+        response,
+        ...buildRequestForClientCredentialsFlow(options),
+        pendingTasks,
+        requestState,
+        tokenCache,
+        tokenCacheKey: buildTokenCacheKey(options),
+        fetch: options.fetch,
+      }
+      authMiddlewareBase(params, next)
     }
-    const params = {
-      ...options,
-      request,
-      response,
-      ...buildRequestForClientCredentialsFlow(options),
-      pendingTasks,
-      requestState,
-      tokenCache,
-      tokenCacheKey: buildTokenCacheKey(options),
-      fetch: options.fetch,
-    }
-    authMiddlewareBase(params, next)
-  }
 }

--- a/packages/sdk-middleware-auth/src/existing-token.js
+++ b/packages/sdk-middleware-auth/src/existing-token.js
@@ -11,33 +11,31 @@ export default function createAuthMiddlewareWithExistingToken(
   authorization: string = '',
   options: ExistingTokenMiddlewareOptions = {}
 ): Middleware {
-  return (next: Next): Next => (
-    request: MiddlewareRequest,
-    response: MiddlewareResponse
-  ): mixed => {
-    if (typeof authorization !== 'string')
-      throw new Error('authorization must be a string')
-    const force = options.force === undefined ? true : options.force
+  return (next: Next): Next =>
+    (request: MiddlewareRequest, response: MiddlewareResponse): mixed => {
+      if (typeof authorization !== 'string')
+        throw new Error('authorization must be a string')
+      const force = options.force === undefined ? true : options.force
 
-    /** The request will not be modified if:
-     *  1. no argument is passed
-     *  2. force is false and authorization header exists
-     */
-    if (
-      !authorization ||
-      (((request.headers && request.headers.authorization) ||
-        (request.headers && request.headers.Authorization)) &&
-        force === false)
-    ) {
-      return next(request, response)
+      /** The request will not be modified if:
+       *  1. no argument is passed
+       *  2. force is false and authorization header exists
+       */
+      if (
+        !authorization ||
+        (((request.headers && request.headers.authorization) ||
+          (request.headers && request.headers.Authorization)) &&
+          force === false)
+      ) {
+        return next(request, response)
+      }
+      const requestWithAuth = {
+        ...request,
+        headers: {
+          ...request.headers,
+          Authorization: authorization,
+        },
+      }
+      return next(requestWithAuth, response)
     }
-    const requestWithAuth = {
-      ...request,
-      headers: {
-        ...request.headers,
-        Authorization: authorization,
-      },
-    }
-    return next(requestWithAuth, response)
-  }
 }

--- a/packages/sdk-middleware-auth/src/password-flow.js
+++ b/packages/sdk-middleware-auth/src/password-flow.js
@@ -19,29 +19,27 @@ export default function createAuthMiddlewareForPasswordFlow(
   const pendingTasks: Array<Task> = []
   const requestState = store(false)
 
-  return (next: Next): Next => (
-    request: MiddlewareRequest,
-    response: MiddlewareResponse
-  ) => {
-    // Check if there is already a `Authorization` header in the request.
-    // If so, then go directly to the next middleware.
-    if (
-      (request.headers && request.headers.authorization) ||
-      (request.headers && request.headers.Authorization)
-    ) {
-      next(request, response)
-      return
+  return (next: Next): Next =>
+    (request: MiddlewareRequest, response: MiddlewareResponse) => {
+      // Check if there is already a `Authorization` header in the request.
+      // If so, then go directly to the next middleware.
+      if (
+        (request.headers && request.headers.authorization) ||
+        (request.headers && request.headers.Authorization)
+      ) {
+        next(request, response)
+        return
+      }
+      const params = {
+        ...options,
+        request,
+        response,
+        ...buildRequestForPasswordFlow(options),
+        pendingTasks,
+        requestState,
+        tokenCache,
+        fetch: options.fetch,
+      }
+      authMiddlewareBase(params, next, options)
     }
-    const params = {
-      ...options,
-      request,
-      response,
-      ...buildRequestForPasswordFlow(options),
-      pendingTasks,
-      requestState,
-      tokenCache,
-      fetch: options.fetch,
-    }
-    authMiddlewareBase(params, next, options)
-  }
 }

--- a/packages/sdk-middleware-auth/src/refresh-token-flow.js
+++ b/packages/sdk-middleware-auth/src/refresh-token-flow.js
@@ -19,29 +19,27 @@ export default function createAuthMiddlewareForRefreshTokenFlow(
   const pendingTasks: Array<Task> = []
 
   const requestState = store(false)
-  return (next: Next): Next => (
-    request: MiddlewareRequest,
-    response: MiddlewareResponse
-  ) => {
-    // Check if there is already a `Authorization` header in the request.
-    // If so, then go directly to the next middleware.
-    if (
-      (request.headers && request.headers.authorization) ||
-      (request.headers && request.headers.Authorization)
-    ) {
-      next(request, response)
-      return
+  return (next: Next): Next =>
+    (request: MiddlewareRequest, response: MiddlewareResponse) => {
+      // Check if there is already a `Authorization` header in the request.
+      // If so, then go directly to the next middleware.
+      if (
+        (request.headers && request.headers.authorization) ||
+        (request.headers && request.headers.Authorization)
+      ) {
+        next(request, response)
+        return
+      }
+      const params = {
+        ...options,
+        request,
+        response,
+        ...buildRequestForRefreshTokenFlow(options),
+        pendingTasks,
+        requestState,
+        tokenCache,
+        fetch: options.fetch,
+      }
+      authMiddlewareBase(params, next)
     }
-    const params = {
-      ...options,
-      request,
-      response,
-      ...buildRequestForRefreshTokenFlow(options),
-      pendingTasks,
-      requestState,
-      tokenCache,
-      fetch: options.fetch,
-    }
-    authMiddlewareBase(params, next)
-  }
 }

--- a/packages/sdk-middleware-auth/test/anonymous-session-flow.spec.js
+++ b/packages/sdk-middleware-auth/test/anonymous-session-flow.spec.js
@@ -51,9 +51,8 @@ describe('Anonymous Session Flow', () => {
         resolve()
       }
       const middlewareOptions = createTestMiddlewareOptions()
-      const authMiddleware = createAuthMiddlewareForAnonymousSessionFlow(
-        middlewareOptions
-      )
+      const authMiddleware =
+        createAuthMiddlewareForAnonymousSessionFlow(middlewareOptions)
 
       authMiddleware(next)(request, response)
     }))

--- a/packages/sdk-middleware-auth/test/client-crendentials-flow.spec.js
+++ b/packages/sdk-middleware-auth/test/client-crendentials-flow.spec.js
@@ -60,9 +60,8 @@ describe('Client Crentials Flow', () => {
         jest.unmock('../src/base-auth-flow')
       }
       const middlewareOptions = createTestMiddlewareOptions()
-      const authMiddleware = createAuthMiddlewareForClientCredentialsFlow(
-        middlewareOptions
-      )
+      const authMiddleware =
+        createAuthMiddlewareForClientCredentialsFlow(middlewareOptions)
 
       authMiddleware(next)(request, response)
     }))
@@ -102,9 +101,8 @@ describe('Client Crentials Flow', () => {
         fetch,
         tokenCache,
       })
-      const authMiddleware = createAuthMiddlewareForClientCredentialsFlow(
-        middlewareOptions
-      )
+      const authMiddleware =
+        createAuthMiddlewareForClientCredentialsFlow(middlewareOptions)
 
       authMiddleware(next)(request, response)
     }))

--- a/packages/sdk-middleware-auth/test/password-flow.spec.js
+++ b/packages/sdk-middleware-auth/test/password-flow.spec.js
@@ -52,8 +52,7 @@ describe('Password Flow', () => {
           request,
           response,
           pendingTasks: [],
-          url:
-            'https://auth.europe-west1.gcp.commercetools.com/oauth/foo/customers/token',
+          url: 'https://auth.europe-west1.gcp.commercetools.com/oauth/foo/customers/token',
           basicAuth: 'MTIzOnNlY3JldA==',
         })
         expect(authMiddlewareBase).toHaveBeenCalledTimes(1)
@@ -61,9 +60,8 @@ describe('Password Flow', () => {
         resolve()
       }
       const middlewareOptions = createTestMiddlewareOptions()
-      const authMiddleware = createAuthMiddlewareForPasswordFlow(
-        middlewareOptions
-      )
+      const authMiddleware =
+        createAuthMiddlewareForPasswordFlow(middlewareOptions)
 
       authMiddleware(next)(request, response)
     }))

--- a/packages/sdk-middleware-auth/test/refresh-token-flow.spec.js
+++ b/packages/sdk-middleware-auth/test/refresh-token-flow.spec.js
@@ -54,9 +54,8 @@ describe('Refresh Token Flow', () => {
         jest.unmock('../src/base-auth-flow')
       }
       const middlewareOptions = createTestMiddlewareOptions()
-      const authMiddleware = createAuthMiddlewareForRefreshTokenFlow(
-        middlewareOptions
-      )
+      const authMiddleware =
+        createAuthMiddlewareForRefreshTokenFlow(middlewareOptions)
 
       authMiddleware(next)(request, response)
     }))

--- a/packages/sdk-middleware-correlation-id/src/correlation-id.js
+++ b/packages/sdk-middleware-correlation-id/src/correlation-id.js
@@ -10,17 +10,15 @@ import type {
 export default function createCorrelationIdMiddleware(
   options: CorrelationIdMiddlewareOptions
 ): Middleware {
-  return (next: Next): Next => (
-    request: MiddlewareRequest,
-    response: MiddlewareResponse
-  ) => {
-    const nextRequest = {
-      ...request,
-      headers: {
-        ...request.headers,
-        'X-Correlation-ID': options.generate(),
-      },
+  return (next: Next): Next =>
+    (request: MiddlewareRequest, response: MiddlewareResponse) => {
+      const nextRequest = {
+        ...request,
+        headers: {
+          ...request.headers,
+          'X-Correlation-ID': options.generate(),
+        },
+      }
+      next(nextRequest, response)
     }
-    next(nextRequest, response)
-  }
 }

--- a/packages/sdk-middleware-correlation-id/test/correlation-id.spec.js
+++ b/packages/sdk-middleware-correlation-id/test/correlation-id.spec.js
@@ -27,9 +27,8 @@ describe('CorrelationId', () => {
     },
   })
   const response = createTestResponse()
-  const correlationIdMiddleware = createCorrelationIdMiddleware(
-    middlewareOptions
-  )
+  const correlationIdMiddleware =
+    createCorrelationIdMiddleware(middlewareOptions)
 
   const next = (req) => {
     test('retains existing headers', () => {

--- a/packages/sdk-middleware-logger/src/logger.js
+++ b/packages/sdk-middleware-logger/src/logger.js
@@ -7,15 +7,13 @@ import type {
 } from 'types/sdk'
 
 export default function createLoggerMiddleware(): Middleware {
-  return (next: Next): Next => (
-    request: MiddlewareRequest,
-    response: MiddlewareResponse
-  ) => {
-    const { error, body, statusCode } = response
-    /* eslint-disable */
-    console.log('Request: ', request)
-    console.log('Response: ', { error, body, statusCode })
-    /* eslint-enable */
-    next(request, response)
-  }
+  return (next: Next): Next =>
+    (request: MiddlewareRequest, response: MiddlewareResponse) => {
+      const { error, body, statusCode } = response
+      /* eslint-disable */
+      console.log('Request: ', request)
+      console.log('Response: ', { error, body, statusCode })
+      /* eslint-enable */
+      next(request, response)
+    }
 }

--- a/packages/sdk-middleware-user-agent/src/user-agent.ts
+++ b/packages/sdk-middleware-user-agent/src/user-agent.ts
@@ -21,17 +21,15 @@ export default function createUserAgentMiddleware(
     ...options,
   })
 
-  return (next: Dispatch): Dispatch => (
-    request: MiddlewareRequest,
-    response: MiddlewareResponse
-  ) => {
-    const requestWithUserAgent = {
-      ...request,
-      headers: {
-        ...request.headers,
-        'User-Agent': userAgent,
-      },
+  return (next: Dispatch): Dispatch =>
+    (request: MiddlewareRequest, response: MiddlewareResponse) => {
+      const requestWithUserAgent = {
+        ...request,
+        headers: {
+          ...request.headers,
+          'User-Agent': userAgent,
+        },
+      }
+      next(requestWithUserAgent, response)
     }
-    next(requestWithUserAgent, response)
-  }
 }

--- a/packages/state-importer/src/main.js
+++ b/packages/state-importer/src/main.js
@@ -128,9 +128,10 @@ export default class StateImport {
     const existingStatesRequest = StateImport._buildRequest(uri, 'GET')
     return this.client
       .execute(existingStatesRequest)
-      .then(({ body: { results: existingStates } }: Object): Promise<
-        Array<void>
-      > => this._createOrUpdate(states, existingStates))
+      .then(
+        ({ body: { results: existingStates } }: Object): Promise<Array<void>> =>
+          this._createOrUpdate(states, existingStates)
+      )
       .then((): Promise<void> => Promise.resolve())
       .catch((error: any): Error => {
         // format error and throw to CLI error handler

--- a/packages/sync-actions/src/order-actions.js
+++ b/packages/sync-actions/src/order-actions.js
@@ -113,14 +113,12 @@ export function actionsMapParcels(diff, oldObj, newObj, deliveryHashMap) {
         newObj.shippingInfo.deliveries
       )
       if (REGEX_UNDERSCORE_NUMBER.test(key) || REGEX_NUMBER.test(key)) {
-        const [
-          addParcelAction,
-          removeParcelAction,
-        ] = _buildDeliveryParcelsAction(
-          delivery.parcels,
-          oldDelivery,
-          newDelivery
-        )
+        const [addParcelAction, removeParcelAction] =
+          _buildDeliveryParcelsAction(
+            delivery.parcels,
+            oldDelivery,
+            newDelivery
+          )
 
         addParcelActions = addParcelActions.concat(addParcelAction)
         removeParcelActions = removeParcelActions.concat(removeParcelAction)

--- a/packages/sync-actions/src/product-actions.js
+++ b/packages/sync-actions/src/product-actions.js
@@ -707,16 +707,13 @@ export function actionsMapPrices(
         newObj.variants
       )
       if (REGEX_UNDERSCORE_NUMBER.test(key) || REGEX_NUMBER.test(key)) {
-        const [
-          addPriceAction,
-          changePriceAction,
-          removePriceAction,
-        ] = _buildVariantPricesAction(
-          variant.prices,
-          oldVariant,
-          newVariant,
-          enableDiscounted
-        )
+        const [addPriceAction, changePriceAction, removePriceAction] =
+          _buildVariantPricesAction(
+            variant.prices,
+            oldVariant,
+            newVariant,
+            enableDiscounted
+          )
 
         addPriceActions = addPriceActions.concat(addPriceAction)
         changePriceActions = changePriceActions.concat(changePriceAction)

--- a/packages/sync-actions/src/product-types-actions.js
+++ b/packages/sync-actions/src/product-types-actions.js
@@ -186,13 +186,14 @@ const generateUpdateActionsForAttributeEnumValues = (
     ...Object.values(
       removedAttributeEnumValues.reduce(
         (nextEnumUpdateActions, removedAttributeEnumValue) => {
-          const removedAttributeEnumValueOfSameAttributeName = nextEnumUpdateActions[
-            removedAttributeEnumValue.hint.attributeName
-          ] || {
-            keys: [],
-            attributeName: removedAttributeEnumValue.hint.attributeName,
-            action: 'removeEnumValues',
-          }
+          const removedAttributeEnumValueOfSameAttributeName =
+            nextEnumUpdateActions[
+              removedAttributeEnumValue.hint.attributeName
+            ] || {
+              keys: [],
+              attributeName: removedAttributeEnumValue.hint.attributeName,
+              action: 'removeEnumValues',
+            }
           return {
             ...nextEnumUpdateActions,
             [removedAttributeEnumValue.hint.attributeName]: {

--- a/packages/sync-actions/test/product-sync-images.spec.js
+++ b/packages/sync-actions/test/product-sync-images.spec.js
@@ -198,16 +198,14 @@ describe('Actions', () => {
             assets: [],
             images: [
               {
-                url:
-                  'https://95bc80c3c245100a18cc-04fc5bec7ec901344d7cbd57f9a2fab3.ssl.cf3.rackcdn.com/Screen+Shot+2017-04--LOx1OrZZ.png',
+                url: 'https://95bc80c3c245100a18cc-04fc5bec7ec901344d7cbd57f9a2fab3.ssl.cf3.rackcdn.com/Screen+Shot+2017-04--LOx1OrZZ.png',
                 dimensions: {
                   w: 1456,
                   h: 1078,
                 },
               },
               {
-                url:
-                  'https://95bc80c3c245100a18cc-04fc5bec7ec901344d7cbd57f9a2fab3.ssl.cf3.rackcdn.com/cactus-with-surfboar-BmOeVZEZ.jpg',
+                url: 'https://95bc80c3c245100a18cc-04fc5bec7ec901344d7cbd57f9a2fab3.ssl.cf3.rackcdn.com/cactus-with-surfboar-BmOeVZEZ.jpg',
                 label: 'cactus',
                 dimensions: {
                   w: 602,
@@ -245,8 +243,7 @@ describe('Actions', () => {
           sku: '89978FRU',
           images: [
             {
-              url:
-                'https://95bc80c3c245100a18cc-04fc5bec7ec901344d7cbd57f9a2fab3.ssl.cf3.rackcdn.com/cactus-with-surfboar-BmOeVZEZ.jpg',
+              url: 'https://95bc80c3c245100a18cc-04fc5bec7ec901344d7cbd57f9a2fab3.ssl.cf3.rackcdn.com/cactus-with-surfboar-BmOeVZEZ.jpg',
               label: 'cactus',
               dimensions: {
                 w: 602,
@@ -254,8 +251,7 @@ describe('Actions', () => {
               },
             },
             {
-              url:
-                'https://95bc80c3c245100a18cc-04fc5bec7ec901344d7cbd57f9a2fab3.ssl.cf3.rackcdn.com/Screen+Shot+2017-04--LOx1OrZZ.png',
+              url: 'https://95bc80c3c245100a18cc-04fc5bec7ec901344d7cbd57f9a2fab3.ssl.cf3.rackcdn.com/Screen+Shot+2017-04--LOx1OrZZ.png',
               dimensions: {
                 w: 1456,
                 h: 1078,
@@ -353,16 +349,14 @@ describe('Actions', () => {
             prices: [],
             images: [
               {
-                url:
-                  'https://95bc80c3c245100a18cc-04fc5bec7ec901344d7cbd57f9a2fab3.ssl.cf3.rackcdn.com/Screen+Shot+2017-04--LOx1OrZZ.png',
+                url: 'https://95bc80c3c245100a18cc-04fc5bec7ec901344d7cbd57f9a2fab3.ssl.cf3.rackcdn.com/Screen+Shot+2017-04--LOx1OrZZ.png',
                 dimensions: {
                   w: 1456,
                   h: 1078,
                 },
               },
               {
-                url:
-                  'https://95bc80c3c245100a18cc-04fc5bec7ec901344d7cbd57f9a2fab3.ssl.cf3.rackcdn.com/cactus-with-surfboar-BmOeVZEZ.jpg',
+                url: 'https://95bc80c3c245100a18cc-04fc5bec7ec901344d7cbd57f9a2fab3.ssl.cf3.rackcdn.com/cactus-with-surfboar-BmOeVZEZ.jpg',
                 label: 'cactus',
                 dimensions: {
                   w: 602,
@@ -402,8 +396,7 @@ describe('Actions', () => {
           prices: [],
           images: [
             {
-              url:
-                'https://95bc80c3c245100a18cc-04fc5bec7ec901344d7cbd57f9a2fab3.ssl.cf3.rackcdn.com/cactus-with-surfboar-BmOeVZEZ.jpg',
+              url: 'https://95bc80c3c245100a18cc-04fc5bec7ec901344d7cbd57f9a2fab3.ssl.cf3.rackcdn.com/cactus-with-surfboar-BmOeVZEZ.jpg',
               label: 'cactus',
               dimensions: {
                 w: 602,

--- a/types/sdk.js
+++ b/types/sdk.js
@@ -205,7 +205,7 @@ type requestBaseOptions = {
 }
 export type executeRequestOptions = requestBaseOptions & {
   fetcher: typeof fetch,
-  tokenCache: TokenCache
+  tokenCache: TokenCache,
 }
 
 export type AuthMiddlewareBaseOptions = requestBaseOptions & {
@@ -246,12 +246,13 @@ export type HttpMiddlewareOptions = {
   maskSensitiveHeaderData?: boolean,
   timeout?: number,
   enableRetry?: boolean,
+  retryCodes?: Array<number>,
   retryConfig?: {
     maxRetries?: number,
     retryDelay?: number,
     backoff?: boolean,
     maxDelay?: number,
-    retryOnAbort: boolean
+    retryOnAbort: boolean,
   },
   fetch?: typeof fetch,
   /**


### PR DESCRIPTION
#### Summary

- add retryCodes option to HttpMiddlewareOptions
- add unit test
- add documentation
- add flow types
- remove deprecated options from `.flowconfig`

#### Description

This adds options to allow customers retry requests on a given status (error) codes.

- Tests
  - [x] Unit
- [x] Documentation

#### Related Issue:

https://github.com/commercetools/nodejs/issues/1743

Note:
Direct file changes are:
- [http.js](https://github.com/commercetools/nodejs/pull/1763/files#diff-06163118d2bcb7381ae16147c21bd62bf5b2f2c5aff4c1394301f63f03527140)
- [sdkMiddlewareHttp.md](https://github.com/commercetools/nodejs/pull/1763/files#diff-1e92b032763d9a06be1a93d747a71c2d2a3e3f111e8cbb80ef5d2c36f2533963)
- [http.spec.js](https://github.com/commercetools/nodejs/pull/1763/files#diff-2dc45118da59457716f038e656ee45aa121dfbbfc9ff22749d2340f535b2f131)
- [client.js](https://github.com/commercetools/nodejs/pull/1763/files#diff-f8c301c29069a12b85ddff25f3bb279b2ea987b5f1358458268e6496715c1ad1)
- [sdk.js](https://github.com/commercetools/nodejs/pull/1763/files#diff-5caf5fef2f8ba47fdf0d0287f68502fb216ee3a6f5ccf221757921dd1253f284)
- [.flowconfig](https://github.com/commercetools/nodejs/pull/1763/files#diff-0a2654f2e87eaa423634a60e1aa04ad7b61a755d632938219b19e79847efcfbf)

Others are as a result of flow (lint:format) changes.