### PR TITLE
feat(sync-action): add support for staged quotes

### DIFF
--- a/packages/sync-actions/src/staged-quotes-actions.js
+++ b/packages/sync-actions/src/staged-quotes-actions.js
@@ -1,0 +1,18 @@
+import { buildBaseAttributesActions } from './utils/common-actions'
+
+export const baseActionsList = [
+  { action: 'changeStagedQuoteState', key: 'stagedQuoteState' },
+  { action: 'setSellerComment', key: 'sellerComment' },
+  { action: 'setValidTo', key: 'validTo'},
+  { action: 'transitionState', key: 'state'},
+]
+
+export function actionsMapBase(diff, oldObj, newObj, config = {}) {
+  return buildBaseAttributesActions({
+    actions: baseActionsList,
+    diff,
+    oldObj,
+    newObj,
+    shouldOmitEmptyString: config.shouldOmitEmptyString,
+  })
+}

--- a/packages/sync-actions/src/staged-quotes.js
+++ b/packages/sync-actions/src/staged-quotes.js
@@ -1,0 +1,72 @@
+/* @flow */
+import flatten from 'lodash.flatten'
+import type {
+  SyncAction,
+  SyncActionConfig,
+  ActionGroup,
+  UpdateAction,
+} from 'types/sdk'
+import createBuildActions from './utils/create-build-actions'
+import createMapActionGroup from './utils/create-map-action-group'
+import actionsMapCustom from './utils/action-map-custom'
+import * as StagedQuotesActions from './staged-quotes-actions'
+import * as diffpatcher from './utils/diffpatcher'
+
+const actionGroups = [
+  'base',
+  'custom',
+]
+
+function createStagedQuotesMapActions(
+  mapActionGroup: Function,
+  syncActionConfig: SyncActionConfig
+): (
+  diff: Object,
+  newObj: Object,
+  oldObj: Object,
+  options: Object
+) => Array<UpdateAction> {
+  return function doMapActions(
+    diff: Object,
+    newObj: Object,
+    oldObj: Object,
+  ): Array<UpdateAction> {
+    const allActions = []
+
+    allActions.push(
+      mapActionGroup('base', (): Array<UpdateAction> =>
+        StagedQuotesActions.actionsMapBase(
+          diff,
+          oldObj,
+          newObj,
+          syncActionConfig
+        )
+      )
+    )
+
+    allActions.push(
+      mapActionGroup('custom', (): Array<UpdateAction> =>
+        actionsMapCustom(diff, newObj, oldObj)
+      )
+    )
+
+    return flatten(allActions)
+  }
+}
+
+export default (
+  actionGroupList: Array<ActionGroup>,
+  syncActionConfig: SyncActionConfig
+): SyncAction => {
+  const mapActionGroup = createMapActionGroup(actionGroupList)
+  const doMapActions = createStagedQuotesMapActions(mapActionGroup, syncActionConfig)
+
+  const buildActions = createBuildActions(
+    diffpatcher.diff,
+    doMapActions,
+  )
+
+  return { buildActions }
+}
+
+export { actionGroups }

