### PR TITLE
fix(sync-actions): fix enum type actions

### DIFF
--- a/.changeset/six-melons-hope.md
+++ b/.changeset/six-melons-hope.md
@@ -1,0 +1,5 @@
+---
+'@commercetools/sync-actions': minor
+---
+
+Fix custom types sync actions to detect addEnumValue action correctly

--- a/packages/sync-actions/src/types-actions.js
+++ b/packages/sync-actions/src/types-actions.js
@@ -31,16 +31,16 @@ export function actionsMapBase(diff, oldObj, newObj, config = {}) {
   })
 }
 
-function actionsMapEnums(attributeType, attributeDiff, previous, next) {
+function actionsMapEnums(fieldName, attributeType, attributeDiff, previous, next) {
   const addEnumActionName =
-    attributeType === 'enum' ? 'addEnumValue' : 'addLocalizedEnumValue'
+    attributeType === 'Enum' ? 'addEnumValue' : 'addLocalizedEnumValue'
   const changeEnumOrderActionName =
-    attributeType === 'enum'
+    attributeType === 'Enum'
       ? 'changeEnumValueOrder'
       : 'changeLocalizedEnumValueOrder'
   const buildArrayActions = createBuildArrayActions('values', {
     [ADD_ACTIONS]: (newEnum) => ({
-      fieldName: next.name,
+      fieldName,
       action: addEnumActionName,
       value: newEnum,
     }),
@@ -56,13 +56,13 @@ function actionsMapEnums(attributeType, attributeDiff, previous, next) {
       const changeActions = []
       if (oldEnumInNext) {
         changeActions.push({
-          fieldName: next.name,
+          fieldName,
           action: changeEnumOrderActionName,
           value: newEnum,
         })
       } else {
         changeActions.push({
-          fieldName: next.name,
+          fieldName,
           action: addEnumActionName,
           value: newEnum,
         })
@@ -89,7 +89,7 @@ function actionsMapEnums(attributeType, attributeDiff, previous, next) {
     ...(newEnumValuesOrder.length > 0
       ? [
           {
-            fieldName: next.name,
+            fieldName,
             action: changeEnumOrderActionName,
             keys: newEnumValuesOrder,
           },
@@ -131,6 +131,7 @@ export function actionsMapFieldDefinitions(
       } else if (diffValue.type.values) {
         actions.push(
           ...actionsMapEnums(
+            extractedPairs.oldObj.name,
             extractedPairs.oldObj.type.name,
             diffValue.type,
             extractedPairs.oldObj.type,

--- a/packages/sync-actions/test/types-sync-enums.spec.js
+++ b/packages/sync-actions/test/types-sync-enums.spec.js
@@ -20,8 +20,9 @@ describe('Actions', () => {
         before = createTestType({
           fieldDefinitions: [
             {
+              name: 'enum',
               type: {
-                name: 'enum',
+                name: 'Enum',
                 values: [],
               },
             },
@@ -30,8 +31,9 @@ describe('Actions', () => {
         now = createTestType({
           fieldDefinitions: [
             {
+              name: 'enum',
               type: {
-                name: 'enum',
+                name: 'Enum',
                 values: [
                   {
                     key: 'enum_1',
@@ -63,8 +65,9 @@ describe('Actions', () => {
         before = createTestType({
           fieldDefinitions: [
             {
+              name: 'enum',
               type: {
-                name: 'enum',
+                name: 'Enum',
                 values: [
                   { key: 'enum_0', label: 'enum-0' },
                   { key: 'enum_2', label: 'enum-2' },
@@ -77,8 +80,9 @@ describe('Actions', () => {
         now = createTestType({
           fieldDefinitions: [
             {
+              name: 'enum',
               type: {
-                name: 'enum',
+                name: 'Enum',
                 values: [
                   { key: 'enum_1', label: 'enum-1' },
                   { key: 'enum_3', label: 'enum-3' },
@@ -115,8 +119,9 @@ describe('Actions', () => {
         before = createTestType({
           fieldDefinitions: [
             {
+              name: 'enum',
               type: {
-                name: 'enum',
+                name: 'Enum',
                 values: [
                   { key: 'enum_1', label: 'enum-1' },
                   { key: 'enum_2', label: 'enum-2' },
@@ -129,8 +134,9 @@ describe('Actions', () => {
         now = createTestType({
           fieldDefinitions: [
             {
+              name: 'enum',
               type: {
-                name: 'enum',
+                name: 'Enum',
                 values: [
                   { key: 'enum_4', label: 'enum-4' },
                   { key: 'enum_1', label: 'enum-1' },
@@ -163,6 +169,7 @@ describe('Actions', () => {
         before = createTestType({
           fieldDefinitions: [
             {
+              name: 'lenum',
               type: {
                 name: 'lenum',
                 values: [],
@@ -173,6 +180,7 @@ describe('Actions', () => {
         now = createTestType({
           fieldDefinitions: [
             {
+              name: 'lenum',
               type: {
                 name: 'lenum',
                 values: [
@@ -212,6 +220,7 @@ describe('Actions', () => {
         before = createTestType({
           fieldDefinitions: [
             {
+              name: 'lenum',
               type: {
                 name: 'lenum',
                 values: [
@@ -226,6 +235,7 @@ describe('Actions', () => {
         now = createTestType({
           fieldDefinitions: [
             {
+              name: 'lenum',
               type: {
                 name: 'lenum',
                 values: [
@@ -257,6 +267,7 @@ describe('Actions', () => {
         before = createTestType({
           fieldDefinitions: [
             {
+              name: 'lenum',
               type: {
                 name: 'lenum',
                 values: [
@@ -271,6 +282,7 @@ describe('Actions', () => {
         now = createTestType({
           fieldDefinitions: [
             {
+              name: 'lenum',
               type: {
                 name: 'lenum',
                 values: [


### PR DESCRIPTION
#### Fix (sync-actions): addEnumValue should be generated when there type is ``

Fixes: https://jira.commercetools.com/browse/SUPPORT-16999

When using the sync-actions library to sync custom types wrong update actions are generated when enum values are updated.
we check for the attribute type with a lower ‘e’ instead of an capital 'E’ as required in the CustomFieldEnumType.
Also, we don't pass fieldName when generating the action so it takes type as a fieldName which is incorrect.
