### PR TITLE
refactor(utils): improve performance of `copyEmptyArrayProps` function

### DIFF
--- a/.changeset/wise-timers-shake.md
+++ b/.changeset/wise-timers-shake.md
@@ -1,0 +1,5 @@
+---
+'@commercetools/sync-actions': minor
+---
+
+feat(sync-actions): improve performance for large arrays comparisons"

--- a/packages/sync-actions/src/utils/copy-empty-array-props.js
+++ b/packages/sync-actions/src/utils/copy-empty-array-props.js
@@ -13,18 +13,17 @@ const CUSTOM = 'custom'
 export default function copyEmptyArrayProps(oldObj = {}, newObj = {}) {
   if (!isNil(oldObj) && !isNil(newObj)) {
     const nextObjectWithEmptyArray = Object.entries(oldObj).reduce(
-      (nextObject, [key, value]) => {
-        const merged = {
-          ...newObj,
-          ...nextObject,
-        }
-
+      (merged, [key, value]) => {
         // Ignore CUSTOM key as this object is dynamic and its up to the user to dynamically change it
         // todo, it would be better if we pass it as ignored keys param
         if (key === CUSTOM) return merged
 
         if (Array.isArray(value) && newObj[key] && newObj[key].length >= 1) {
           /* eslint-disable no-plusplus */
+          const hashMapValue = value.reduce((acc, val) => {
+            acc[val.id] = val
+            return acc
+          }, {})
           for (let i = 0; i < newObj[key].length; i++) {
             if (
               !isNil(newObj[key][i]) &&
@@ -32,16 +31,14 @@ export default function copyEmptyArrayProps(oldObj = {}, newObj = {}) {
               !isNil(newObj[key][i].id)
             ) {
               // Since its unordered array elements then check if the element on `oldObj` exists by id
-              const foundObject = value.find(
-                (v) => Number(v.id) === Number(newObj[key][i].id)
-              )
+              const foundObject = hashMapValue[newObj[key][i].id]
               if (!isNil(foundObject)) {
                 const [, nestedObject] = copyEmptyArrayProps(
                   foundObject,
                   newObj[key][i]
                 )
                 /* eslint-disable no-param-reassign */
-                newObj[key][i] = nestedObject
+                merged[key][i] = nestedObject
               }
             }
           }
@@ -49,10 +46,8 @@ export default function copyEmptyArrayProps(oldObj = {}, newObj = {}) {
           return merged
         }
         if (Array.isArray(value)) {
-          return {
-            ...merged,
-            [key]: isNil(newObj[key]) ? [] : newObj[key],
-          }
+          merged[key] = isNil(newObj[key]) ? [] : newObj[key]
+          return merged
         }
         if (
           !isNil(newObj[key]) &&
@@ -62,10 +57,8 @@ export default function copyEmptyArrayProps(oldObj = {}, newObj = {}) {
           !(value instanceof Date)
         ) {
           const [, nestedObject] = copyEmptyArrayProps(value, newObj[key])
-          return {
-            ...merged,
-            [key]: nestedObject,
-          }
+          merged[key] = nestedObject
+          return merged
         }
         return merged
       },

--- a/packages/sync-actions/test/utils/copy-empty-array-props.spec.js
+++ b/packages/sync-actions/test/utils/copy-empty-array-props.spec.js
@@ -308,7 +308,7 @@ test('shouldnt change objects since there is no arrays to copy', () => {
   expect(fixedNewObj).toEqual(newObj)
 })
 
-test('performance test for large arrays should be less than 100 ms', () => {
+test('performance test for large arrays should be less than 200 ms', () => {
   const oldObj = {
     addresses: Array(5000)
       .fill(null)
@@ -327,5 +327,5 @@ test('performance test for large arrays should be less than 100 ms', () => {
 
   expect(old).toEqual(oldObj)
   expect(fixedNewObj).toEqual(newObj)
-  expect(end - start).toBeLessThan(100)
+  expect(end - start).toBeLessThan(200)
 })

--- a/packages/sync-actions/test/utils/copy-empty-array-props.spec.js
+++ b/packages/sync-actions/test/utils/copy-empty-array-props.spec.js
@@ -1,3 +1,4 @@
+import { performance } from 'perf_hooks'
 import copyEmptyArrayProps from '../../src/utils/copy-empty-array-props'
 
 describe('null check on root value', () => {
@@ -305,4 +306,26 @@ test('shouldnt change objects since there is no arrays to copy', () => {
 
   expect(old).toEqual(oldObj)
   expect(fixedNewObj).toEqual(newObj)
+})
+
+test('performance test for large arrays should be less than 100 ms', () => {
+  const oldObj = {
+    addresses: Array(5000)
+      .fill(null)
+      .map((a, index) => ({ id: `address-${index}` })),
+  }
+
+  const newObj = {
+    addresses: Array(5000)
+      .fill(null)
+      .map((a, index) => ({ id: `address-${index}` })),
+  }
+
+  const start = performance.now()
+  const [old, fixedNewObj] = copyEmptyArrayProps(oldObj, newObj)
+  const end = performance.now()
+
+  expect(old).toEqual(oldObj)
+  expect(fixedNewObj).toEqual(newObj)
+  expect(end - start).toBeLessThan(100)
 })


### PR DESCRIPTION
#### Summary

Refactors a little bit the way `copyEmptyArrayProps` is implemented in order to seek a better performance specially for cases with a huge amount of items in an array.

#### Description

Context: We (pangolins) do a heavy use of this library in Audit Log. We were observing some customer comparisons that were taking a huge amount of time and when debugging that led us to spotting sync actions library as the one that was causing the delay.

After some investigation, we found that the library was not really performant for cases when customers with a huge amount of addresses where compared between versions. In our case it was a customer with almost 13k addresses in the old and new version.

In this PR we propose a solution by changing the implementation to remove the usage of spread operators inside a reduce in favour of attribute assignments or even the usage of a map instead of array methods which usually led to the O(n^2) problem [More info](https://prateeksurana.me/blog/why-using-object-spread-with-reduce-bad-idea/#why-is-the-spread-operator-so-slow)

#### Todo

- Tests
  - [X] Unit
  - [X] Integration
  - [ ] Acceptance
- [ ] Documentation
- [x] `Type` label for the PR <!-- Used to automatically generate the changelog -->
  <!-- Two persons should review a PR, don't forget to assign them. -->
  <!-- Please remember to squash merge. -->
  <!-- All contribution guidelines can be found here: https://github.com/commercetools/nodejs/blob/master/CONTRIBUTING.md -->