--- a/packages/sync-actions/test/staged-quotes-sync.spec.js
+++ b/packages/sync-actions/test/staged-quotes-sync.spec.js
@@ -1,0 +1,165 @@
+import createStagedQuotesSync, { actionGroups } from '../src/staged-quotes'
+import { baseActionsList } from '../src/staged-quotes-actions'
+
+describe('Exports', () => {
+  test('action group list', () => {
+    expect(actionGroups).toEqual(['base', 'custom'])
+  })
+
+  describe('action list', () => {
+    test('should contain `changeStagedQuoteState` action', () => {
+      expect(baseActionsList).toEqual(
+        expect.arrayContaining([{ action: 'changeStagedQuoteState', key: 'stagedQuoteState' }])
+      )
+    })
+
+    test('should contain `setSellerComment` action', () => {
+      expect(baseActionsList).toEqual(
+        expect.arrayContaining([{ action: 'setSellerComment', key: 'sellerComment' }])
+      )
+    })
+
+    test('should contain `setValidTo` action', () => {
+      expect(baseActionsList).toEqual(
+        expect.arrayContaining([{ action: 'setValidTo', key: 'validTo' }])
+      )
+    })
+
+    test('should contain `transitionState` action', () => {
+      expect(baseActionsList).toEqual(
+        expect.arrayContaining([{ action: 'transitionState', key: 'state' }])
+      )
+    })
+  })
+})
+
+describe('Actions', () => {
+  let stagedQuotesSync
+  beforeEach(() => {
+    stagedQuotesSync = createStagedQuotesSync()
+  })
+
+  test('should build `changeQuoteState` action', () => {
+    const before = { stagedQuoteState: 'InProgress' }
+    const now = { stagedQuoteState: 'Sent' }
+    const actual = stagedQuotesSync.buildActions(now, before)
+    const expected = [
+      {
+        action: 'changeStagedQuoteState',
+        ...now
+      }
+    ]
+    expect(actual).toEqual(expected)
+  })
+
+  test('should build `setSellerComment` action', () => {
+    const before = { sellerComment: '' }
+    const now = { sellerComment: 'let me know if this matches your expectations' }
+    const actual = stagedQuotesSync.buildActions(now, before)
+    const expected = [
+      {
+        action: 'setSellerComment',
+        ...now
+      }
+    ]
+    expect(actual).toEqual(expected)
+  })
+
+  test('should build `setValidTo` action', () => {
+    const before = { validTo: '' }
+    const now = { validTo: '2022-09-22T15:41:55.816Z' }
+    const actual = stagedQuotesSync.buildActions(now, before)
+    const expected = [
+      {
+        action: 'setValidTo',
+        ...now
+      }
+    ]
+    expect(actual).toEqual(expected)
+  })
+
+  test('should build `transitionState` action', () => {
+    const before = {
+      state : {
+      typeId : 'state',
+      id : 'sid1'
+      }
+    }
+    const now = {
+      state : {
+      typeId : 'state',
+      id : 'sid2'
+      }
+    }
+    const actual = stagedQuotesSync.buildActions(now, before)
+    const expected = [
+      {
+        action: 'transitionState',
+        ...now
+      }
+    ]
+    expect(actual).toEqual(expected)
+  })
+
+  test('should build `setCustomType` action', () => {
+    const before = {
+      custom: {
+        type: {
+          typeId: 'type',
+          id: 'customType1',
+        },
+        fields: {
+          customField1: true,
+        },
+      },
+    }
+    const now = {
+      custom: {
+        type: {
+          typeId: 'type',
+          id: 'customType2',
+        },
+        fields: {
+          customField1: true,
+        },
+      },
+    }
+    const actual = stagedQuotesSync.buildActions(now, before)
+    const expected = [{ action: 'setCustomType', ...now.custom }]
+    expect(actual).toEqual(expected)
+  })
+
+  test('should build `setCustomField` action', () => {
+    const before = {
+      custom: {
+        type: {
+          typeId: 'type',
+          id: 'customType1',
+        },
+        fields: {
+          customField1: false,
+        },
+      },
+    }
+    const now = {
+      custom: {
+        type: {
+          typeId: 'type',
+          id: 'customType1',
+        },
+        fields: {
+          customField1: true,
+        },
+      },
+    }
+    const actual = stagedQuotesSync.buildActions(now, before)
+    const expected = [
+      {
+        action: 'setCustomField',
+        name: 'customField1',
+        value: true,
+      },
+    ]
+    expect(actual).toEqual(expected)
+  })
+})


### PR DESCRIPTION
#### Summary

Add sync-actions coverage for staged quotes. [link to docs](https://docs.commercetools.com/api/projects/staged-quotes#update-actions)

#### Description
