### PR TITLE
feat(sync-actions): add support for standalone prices

### DIFF
--- a/packages/sync-actions/src/prices-actions.js
+++ b/packages/sync-actions/src/prices-actions.js
@@ -1,0 +1,21 @@
+/* eslint-disable max-len */
+import {
+  buildBaseAttributesActions,
+} from './utils/common-actions'
+
+
+export const baseActionsList = [
+  { action: 'changeValue', key: 'value' },
+  { action: 'setDiscountedPrice', key: 'discounted' },
+]
+
+export function actionsMapBase(diff, oldObj, newObj, config = {}) {
+  return buildBaseAttributesActions({
+    actions: baseActionsList,
+    diff,
+    oldObj,
+    newObj,
+    shouldOmitEmptyString: config.shouldOmitEmptyString,
+  })
+}
+

--- a/packages/sync-actions/src/prices.js
+++ b/packages/sync-actions/src/prices.js
@@ -1,0 +1,72 @@
+/* @flow */
+import flatten from 'lodash.flatten'
+import type {
+  SyncAction,
+  SyncActionConfig,
+  ActionGroup,
+  UpdateAction,
+} from 'types/sdk'
+import createBuildActions from './utils/create-build-actions'
+import createMapActionGroup from './utils/create-map-action-group'
+import actionsMapCustom from './utils/action-map-custom'
+import * as pricesActions from './prices-actions'
+import * as diffpatcher from './utils/diffpatcher'
+
+const actionGroups = [
+  'base',
+  'custom',
+]
+
+function createPriceMapActions(
+  mapActionGroup: Function,
+  syncActionConfig: SyncActionConfig
+): (
+  diff: Object,
+  newObj: Object,
+  oldObj: Object,
+  options: Object
+) => Array<UpdateAction> {
+  return function doMapActions(
+    diff: Object,
+    newObj: Object,
+    oldObj: Object,
+  ): Array<UpdateAction> {
+    const allActions = []
+
+    allActions.push(
+      mapActionGroup('base', (): Array<UpdateAction> =>
+        pricesActions.actionsMapBase(
+          diff,
+          oldObj,
+          newObj,
+          syncActionConfig
+        )
+      )
+    )
+
+    allActions.push(
+      mapActionGroup('custom', (): Array<UpdateAction> =>
+        actionsMapCustom(diff, newObj, oldObj)
+      )
+    )
+
+    return flatten(allActions)
+  }
+}
+
+export default (
+  actionGroupList: Array<ActionGroup>,
+  syncActionConfig: SyncActionConfig
+): SyncAction => {
+  const mapActionGroup = createMapActionGroup(actionGroupList)
+  const doMapActions = createPriceMapActions(mapActionGroup, syncActionConfig)
+
+  const buildActions = createBuildActions(
+    diffpatcher.diff,
+    doMapActions,
+  )
+
+  return { buildActions }
+}
+
+export { actionGroups }

