### PR TITLE
Remove TS section from documentation

### DIFF
--- a/docs/sdk/api/typescriptSdk.md
+++ b/docs/sdk/api/typescriptSdk.md
@@ -1,5 +1,8 @@
 # TypeScript SDK Client v2
 
+Follow this [link](https://docs.commercetools.com/sdk/javascript-sdk) for an up to date and more accurate JavaScript/TypeScript SDK documentation.
+
+<!--
 We provide a packages written in typescript for using our API
 
 The **@commercetools/sdk-client-v2** is the TypeScript package that facilitates HTTP [requests](https://commercetools.github.io/nodejs/sdk/Glossary.html#clientrequest) to the Platform, ML or History API by using a predefined set of middlewares.
@@ -782,3 +785,5 @@ const client: Client = new ClientBuilder()
   ...
   .build()
 ```
+
+-->


### PR DESCRIPTION
#### Summary

- comment off all the TS section from docs
- provide a link to redirect users to the new documentation

#### Description
We now have a new and more lucid documentation from the docs team and hence no need for this duplicate doc of the TS SDK.

<!-- Describe the changes in this PR here and provide some context -->

- Tests
  - [ ] Unit
  - [ ] Integration
  - [ ] Acceptance
- [x] Documentation
- [ ] `Type` label for the PR <!-- Used to automatically generate the changelog -->
  <!-- Two persons should review a PR, don't forget to assign them. -->
  <!-- Please remember to squash merge. -->
  <!-- All contribution guidelines can be found here: https://github.com/commercetools/nodejs/blob/master/CONTRIBUTING.md -->
