### PR TITLE
chore - release resource-deleter patch version

### DIFF
--- a/.changeset/gorgeous-terms-cheer.md
+++ b/.changeset/gorgeous-terms-cheer.md
@@ -1,0 +1,5 @@
+---
+'@commercetools/resource-deleter': patch
+---
+
+fix `regeneratorRuntime` issue

--- a/integration-tests/sdk/channels.it.js
+++ b/integration-tests/sdk/channels.it.js
@@ -28,6 +28,7 @@ describe('Channels', () => {
     'createdBy',
     'lastModifiedAt',
     'lastModifiedBy',
+    'versionModifiedAt'
   ]
   const service = createRequestBuilder({ projectKey }).channels
   const httpMiddleware = createHttpMiddleware({


### PR DESCRIPTION
#### Release resource-deleter patch version
I have [a fix](https://github.com/commercetools/nodejs/commit/25cb3f3cc92ce83888582eae6d98075c5f46ba02) merged into main branch to fix `regeneratorRuntime` however it was never released probably because of our new release process. So created this changeset to release the patch version of the mentioned package. 

Fix: https://jira.commercetools.com/browse/SUPPORT-17037