--- a/packages/sync-actions/test/price-sync.spec.js
+++ b/packages/sync-actions/test/price-sync.spec.js
@@ -1,0 +1,463 @@
+import pricesSyncFn from '../src/prices'
+
+const pricesSync = pricesSyncFn()
+
+const dateNow = new Date()
+const twoWeeksFromNow = new Date(Date.now() + 12096e5) // two weeks from now
+const threeWeeksFromNow = new Date(Date.now() + 12096e5 * 1.5)
+
+/* eslint-disable max-len */
+describe('price actions', () => {
+
+  test('should not build actions if price are not set', () => {
+    const before = {}
+    const now = {}
+    const actions = pricesSync.buildActions(now, before)
+    expect(actions).toEqual([])
+  })
+
+  test('should not build actions if now price are not set', () => {
+    const before = {
+      id: '9fe6610f',
+      value: {
+        type: 'centPrecision',
+        currencyCode: 'EUR',
+        centAmount: 1900,
+        fractionDigits: 2,
+      },
+    }
+    const now = {}
+    const actions = pricesSync.buildActions(now, before)
+    expect(actions).toEqual([])
+  })
+
+  test('should generate changeValue action', () => {
+    const before = {
+      id: '9fe6610f',
+      value: {
+        type: 'centPrecision',
+        currencyCode: 'EUR',
+        centAmount: 1900,
+        fractionDigits: 2,
+      },
+    }
+
+    const now = {
+      id: '9fe6610f',
+      value: {
+        type: 'centPrecision',
+        currencyCode: 'EUR',
+        centAmount: 5678,
+        fractionDigits: 2,
+      },
+    }
+
+    const actions = pricesSync.buildActions(now, before)
+    expect(actions).toEqual([
+      {
+        action: 'changeValue',
+        value: {
+          centAmount: 5678,
+          currencyCode: 'EUR',
+          fractionDigits: 2,
+          type: 'centPrecision',
+        },
+      },
+    ])
+  })
+
+  test('should build `setDiscountedPrice` action for newly discounted', () => {
+    const before = {
+      id: '1010',
+      value: { currencyCode: 'EGP', centAmount: 1000 },
+      country: 'UK',
+      validFrom: dateNow,
+      validUntil: twoWeeksFromNow
+    }
+
+    const now = {
+      id: '1010',
+      value: { currencyCode: 'EGP', centAmount: 1000 },
+      country: 'UK',
+      validFrom: dateNow,
+      validUntil: twoWeeksFromNow,
+      discounted: {
+        value: { centAmount: 4000, currencyCode: 'EGP' },
+        discount: { typeId: 'product-discount', id: 'pd1' },
+      }
+    }
+
+    const actions = pricesSync.buildActions(now, before)
+    expect(actions).toEqual(
+      [
+        {
+          action: 'setDiscountedPrice',
+          discounted: {
+            value: { centAmount: 4000, currencyCode: 'EGP' },
+            discount: {
+              typeId: 'product-discount',
+              id: 'pd1'
+            }
+          }
+        },
+      ]
+    )
+  })
+
+  test('should build `setDiscountedPrice` action for removed discounted', () => {
+    const before = {
+      id: '1010',
+      value: { currencyCode: 'EGP', centAmount: 1000 },
+      country: 'UK',
+      validFrom: dateNow,
+      validUntil: twoWeeksFromNow,
+      discounted: {
+        value: { centAmount: 4000, currencyCode: 'EGP' },
+        discount: { typeId: 'product-discount', id: 'pd1' },
+      }
+    }
+
+    const now = {
+      id: '1010',
+      value: { currencyCode: 'EGP', centAmount: 1000 },
+      country: 'UK',
+      validFrom: dateNow,
+      validUntil: twoWeeksFromNow,
+      //TODO: check this
+      discounted: null
+    }
+
+    const actions = pricesSync.buildActions(now, before)
+    expect(actions).toEqual(
+      [
+        {
+          action: 'setDiscountedPrice',
+          discounted: undefined
+        },
+      ]
+    )
+  })
+
+  test('should build `setDiscountedPrice` action for changed value centAmount', () => {
+    const before = {
+      id: '1010',
+      value: { currencyCode: 'GBP', centAmount: 1000 },
+      country: 'UK',
+      validFrom: dateNow,
+      validUntil: twoWeeksFromNow,
+      discounted: {
+        value: { centAmount: 4000, currencyCode: 'EUR' },
+        discount: { typeId: 'product-discount', id: 'pd1' },
+      }
+    }
+
+    const now = {
+      id: '1010',
+      value: { currencyCode: 'GBP', centAmount: 1000 },
+      country: 'UK',
+      validFrom: dateNow,
+      validUntil: twoWeeksFromNow,
+      discounted: {
+        value: { centAmount: 3000, currencyCode: 'EUR' },
+        discount: { typeId: 'product-discount', id: 'pd1' },
+      }
+    }
+
+    const actions = pricesSync.buildActions(now, before)
+    expect(actions).toEqual(
+      [
+        {
+          action: 'setDiscountedPrice',
+          discounted: {
+            value: { centAmount: 3000, currencyCode: 'EUR' },
+            discount: {
+              typeId: 'product-discount',
+              id: 'pd1'
+            }
+          }
+        },
+      ]
+    )
+  })
+
+  test('should generate setCustomField actions', () => {
+    const before = {
+      value: {
+        type: 'centPrecision',
+        currencyCode: 'EUR',
+        centAmount: 1900,
+        fractionDigits: 2,
+      },
+      id: '9fe6610f',
+      country: 'DE',
+      custom: {
+        type: {
+          typeId: 'type',
+          id: '218d8068',
+        },
+        fields: {
+          touchpoints: ['value'],
+        },
+      },
+    }
+
+    const now = {
+      value: {
+        type: 'centPrecision',
+        currencyCode: 'EUR',
+        centAmount: 1900,
+        fractionDigits: 2,
+      },
+      id: '9fe6610f',
+      country: 'DE',
+      custom: {
+        type: {
+          typeId: 'type',
+          id: '218d8068',
+        },
+        fields: {
+          published: false,
+        },
+      },
+    }
+
+    const actions = pricesSync.buildActions(now, before)
+    expect(actions).toEqual([
+      {
+        action: 'setCustomField',
+        name: 'touchpoints',
+        value: undefined,
+      },
+      {
+        action: 'setCustomField',
+        name: 'published',
+        value: false,
+      },
+    ])
+  })
+
+  test('should build `setCustomType` action without fields', () => {
+    const before = {
+      id: '888',
+      value: { currencyCode: 'GBP', centAmount: 1000 },
+      country: 'UK',
+      validFrom: dateNow,
+      validUntil: twoWeeksFromNow,
+    }
+
+    const now = {
+      id: '888',
+      value: { currencyCode: 'GBP', centAmount: 1000 },
+      country: 'UK',
+      validFrom: dateNow,
+      validUntil: twoWeeksFromNow,
+      custom: {
+        type: {
+          typeId: 'type',
+          id: '5678',
+        },
+      },
+    }
+
+    const actions = pricesSync.buildActions(now, before)
+    expect(actions).toEqual([
+      {
+        action: 'setCustomType',
+        type: {
+          id: '5678',
+          typeId: 'type',
+        },
+      },
+    ])
+  })
+
+  test('should build `setCustomType` action', () => {
+    const before = {
+      id: '999',
+      value: { currencyCode: 'GBP', centAmount: 1000 },
+      country: 'UK',
+      validFrom: dateNow,
+      validUntil: twoWeeksFromNow,
+    }
+
+    const now = {
+      // set price custom type and field
+      id: '999',
+      value: { currencyCode: 'GBP', centAmount: 1000 },
+      country: 'UK',
+      validFrom: dateNow,
+      validUntil: twoWeeksFromNow,
+      custom: {
+        type: {
+          typeId: 'type',
+          id: '5678',
+        },
+        fields: {
+          source: 'shop',
+        },
+      },
+    }
+
+    const actions = pricesSync.buildActions(now, before)
+    expect(actions).toEqual([
+      {
+        action: 'setCustomType',
+        type: {
+          id: '5678',
+          typeId: 'type',
+        },
+        fields: {
+          source: 'shop',
+        },
+      },
+    ]
+    )
+  })
+
+  test('should build `setCustomType` action which delete custom type', () => {
+    const before = {
+      id: '1111',
+      value: { currencyCode: 'GBP', centAmount: 1000 },
+      country: 'UK',
+      validFrom: dateNow,
+      validUntil: twoWeeksFromNow,
+      custom: {
+        type: {
+          typeId: 'type',
+          id: '5678',
+        },
+        fields: {
+          source: 'shop',
+        },
+      },
+    }
+
+    const now = {
+      // remove price custom field and type
+      id: '1111',
+      value: { currencyCode: 'GBP', centAmount: 1000 },
+      country: 'UK',
+      validFrom: dateNow,
+      validUntil: twoWeeksFromNow,
+    }
+
+    const actions = pricesSync.buildActions(now, before)
+    expect(actions).toEqual(
+      [
+        {
+          action: 'setCustomType',
+        },
+      ]
+    )
+  })
+
+  test('should build `setCustomField` action', () => {
+    const before = {
+      id: '1010',
+      value: { currencyCode: 'GBP', centAmount: 1000 },
+      country: 'UK',
+      validFrom: dateNow,
+      validUntil: twoWeeksFromNow,
+      custom: {
+        type: {
+          typeId: 'type',
+          id: '5678',
+        },
+        fields: {
+          source: 'shop',
+        },
+      },
+    }
+
+    const now = {
+      id: '1010',
+      value: { currencyCode: 'GBP', centAmount: 1000 },
+      country: 'UK',
+      validFrom: dateNow,
+      validUntil: twoWeeksFromNow,
+      custom: {
+        type: {
+          typeId: 'type',
+          id: '5678',
+        },
+        fields: {
+          source: 'random',
+        },
+      },
+    }
+
+    const actions = pricesSync.buildActions(now, before)
+    expect(actions).toEqual(
+      [
+        {
+          action: 'setCustomField',
+          name: 'source',
+          value: 'random',
+        },
+      ]
+    )
+  })
+
+  test('should build three `setCustomField` action', () => {
+    const before = {
+      id: '1010',
+      value: { currencyCode: 'GBP', centAmount: 1000 },
+      country: 'UK',
+      validFrom: dateNow,
+      validUntil: twoWeeksFromNow,
+      custom: {
+        type: {
+          typeId: 'type',
+          id: '5678',
+        },
+        fields: {
+          source: 'shop',
+          source2: 'shop2',
+          source3: 'shop3',
+          source4: 'shop4',
+        },
+      },
+    }
+
+    const now = {
+      id: '1010',
+      value: { currencyCode: 'GBP', centAmount: 1000 },
+      country: 'UK',
+      validFrom: dateNow,
+      validUntil: twoWeeksFromNow,
+      custom: {
+        type: {
+          typeId: 'type',
+          id: '5678',
+        },
+        fields: {
+          source: 'random',
+          source2: 'random2',
+          source3: 'random3',
+          source4: 'shop4',
+        },
+      },
+    }
+
+    const actions = pricesSync.buildActions(now, before)
+    expect(actions).toEqual(
+      [
+        {
+          action: 'setCustomField',
+          name: 'source',
+          value: 'random',
+        },
+        {
+          action: 'setCustomField',
+          name: 'source2',
+          value: 'random2',
+        },
+        {
+          action: 'setCustomField',
+          name: 'source3',
+          value: 'random3',
+        },
+      ]
+    )
+  })
+})

