### PR TITLE
feat(sync-actions): add product selection sync actions

### DIFF
--- a/.changeset/four-mangos-warn.md
+++ b/.changeset/four-mangos-warn.md
@@ -1,0 +1,7 @@
+---
+'@commercetools/sync-actions': minor
+---
+
+feat(sync-actions/product-selections): add sync action support for product selections
+
+As product selections are available via the API, the sync-actions package is updated to support generating update actions for product selections.

--- a/packages/sync-actions/src/product-selections-actions.js
+++ b/packages/sync-actions/src/product-selections-actions.js
@@ -1,0 +1,15 @@
+import { buildBaseAttributesActions } from './utils/common-actions'
+
+export const baseActionsList = [
+  { action: 'setName', key: 'name' },
+  { action: 'setKey', key: 'key' },
+]
+
+export function actionsMapBase(diff, oldObj, newObj) {
+  return buildBaseAttributesActions({
+    actions: baseActionsList,
+    diff,
+    oldObj,
+    newObj,
+  })
+}

--- a/packages/sync-actions/src/product-selections.js
+++ b/packages/sync-actions/src/product-selections.js
@@ -1,0 +1,55 @@
+/* @flow */
+import flatten from 'lodash.flatten'
+import type { SyncAction, UpdateAction, ActionGroup } from 'types/sdk'
+import createBuildActions from './utils/create-build-actions'
+import createMapActionGroup from './utils/create-map-action-group'
+import actionsMapCustom from './utils/action-map-custom'
+import * as productSelectionsActions from './product-selections-actions'
+import * as diffpatcher from './utils/diffpatcher'
+
+export const actionGroups = ['base']
+
+function createProductSelectionsMapActions(
+  mapActionGroup: (
+    type: string,
+    fn: () => Array<UpdateAction>
+  ) => Array<UpdateAction>
+): (
+  diff: Object,
+  next: Object,
+  previous: Object,
+  options: Object
+) => Array<UpdateAction> {
+  return function doMapActions(
+    diff: Object,
+    next: Object,
+    previous: Object
+  ): Array<UpdateAction> {
+    const allActions = []
+    allActions.push(
+      mapActionGroup('base', (): Array<UpdateAction> =>
+        productSelectionsActions.actionsMapBase(diff, previous, next)
+      )
+    )
+    allActions.push(
+      mapActionGroup('custom', (): Array<UpdateAction> =>
+        actionsMapCustom(diff, next, previous)
+      )
+    )
+
+    return flatten(allActions)
+  }
+}
+
+export default (actionGroupList: Array<ActionGroup>): SyncAction => {
+  const mapActionGroup = createMapActionGroup(actionGroupList)
+  const doMapActions = createProductSelectionsMapActions(mapActionGroup)
+  const onBeforeApplyingDiff = null
+  const buildActions = createBuildActions(
+    diffpatcher.diff,
+    doMapActions,
+    onBeforeApplyingDiff
+  )
+
+  return { buildActions }
+}

--- a/packages/sync-actions/test/product-selections-sync.spec.js
+++ b/packages/sync-actions/test/product-selections-sync.spec.js
@@ -1,0 +1,114 @@
+import { baseActionsList } from '../src/product-selections-actions'
+import productSelectionsSyncFn, {
+  actionGroups,
+} from '../src/product-selections'
+
+describe('Exports', () => {
+  test('action group list', () => {
+    expect(actionGroups).toEqual(['base'])
+  })
+
+  test('correctly define base actions list', () => {
+    expect(baseActionsList).toEqual([
+      { action: 'setName', key: 'name' },
+      { action: 'setKey', key: 'key' },
+    ])
+  })
+})
+
+describe('Actions', () => {
+  let productSelectionsSync
+  beforeEach(() => {
+    productSelectionsSync = productSelectionsSyncFn()
+  })
+
+  test('should build `setName` action', () => {
+    const before = {
+      name: { en: 'Algeria' },
+    }
+    const now = {
+      name: { en: 'Algeria', de: 'Algerian' },
+    }
+
+    const actual = productSelectionsSync.buildActions(now, before)
+    const expected = [{ action: 'setName', name: now.name }]
+    expect(actual).toEqual(expected)
+  })
+
+  test('should build `setKey` action', () => {
+    const before = {
+      key: '',
+    }
+    const now = {
+      key: 'new-key',
+    }
+
+    const actual = productSelectionsSync.buildActions(now, before)
+    const expected = [{ action: 'setKey', key: now.key }]
+    expect(actual).toEqual(expected)
+  })
+
+  describe('custom fields', () => {
+    test('should build `setCustomType` action', () => {
+      const before = {
+        custom: {
+          type: {
+            typeId: 'type',
+            id: 'customType1',
+          },
+          fields: {
+            customField1: true,
+          },
+        },
+      }
+      const now = {
+        custom: {
+          type: {
+            typeId: 'type',
+            id: 'customType2',
+          },
+          fields: {
+            customField1: true,
+          },
+        },
+      }
+      const actual = productSelectionsSync.buildActions(now, before)
+      const expected = [{ action: 'setCustomType', ...now.custom }]
+      expect(actual).toEqual(expected)
+    })
+  })
+
+  test('should build `setCustomField` action', () => {
+    const before = {
+      custom: {
+        type: {
+          typeId: 'type',
+          id: 'customType1',
+        },
+        fields: {
+          customField1: false,
+        },
+      },
+    }
+    const now = {
+      custom: {
+        type: {
+          typeId: 'type',
+          id: 'customType1',
+        },
+        fields: {
+          customField1: true,
+        },
+      },
+    }
+    const actual = productSelectionsSync.buildActions(now, before)
+    const expected = [
+      {
+        action: 'setCustomField',
+        name: 'customField1',
+        value: true,
+      },
+    ]
+    expect(actual).toEqual(expected)
+  })
+})


### PR DESCRIPTION
#### Summary
- Product Selections are introduced to the platform since January. We also have implemented a view in the MC to enable users to create product selection and also update them. Since the product selection were not public, the sync action for updating the product selection were generated locally in the MC code base and used for the update mutations of the GraphQL API. This PR adds product selections related sync actions to the `sync-actions` package.

 