### PR TITLE
fix(resource-deleter): add regeneratorRuntime dependency to remove error

### DIFF
--- a/packages/resource-deleter/package.json
+++ b/packages/resource-deleter/package.json
@@ -43,6 +43,8 @@
     "pino": "^6.0.0",
     "pretty-error": "^2.1.1",
     "prompts": "^2.0.4",
-    "yargs": "^16.0.0"
+    "yargs": "^16.0.0",
+    "core-js": "^3.22.5",
+    "regenerator-runtime": "^0.13.9"
   }
 }

--- a/packages/resource-deleter/src/cli.js
+++ b/packages/resource-deleter/src/cli.js
@@ -1,3 +1,6 @@
+import "core-js/stable";
+import "regenerator-runtime/runtime";
+
 import fs from 'fs'
 import { getCredentials } from '@commercetools/get-credentials'
 import pino from 'pino'

--- a/yarn.lock
+++ b/yarn.lock
@@ -1473,13 +1473,6 @@
     node-fetch "^2.6.1"
     querystring "^0.2.1"
 
-"@commercetools/sdk-middleware-auth@^5.1.6":
-  version "5.1.7"
-  resolved "https://registry.yarnpkg.com/@commercetools/sdk-middleware-auth/-/sdk-middleware-auth-5.1.7.tgz#3035d51597e34ac4e2aad60b72036b361738506f"
-  integrity sha512-lSuGWmyVtS1XRnu/R8KaUJDvF/k0OIM2lRmvCL0ih0SdRy6ztaMiEXDTKkvqS1F/mfsNjDVQRhXB6yT4OjYF7w==
-  dependencies:
-    node-fetch "^2.3.0"
-
 "@commitlint/cli@12.1.4":
   version "12.1.4"
   resolved "https://registry.yarnpkg.com/@commitlint/cli/-/cli-12.1.4.tgz#af4d9dd3c0122c7b39a61fa1cd2abbad0422dbe0"
@@ -5378,6 +5371,11 @@ core-js@^2.4.0, core-js@^2.5.0:
   version "2.6.11"
   resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.6.11.tgz#38831469f9922bded8ee21c9dc46985e0399308c"
   integrity sha512-5wjnpaT/3dV+XB4borEsnAYQchn00XSgTAWKDkEqv+K8KevjbzmofK6hfJ9TZIlpj2N0xQpazy7PiRQiWHqzWg==
+
+core-js@^3.22.5:
+  version "3.22.5"
+  resolved "https://registry.yarnpkg.com/core-js/-/core-js-3.22.5.tgz#a5f5a58e663d5c0ebb4e680cd7be37536fb2a9cf"
+  integrity sha512-VP/xYuvJ0MJWRAobcmQ8F2H6Bsn+s7zqAAjFaHGBMc5AQm7zaelhD1LGduFn2EehEcQcU+br6t+fwbpQ5d1ZWA==
 
 core-util-is@1.0.2, core-util-is@~1.0.0:
   version "1.0.2"
@@ -10777,7 +10775,7 @@ node-fetch-npm@^2.0.2:
     json-parse-better-errors "^1.0.0"
     safe-buffer "^5.1.1"
 
-node-fetch@^2.3.0, node-fetch@^2.5.0, node-fetch@^2.6.1:
+node-fetch@^2.5.0, node-fetch@^2.6.1:
   version "2.6.1"
   resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.1.tgz#045bd323631f76ed2e2b55573394416b639a0052"
   integrity sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw==
@@ -12776,6 +12774,11 @@ regenerator-runtime@^0.13.4:
   version "0.13.7"
   resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.13.7.tgz#cac2dacc8a1ea675feaabaeb8ae833898ae46f55"
   integrity sha512-a54FxoJDIr27pgf7IgeQGxmqUNYrcV338lf/6gH456HZ/PhX+5BcwHXG9ajESmwe6WRO0tAzRUrRmNONWgkrew==
+
+regenerator-runtime@^0.13.9:
+  version "0.13.9"
+  resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.13.9.tgz#8925742a98ffd90814988d7566ad30ca3b263b52"
+  integrity sha512-p3VT+cOEgxFsRRA9X4lkI1E+k2/CtnKtU4gcxyaCUreilL/vqI6CdZ3wxVUx3UOUg+gnUOQQcRI7BmSI656MYA==
 
 regenerator-transform@^0.14.2:
   version "0.14.5"


### PR DESCRIPTION
#### Fixing Error "regeneratorRuntime is not defined" in resource-deleter

Recently I was investigating issue in `resource-deleter` and found that after bumping babel, resource-deletor throws an error because we use `async & await` and regeneratorRuntime import was missing in the package.

- Added `core-js`
- Added `regenerator-runtime`

More info can be found here https://stackoverflow.com/questions/53558916/babel-7-referenceerror-regeneratorruntime-is-not-defined

 