--- a/packages/sync-actions/test/price-sync.spec.js
+++ b/packages/sync-actions/test/price-sync.spec.js
@@ -30,6 +30,56 @@ describe('price actions', () => {
     expect(actions).toEqual([])
   })
 
+  test('should not build actions if there is no changes', () => {
+    const before = {
+      id: '9fe6610f',
+      value: {
+        type: 'centPrecision',
+        currencyCode: 'EUR',
+        centAmount: 1900,
+        fractionDigits: 2,
+      },
+      discounted: {
+        value: { centAmount: 4000, currencyCode: 'EGP' },
+        discount: { typeId: 'product-discount', id: 'pd1' },
+      },
+      custom: {
+        type: {
+          typeId: 'type',
+          id: '5678',
+        },
+        fields: {
+          source: 'shop',
+        },
+      },
+    }
+
+    const now = {
+      id: '9fe6610f',
+      value: {
+        type: 'centPrecision',
+        currencyCode: 'EUR',
+        centAmount: 1900,
+        fractionDigits: 2,
+      },
+      discounted: {
+        value: { centAmount: 4000, currencyCode: 'EGP' },
+        discount: { typeId: 'product-discount', id: 'pd1' },
+      },
+      custom: {
+        type: {
+          typeId: 'type',
+          id: '5678',
+        },
+        fields: {
+          source: 'shop',
+        },
+      },
+    }
+    const actions = pricesSync.buildActions(now, before)
+    expect(actions).toEqual([])
+  })
+
   test('should generate changeValue action', () => {
     const before = {
       id: '9fe6610f',

--- a/packages/sync-actions/test/price-sync.spec.js
+++ b/packages/sync-actions/test/price-sync.spec.js
@@ -3,8 +3,7 @@ import pricesSyncFn from '../src/prices'
 const pricesSync = pricesSyncFn()
 
 const dateNow = new Date()
-const twoWeeksFromNow = new Date(Date.now() + 12096e5) // two weeks from now
-const threeWeeksFromNow = new Date(Date.now() + 12096e5 * 1.5)
+const twoWeeksFromNow = new Date(Date.now() + 12096e5)
 
 /* eslint-disable max-len */
 describe('price actions', () => {


### PR DESCRIPTION
#### Description

<!-- Describe the changes in this PR here and provide some context -->
add support for update actions for standalone prices:
- changeValue
- setDiscountedPrice
- setCustomType
- setCustomField

#### Todo

- Tests
  - [x] Unit
  - [ ] Integration
  - [ ] Acceptance
- [ ] Documentation
- [x] `Type` label for the PR <!-- Used to automatically generate the changelog -->
  <!-- Two persons should review a PR, don't forget to assign them. -->
  <!-- Please remember to squash merge. -->
  <!-- All contribution guidelines can be found here: https://github.com/commercetools/nodejs/blob/master/CONTRIBUTING.md -->
