### PR TITLE
fix(sync-actions/orders): adjust diff calculation of returnInfo items

### DIFF
--- a/.changeset/flat-phones-explain.md
+++ b/.changeset/flat-phones-explain.md
@@ -1,0 +1,5 @@
+---
+'@commercetools/sync-actions': patch
+---
+
+fix(sync-actions/orders): adjust diff calculation of returnInfo items

--- a/packages/sync-actions/src/order-actions.js
+++ b/packages/sync-actions/src/order-actions.js
@@ -148,11 +148,9 @@ export function actionsMapReturnsInfo(diff, oldObj, newObj) {
     },
     [CHANGE_ACTIONS]: (oldSReturnInfo, newReturnInfo, key) => {
       const { items = {} } = returnInfoDiff[key]
-
       if (Object.keys(items).length === 0) {
         return []
       }
-
       return Object.keys(items).reduce((actions, index) => {
         const item = newReturnInfo.items[index]
         if (items[index].shipmentState) {
@@ -169,7 +167,6 @@ export function actionsMapReturnsInfo(diff, oldObj, newObj) {
             paymentState: item.paymentState,
           })
         }
-
         return actions
       }, [])
     },

--- a/packages/sync-actions/src/order-actions.js
+++ b/packages/sync-actions/src/order-actions.js
@@ -148,34 +148,30 @@ export function actionsMapReturnsInfo(diff, oldObj, newObj) {
     },
     [CHANGE_ACTIONS]: (oldSReturnInfo, newReturnInfo, key) => {
       const { items = {} } = returnInfoDiff[key]
-      const itemActions = []
-      if (Object.keys(items).length > 0) {
-        return [
-          ...itemActions,
-          ...Object.keys(items).reduce((actions, index) => {
-            const itActions = []
-            const item = newReturnInfo.items[index]
-            if (items[index].shipmentState) {
-              itActions.push({
-                action: 'setReturnShipmentState',
-                returnItemId: item.id,
-                shipmentState: item.shipmentState,
-              })
-            }
-            if (items[index].paymentState) {
-              itActions.push({
-                action: 'setReturnPaymentState',
-                returnItemId: item.id,
-                paymentState: item.paymentState,
-              })
-            }
 
-            return [...actions, ...itActions]
-          }, []),
-        ]
+      if (Object.keys(items).length === 0) {
+        return []
       }
 
-      return itemActions
+      return Object.keys(items).reduce((actions, index) => {
+        const item = newReturnInfo.items[index]
+        if (items[index].shipmentState) {
+          actions.push({
+            action: 'setReturnShipmentState',
+            returnItemId: item.id,
+            shipmentState: item.shipmentState,
+          })
+        }
+        if (items[index].paymentState) {
+          actions.push({
+            action: 'setReturnPaymentState',
+            returnItemId: item.id,
+            paymentState: item.paymentState,
+          })
+        }
+
+        return actions
+      }, [])
     },
   })
 

--- a/packages/sync-actions/src/order-actions.js
+++ b/packages/sync-actions/src/order-actions.js
@@ -146,42 +146,36 @@ export function actionsMapReturnsInfo(diff, oldObj, newObj) {
       }
       return []
     },
-    [CHANGE_ACTIONS]: (oldSReturnInfo, newReturnInfo) => {
-      const updateActions = Object.keys(returnInfoDiff).reduce(
-        (itemActions, key) => {
-          const { items = {} } = returnInfoDiff[key]
-          if (Object.keys(items).length > 0) {
-            return [
-              ...itemActions,
-              ...Object.keys(items).reduce((actions, index) => {
-                const itActions = []
-                const item = newReturnInfo.items[index]
-                if (items[index].shipmentState) {
-                  itActions.push({
-                    action: 'setReturnShipmentState',
-                    returnItemId: item.id,
-                    shipmentState: item.shipmentState,
-                  })
-                }
-                if (items[index].paymentState) {
-                  itActions.push({
-                    action: 'setReturnPaymentState',
-                    returnItemId: item.id,
-                    paymentState: item.paymentState,
-                  })
-                }
+    [CHANGE_ACTIONS]: (oldSReturnInfo, newReturnInfo, key) => {
+      const { items = {} } = returnInfoDiff[key]
+      const itemActions = []
+      if (Object.keys(items).length > 0) {
+        return [
+          ...itemActions,
+          ...Object.keys(items).reduce((actions, index) => {
+            const itActions = []
+            const item = newReturnInfo.items[index]
+            if (items[index].shipmentState) {
+              itActions.push({
+                action: 'setReturnShipmentState',
+                returnItemId: item.id,
+                shipmentState: item.shipmentState,
+              })
+            }
+            if (items[index].paymentState) {
+              itActions.push({
+                action: 'setReturnPaymentState',
+                returnItemId: item.id,
+                paymentState: item.paymentState,
+              })
+            }
 
-                return [...actions, ...itActions]
-              }, []),
-            ]
-          }
+            return [...actions, ...itActions]
+          }, []),
+        ]
+      }
 
-          return itemActions
-        },
-        []
-      )
-
-      return updateActions
+      return itemActions
     },
   })
 

--- a/packages/sync-actions/test/order-sync.spec.js
+++ b/packages/sync-actions/test/order-sync.spec.js
@@ -1,3 +1,4 @@
+import { performance } from 'perf_hooks'
 import orderSyncFn, { actionGroups } from '../src/orders'
 import { baseActionsList } from '../src/order-actions'
 
@@ -653,6 +654,46 @@ describe('Actions', () => {
           },
         ]
         expect(actual).toEqual(expected)
