### PR TITLE
feat: sync custom fields for shipping methods

### DIFF
--- a/.changeset/cyan-taxis-judge.md
+++ b/.changeset/cyan-taxis-judge.md
@@ -1,0 +1,5 @@
+---
+'@commercetools/sync-actions': minor
+---
+
+Add custom fields sync for shipping methods

--- a/packages/sync-actions/src/shipping-methods.js
+++ b/packages/sync-actions/src/shipping-methods.js
@@ -8,10 +8,11 @@ import type {
 } from 'types/sdk'
 import createBuildActions from './utils/create-build-actions'
 import createMapActionGroup from './utils/create-map-action-group'
+import actionsMapCustom from './utils/action-map-custom'
 import * as shippingMethodsActions from './shipping-methods-actions'
 import * as diffpatcher from './utils/diffpatcher'
 
-export const actionGroups = ['base', 'zoneRates']
+export const actionGroups = ['base', 'zoneRates', 'custom']
 
 function createShippingMethodsMapActions(
   mapActionGroup: Function,
@@ -39,6 +40,9 @@ function createShippingMethodsMapActions(
           shippingMethodsActions.actionsMapZoneRates(diff, oldObj, newObj)
         )
       )
+    )
+    allActions.push(
+      mapActionGroup('custom', () => actionsMapCustom(diff, newObj, oldObj))
     )
     return flatten(allActions)
   }

--- a/packages/sync-actions/test/shipping-methods.spec.js
+++ b/packages/sync-actions/test/shipping-methods.spec.js
@@ -3,7 +3,7 @@ import { baseActionsList } from '../src/shipping-methods-actions'
 
 describe('Exports', () => {
   test('action group list', () => {
-    expect(actionGroups).toEqual(['base', 'zoneRates'])
+    expect(actionGroups).toEqual(['base', 'zoneRates', 'custom'])
   })
 
   test('correctly define base actions list', () => {
@@ -525,6 +525,70 @@ describe('Actions', () => {
           action: 'addShippingRate',
           shippingRate: now.zoneRates[1].shippingRates[1],
           zone: now.zoneRates[1].zone,
+        },
+      ]
+      expect(actual).toEqual(expected)
+    })
+  })
+
+  describe('custom fields', () => {
+    test('should build `setCustomType` action', () => {
+      const before = {
+        custom: {
+          type: {
+            typeId: 'type',
+            id: 'customType1',
+          },
+          fields: {
+            customField1: true,
+          },
+        },
+      }
+      const now = {
+        custom: {
+          type: {
+            typeId: 'type',
+            id: 'customType2',
+          },
+          fields: {
+            customField1: true,
+          },
+        },
+      }
+      const actual = shippingMethodsSync.buildActions(now, before)
+      const expected = [{ action: 'setCustomType', ...now.custom }]
+      expect(actual).toEqual(expected)
+    })
+
+    test('should build `setCustomField` action', () => {
+      const before = {
+        custom: {
+          type: {
+            typeId: 'type',
+            id: 'customType1',
+          },
+          fields: {
+            customField1: false,
+          },
+        },
+      }
+      const now = {
+        custom: {
+          type: {
+            typeId: 'type',
+            id: 'customType1',
+          },
+          fields: {
+            customField1: true,
+          },
+        },
+      }
+      const actual = shippingMethodsSync.buildActions(now, before)
+      const expected = [
+        {
+          action: 'setCustomField',
+          name: 'customField1',
+          value: true,
         },
       ]
       expect(actual).toEqual(expected)


### PR DESCRIPTION
#### Summary

Adds sync of custom fields for shipping methods

#### Description

Shipping Methods can have custom fields, unfortunately sync actions were not included for them. This PR includes them.

#### Todo

- Tests
  - [x] Unit
  - [ ] Integration
  - [ ] Acceptance
- [ ] Documentation
- [ ] `Type` label for the PR <!-- Used to automatically generate the changelog -->
  <!-- Two persons should review a PR, don't forget to assign them. -->
  <!-- Please remember to squash merge. -->
  <!-- All contribution guidelines can be found here: https://github.com/commercetools/nodejs/blob/master/CONTRIBUTING.md -->
