### PR TITLE
feat(sync-action): add support for quote requests

### DIFF
--- a/packages/sync-actions/src/quote-requests-actions.js
+++ b/packages/sync-actions/src/quote-requests-actions.js
@@ -1,0 +1,16 @@
+import { buildBaseAttributesActions } from './utils/common-actions'
+
+export const baseActionsList = [
+  { action: 'changeQuoteRequestState', key: 'quoteRequestState' },
+  { action: 'transitionState', key: 'state'},
+]
+
+export function actionsMapBase(diff, oldObj, newObj, config = {}) {
+  return buildBaseAttributesActions({
+    actions: baseActionsList,
+    diff,
+    oldObj,
+    newObj,
+    shouldOmitEmptyString: config.shouldOmitEmptyString,
+  })
+}

--- a/packages/sync-actions/src/quote-requests.js
+++ b/packages/sync-actions/src/quote-requests.js
@@ -1,0 +1,72 @@
+/* @flow */
+import flatten from 'lodash.flatten'
+import type {
+  SyncAction,
+  SyncActionConfig,
+  ActionGroup,
+  UpdateAction,
+} from 'types/sdk'
+import createBuildActions from './utils/create-build-actions'
+import createMapActionGroup from './utils/create-map-action-group'
+import actionsMapCustom from './utils/action-map-custom'
+import * as QuoteRequestsActions from './quote-requests-actions'
+import * as diffpatcher from './utils/diffpatcher'
+
+const actionGroups = [
+  'base',
+  'custom',
+]
+
+function createQuoteRequestsMapActions(
+  mapActionGroup: Function,
+  syncActionConfig: SyncActionConfig
+): (
+  diff: Object,
+  newObj: Object,
+  oldObj: Object,
+  options: Object
+) => Array<UpdateAction> {
+  return function doMapActions(
+    diff: Object,
+    newObj: Object,
+    oldObj: Object,
+  ): Array<UpdateAction> {
+    const allActions = []
+
+    allActions.push(
+      mapActionGroup('base', (): Array<UpdateAction> =>
+        QuoteRequestsActions.actionsMapBase(
+          diff,
+          oldObj,
+          newObj,
+          syncActionConfig
+        )
+      )
+    )
+
+    allActions.push(
+      mapActionGroup('custom', (): Array<UpdateAction> =>
+        actionsMapCustom(diff, newObj, oldObj)
+      )
+    )
+
+    return flatten(allActions)
+  }
+}
+
+export default (
+  actionGroupList: Array<ActionGroup>,
+  syncActionConfig: SyncActionConfig
+): SyncAction => {
+  const mapActionGroup = createMapActionGroup(actionGroupList)
+  const doMapActions = createQuoteRequestsMapActions(mapActionGroup, syncActionConfig)
+
+  const buildActions = createBuildActions(
+    diffpatcher.diff,
+    doMapActions,
+  )
+
+  return { buildActions }
+}
+
+export { actionGroups }

--- a/packages/sync-actions/test/quote-requests-sync.spec.js
+++ b/packages/sync-actions/test/quote-requests-sync.spec.js
@@ -1,0 +1,127 @@
+import createQuoteRequestsSync, { actionGroups } from '../src/quote-requests'
+import { baseActionsList } from '../src/quote-requests-actions'
+
+describe('Exports', () => {
+  test('action group list', () => {
+    expect(actionGroups).toEqual(['base', 'custom'])
+  })
+
+  describe('action list', () => {
+    test('should contain `changeQuoteRequestState` action', () => {
+      expect(baseActionsList).toEqual(
+        expect.arrayContaining([{ action: 'changeQuoteRequestState', key: 'quoteRequestState' }])
+      )
+    })
+
+    test('should contain `transitionState` action', () => {
+      expect(baseActionsList).toEqual(
+        expect.arrayContaining([{ action: 'transitionState', key: 'state' }])
+      )
+    })
+  })
+})
+
+describe('Actions', () => {
+  let quoteRequestsSync
+  beforeEach(() => {
+    quoteRequestsSync = createQuoteRequestsSync()
+  })
+
+  test('should build `changeQuoteRequestState` action', () => {
+    const before = { quoteRequestState: 'Submitted' }
+    const now = { quoteRequestState: 'Accepted' }
+    const actual = quoteRequestsSync.buildActions(now, before)
+    const expected = [
+      {
+        action: 'changeQuoteRequestState',
+        ...now
+      }
+    ]
+    expect(actual).toEqual(expected)
+  })
+
+  test('should build `transitionState` action', () => {
+    const before = {
+      state : {
+      typeId : 'state',
+      id : 'sid1'
+      }
+    }
+    const now = {
+      state : {
+      typeId : 'state',
+      id : 'sid2'
+      }
+    }
+    const actual = quoteRequestsSync.buildActions(now, before)
+    const expected = [
+      {
+        action: 'transitionState',
+        ...now
+      }
+    ]
+    expect(actual).toEqual(expected)
+  })
+
+  test('should build `setCustomType` action', () => {
+    const before = {
+      custom: {
+        type: {
+          typeId: 'type',
+          id: 'customType1',
+        },
+        fields: {
+          customField1: true,
+        },
+      },
+    }
+    const now = {
+      custom: {
+        type: {
+          typeId: 'type',
+          id: 'customType2',
+        },
+        fields: {
+          customField1: true,
+        },
+      },
+    }
+    const actual = quoteRequestsSync.buildActions(now, before)
+    const expected = [{ action: 'setCustomType', ...now.custom }]
+    expect(actual).toEqual(expected)
+  })
+
+  test('should build `setCustomField` action', () => {
+    const before = {
+      custom: {
+        type: {
+          typeId: 'type',
+          id: 'customType1',
+        },
+        fields: {
+          customField1: false,
+        },
+      },
+    }
+    const now = {
+      custom: {
+        type: {
+          typeId: 'type',
+          id: 'customType1',
+        },
+        fields: {
+          customField1: true,
+        },
+      },
+    }
+    const actual = quoteRequestsSync.buildActions(now, before)
+    const expected = [
+      {
+        action: 'setCustomField',
+        name: 'customField1',
+        value: true,
+      },
+    ]
+    expect(actual).toEqual(expected)
+  })
+})


### PR DESCRIPTION
#### Summary

Add sync-actions coverage for quote requests. [link to docs](https://docs.commercetools.com/api/projects/quote-requests#update-actions)

#### Description