+      })
+      describe('performance test', () => {
+        it('should be performant for large arrays', () => {
+          const before = {
+            returnInfo: Array(100)
+              .fill(null)
+              .map((a, index) => ({
+                items: Array(50)
+                  .fill(null)
+                  .map((b, index2) => {
+                    return {
+                      id: `id-${index}-${index2}`,
+                      shipmentState: 'Returned',
+                      paymentState: 'Initial',
+                    }
+                  }),
+              })),
+          }
+          const now = {
+            returnInfo: Array(100)
+              .fill(null)
+              .map((a, index) => ({
+                items: Array(50)
+                  .fill(null)
+                  .map((b, index2) => {
+                    return {
+                      id: `id-${index}-${index2}`,
+                      shipmentState: 'Returned',
+                      paymentState: 'Refunded',
+                    }
+                  }),
+              })),
+          }
+
+          const start = performance.now()
+          orderSync.buildActions(now, before)
+          const end = performance.now()
+
+          expect(end - start).toBeLessThan(200)
+        })
       })
     })
   })

--- a/packages/sync-actions/test/order-sync.spec.js
+++ b/packages/sync-actions/test/order-sync.spec.js
@@ -692,7 +692,7 @@ describe('Actions', () => {
           orderSync.buildActions(now, before)
           const end = performance.now()
 
-          expect(end - start).toBeLessThan(200)
+          expect(end - start).toBeLessThan(400)
         })
       })
     })

--- a/packages/sync-actions/test/order-sync.spec.js
+++ b/packages/sync-actions/test/order-sync.spec.js
@@ -546,6 +546,115 @@ describe('Actions', () => {
       ]
       expect(actual).toEqual(expected)
     })
+    describe('when all items have changed its `paymentState`', () => {
+      test('should build `returnInfoPaymentState` action', () => {
+        const before = {
+          returnInfo: [
+            {
+              items: [
+                {
+                  id: 'id1',
+                  shipmentState: 'Returned',
+                  paymentState: 'Initial',
+                },
+              ],
+            },
+            {
+              items: [
+                {
+                  id: 'id2',
+                  shipmentState: 'Returned',
+                  paymentState: 'Initial',
+                },
+                {
+                  id: 'id3',
+                  shipmentState: 'Returned',
+                  paymentState: 'Initial',
+                },
+                {
+                  id: 'id4',
+                  shipmentState: 'Returned',
+                  paymentState: 'Initial',
+                },
+                {
+                  id: 'id5',
+                  shipmentState: 'Returned',
+                  paymentState: 'Initial',
+                },
+              ],
+              returnDate: '2022-10-24T00:00:00.000Z',
+            },
+          ],
+        }
+        const now = {
+          returnInfo: [
+            {
+              items: [
+                {
+                  id: 'id1',
+                  shipmentState: 'Returned',
+                  paymentState: 'NotRefunded',
+                },
+              ],
+            },
+            {
+              items: [
+                {
+                  id: 'id2',
+                  shipmentState: 'Returned',
+                  paymentState: 'Refunded',
+                },
+                {
+                  id: 'id3',
+                  shipmentState: 'Returned',
+                  paymentState: 'Refunded',
+                },
+                {
+                  id: 'id4',
+                  shipmentState: 'Returned',
+                  paymentState: 'Refunded',
+                },
+                {
+                  id: 'id5',
+                  shipmentState: 'Returned',
+                  paymentState: 'Refunded',
+                },
+              ],
+              returnDate: '2022-10-24T00:00:00.000Z',
+            },
+          ],
+        }
+        const actual = orderSync.buildActions(now, before)
+        const expected = [
+          {
+            action: 'setReturnPaymentState',
+            returnItemId: now.returnInfo[0].items[0].id,
+            paymentState: now.returnInfo[0].items[0].paymentState,
+          },
+          {
+            action: 'setReturnPaymentState',
+            returnItemId: now.returnInfo[1].items[0].id,
+            paymentState: now.returnInfo[1].items[0].paymentState,
+          },
+          {
+            action: 'setReturnPaymentState',
+            returnItemId: now.returnInfo[1].items[1].id,
+            paymentState: now.returnInfo[1].items[1].paymentState,
+          },
+          {
+            action: 'setReturnPaymentState',
+            returnItemId: now.returnInfo[1].items[2].id,
+            paymentState: now.returnInfo[1].items[2].paymentState,
+          },
+          {
+            action: 'setReturnPaymentState',
+            returnItemId: now.returnInfo[1].items[3].id,
+            paymentState: now.returnInfo[1].items[3].paymentState,
+          },
+        ]
+        expect(actual).toEqual(expected)
+      })
+    })
   })
 })
 


### PR DESCRIPTION
#### Summary

As in my previous PR, Audit Log does a heavy usage of sync actions for getting the diff between versions of the same entity.

For one of the events we were having some issues with how sync actions was calculating the diff for an order.

#### Description

This time we have found an event that was returning an error from the sync actions library. It was related to the way we calculated the diff inside `returnInfo`.

The first commit contains a test case in which the error will show up.
The second commit contains the proposed fix.

Let me know your thoughts 🙏 

#### Todo

- Tests
  - [X] Unit
  - [ ] Integration
  - [ ] Acceptance
- [ ] Documentation
- [X] `Type` label for the PR <!-- Used to automatically generate the changelog -->
  <!-- Two persons should review a PR, don't forget to assign them. -->
  <!-- Please remember to squash merge. -->
  <!-- All contribution guidelines can be found here: https://github.com/commercetools/nodejs/blob/master/CONTRIBUTING.md -->
