### PR TITLE
Add set authentication mode sync action

### DIFF
--- a/.changeset/rich-taxis-shake.md
+++ b/.changeset/rich-taxis-shake.md
@@ -1,0 +1,5 @@
+---
+'@commercetools/sync-actions': minor
+---
+
+Add setAuthenticationMode sync action

--- a/packages/sync-actions/src/customer-actions.js
+++ b/packages/sync-actions/src/customer-actions.js
@@ -162,6 +162,7 @@ function buildAuthenticationModeActions({ actions, diff, oldObj, newObj }) {
       const now = newObj[key]
       const isNotDefinedBefore = isEmptyValue(oldObj[key])
       const isNotDefinedNow = isEmptyValue(newObj[key])
+      const authenticationModes = ['Password', 'ExternalAuth']
 
       if (!delta) return undefined
 
@@ -171,6 +172,9 @@ function buildAuthenticationModeActions({ actions, diff, oldObj, newObj }) {
         throw new Error(
           'Cannot set to Password authentication mode without password'
         )
+
+      if (!authenticationModes.includes(newObj.authenticationMode))
+        throw new Error('Invalid Authentication Mode')
 
       if (!isNotDefinedNow && isNotDefinedBefore) {
         // no value previously set

--- a/packages/sync-actions/src/customer-actions.js
+++ b/packages/sync-actions/src/customer-actions.js
@@ -173,7 +173,10 @@ function buildAuthenticationModeActions({ actions, diff, oldObj, newObj }) {
           'Cannot set to Password authentication mode without password'
         )
 
-      if (!authenticationModes.includes(newObj.authenticationMode))
+      if (
+        'authenticationMode' in newObj &&
+        !authenticationModes.includes(newObj.authenticationMode)
+      )
         throw new Error('Invalid Authentication Mode')
 
       if (!isNotDefinedNow && isNotDefinedBefore) {

--- a/packages/sync-actions/src/customer-actions.js
+++ b/packages/sync-actions/src/customer-actions.js
@@ -2,6 +2,7 @@ import isNil from 'lodash.isnil'
 import {
   buildBaseAttributesActions,
   buildReferenceActions,
+  createIsEmptyValue,
 } from './utils/common-actions'
 import createBuildArrayActions, {
   ADD_ACTIONS,
@@ -10,12 +11,6 @@ import createBuildArrayActions, {
 } from './utils/create-build-array-actions'
 import * as diffpatcher from './utils/diffpatcher'
 import clone from './utils/clone'
-
-const normalizeValue = (value) =>
-  typeof value === 'string' ? value.trim() : value
-
-export const createIsEmptyValue = (emptyValues) => (value) =>
-  emptyValues.some((emptyValue) => emptyValue === normalizeValue(value))
 
 const isEmptyValue = createIsEmptyValue([undefined, null, ''])
 

--- a/packages/sync-actions/src/customer-actions.js
+++ b/packages/sync-actions/src/customer-actions.js
@@ -26,6 +26,7 @@ export const baseActionsList = [
     key: 'stores',
   },
   { action: 'setKey', key: 'key' },
+  { action: 'setAuthenticationMode', key: 'authenticationMode' },
 ]
 
 export const setDefaultBaseActionsList = [

--- a/packages/sync-actions/src/customer-actions.js
+++ b/packages/sync-actions/src/customer-actions.js
@@ -17,6 +17,8 @@ const normalizeValue = (value) =>
 export const createIsEmptyValue = (emptyValues) => (value) =>
   emptyValues.some((emptyValue) => emptyValue === normalizeValue(value))
 
+const isEmptyValue = createIsEmptyValue([undefined, null, ''])
+
 export const baseActionsList = [
   { action: 'setSalutation', key: 'salutation' },
   { action: 'changeEmail', key: 'email' },
@@ -125,6 +127,7 @@ export function actionsMapBillingAddresses(diff, oldObj, newObj) {
 
   return handler(diff, oldObj, newObj)
 }
+
 export function actionsMapShippingAddresses(diff, oldObj, newObj) {
   const handler = createBuildArrayActions('shippingAddressIds', {
     [ADD_ACTIONS]: (addressId) => ({
@@ -140,7 +143,15 @@ export function actionsMapShippingAddresses(diff, oldObj, newObj) {
   return handler(diff, oldObj, newObj)
 }
 
-const isEmptyValue = createIsEmptyValue([undefined, null, ''])
+export function actionsMapAuthenticationModes(diff, oldObj, newObj) {
+  // eslint-disable-next-line no-use-before-define
+  return buildAuthenticationModeActions({
+    actions: authenticationModeActionsList,
+    diff,
+    oldObj,
+    newObj,
+  })
+}
 
 function buildAuthenticationModeActions({ actions, diff, oldObj, newObj }) {
   return actions
@@ -152,6 +163,7 @@ function buildAuthenticationModeActions({ actions, diff, oldObj, newObj }) {
       const now = newObj[key]
       const isNotDefinedBefore = isEmptyValue(oldObj[key])
       const isNotDefinedNow = isEmptyValue(newObj[key])
+
       if (!delta) return undefined
 
       if (isNotDefinedNow && isNotDefinedBefore) return undefined
@@ -183,13 +195,4 @@ function buildAuthenticationModeActions({ actions, diff, oldObj, newObj }) {
       return { action: item.action, [key]: patched, [value]: newObj.password }
     })
     .filter((action) => !isNil(action))
-}
-
-export function actionsMapAuthenticationModes(diff, oldObj, newObj) {
-  return buildAuthenticationModeActions({
-    actions: authenticationModeActionsList,
-    diff,
-    oldObj,
-    newObj,
-  })
 }

--- a/packages/sync-actions/src/customer-actions.js
+++ b/packages/sync-actions/src/customer-actions.js
@@ -57,7 +57,11 @@ export const referenceActionsList = [
 ]
 
 export const authenticationModeActionsList = [
-  { action: 'setAuthenticationMode', key: 'authMode', value: 'password' },
+  {
+    action: 'setAuthenticationMode',
+    key: 'authenticationMode',
+    value: 'password',
+  },
 ]
 
 /**
@@ -168,16 +172,16 @@ function buildAuthenticationModeActions({ actions, diff, oldObj, newObj }) {
 
       if (isNotDefinedNow && isNotDefinedBefore) return undefined
 
-      if (newObj.authMode === 'Password' && !newObj.password)
+      if (newObj.authenticationMode === 'Password' && !newObj.password)
         throw new Error(
           'Cannot set to Password authentication mode without password'
         )
 
       if (!isNotDefinedNow && isNotDefinedBefore) {
         // no value previously set
-        if (newObj.authMode === 'ExternalAuth')
-          return { action: item.action, [key]: now }
-        return { action: item.action, [key]: now, [value]: newObj.password }
+        if (newObj.authenticationMode === 'ExternalAuth')
+          return { action: item.action, authMode: now }
+        return { action: item.action, authMode: now, [value]: newObj.password }
       }
 
       /* no new value */
@@ -190,9 +194,13 @@ function buildAuthenticationModeActions({ actions, diff, oldObj, newObj }) {
 
       // We need to clone `before` as `patch` will mutate it
       const patched = diffpatcher.patch(clone(before), delta)
-      if (newObj.authMode === 'ExternalAuth')
-        return { action: item.action, [key]: patched }
-      return { action: item.action, [key]: patched, [value]: newObj.password }
+      if (newObj.authenticationMode === 'ExternalAuth')
+        return { action: item.action, authMode: patched }
+      return {
+        action: item.action,
+        authMode: patched,
+        [value]: newObj.password,
+      }
     })
     .filter((action) => !isNil(action))
 }

--- a/packages/sync-actions/src/customers.js
+++ b/packages/sync-actions/src/customers.js
@@ -13,7 +13,13 @@ import * as customerActions from './customer-actions'
 import * as diffpatcher from './utils/diffpatcher'
 import copyEmptyArrayProps from './utils/copy-empty-array-props'
 
-export const actionGroups = ['base', 'references', 'addresses', 'custom']
+export const actionGroups = [
+  'base',
+  'references',
+  'addresses',
+  'custom',
+  'authenticationModes',
+]
 
 function createCustomerMapActions(
   mapActionGroup: Function,
@@ -70,6 +76,12 @@ function createCustomerMapActions(
     allActions.push(
       mapActionGroup('custom', (): Array<UpdateAction> =>
         actionsMapCustom(diff, newObj, oldObj)
+      )
+    )
+
+    allActions.push(
+      mapActionGroup('authenticationModes', (): Array<UpdateAction> =>
+        customerActions.actionsMapAuthenticationModes(diff, oldObj, newObj)
       )
     )
 

--- a/packages/sync-actions/test/customer-sync.spec.js
+++ b/packages/sync-actions/test/customer-sync.spec.js
@@ -601,10 +601,9 @@ describe('Actions', () => {
     }
     now = {}
 
-    actual = customerSync.buildActions(now, before)
-
-    expected = []
-    expect(actual).toEqual(expected)
+    expect(() => {
+      customerSync.buildActions(now, before)
+    }).toThrow('Invalid Authentication Mode')
 
     before = {
       authenticationMode: 'ExternalAuth',
@@ -613,10 +612,9 @@ describe('Actions', () => {
       authenticationMode: '',
     }
 
-    actual = customerSync.buildActions(now, before)
-
-    expected = []
-    expect(actual).toEqual(expected)
+    expect(() => {
+      customerSync.buildActions(now, before)
+    }).toThrow('Invalid Authentication Mode')
   })
 
   test('should throw error if password not specified while setting authenticationMode to password', () => {
@@ -630,5 +628,18 @@ describe('Actions', () => {
     expect(() => {
       customerSync.buildActions(now, before)
     }).toThrow('Cannot set to Password authentication mode without password')
+  })
+
+  test('should throw error if user specifies invalid authentication mode', () => {
+    const before = {
+      authenticationMode: 'ExternalAuth',
+    }
+    const now = {
+      authenticationMode: 'xyz',
+    }
+
+    expect(() => {
+      customerSync.buildActions(now, before)
+    }).toThrow('Invalid Authentication Mode')
   })
 })

--- a/packages/sync-actions/test/customer-sync.spec.js
+++ b/packages/sync-actions/test/customer-sync.spec.js
@@ -601,9 +601,10 @@ describe('Actions', () => {
     }
     now = {}
 
-    expect(() => {
-      customerSync.buildActions(now, before)
-    }).toThrow('Invalid Authentication Mode')
+    actual = customerSync.buildActions(now, before)
+
+    expected = []
+    expect(actual).toEqual(expected)
 
     before = {
       authenticationMode: 'ExternalAuth',

--- a/packages/sync-actions/test/customer-sync.spec.js
+++ b/packages/sync-actions/test/customer-sync.spec.js
@@ -547,10 +547,10 @@ describe('Actions', () => {
     let expected
 
     before = {
-      authMode: 'Password',
+      authenticationMode: 'Password',
     }
     now = {
-      authMode: 'ExternalAuth',
+      authenticationMode: 'ExternalAuth',
     }
 
     actual = customerSync.buildActions(now, before)
@@ -558,16 +558,16 @@ describe('Actions', () => {
     expected = [
       {
         action: 'setAuthenticationMode',
-        authMode: now.authMode,
+        authMode: now.authenticationMode,
       },
     ]
     expect(actual).toEqual(expected)
 
     before = {
-      authMode: 'ExternalAuth',
+      authenticationMode: 'ExternalAuth',
     }
     now = {
-      authMode: 'Password',
+      authenticationMode: 'Password',
       password: 'abc123',
     }
 
@@ -575,7 +575,7 @@ describe('Actions', () => {
     expected = [
       {
         action: 'setAuthenticationMode',
-        authMode: now.authMode,
+        authMode: now.authenticationMode,
         password: now.password,
       },
     ]
@@ -584,21 +584,20 @@ describe('Actions', () => {
 
     before = {}
     now = {
-      authMode: 'ExternalAuth',
+      authenticationMode: 'ExternalAuth',
     }
 
     actual = customerSync.buildActions(now, before)
-
     expected = [
       {
         action: 'setAuthenticationMode',
-        authMode: now.authMode,
+        authMode: now.authenticationMode,
       },
     ]
     expect(actual).toEqual(expected)
 
     before = {
-      authMode: 'ExternalAuth',
+      authenticationMode: 'ExternalAuth',
     }
     now = {}
 
@@ -608,10 +607,10 @@ describe('Actions', () => {
     expect(actual).toEqual(expected)
 
     before = {
-      authMode: 'ExternalAuth',
+      authenticationMode: 'ExternalAuth',
     }
     now = {
-      authMode: '',
+      authenticationMode: '',
     }
 
     actual = customerSync.buildActions(now, before)
@@ -622,10 +621,10 @@ describe('Actions', () => {
 
   test('should throw error if password not specified while setting authenticationMode to password', () => {
     const before = {
-      authMode: 'ExternalAuth',
+      authenticationMode: 'ExternalAuth',
     }
     const now = {
-      authMode: 'Password',
+      authenticationMode: 'Password',
     }
 
     expect(() => {

--- a/packages/sync-actions/test/customer-sync.spec.js
+++ b/packages/sync-actions/test/customer-sync.spec.js
@@ -7,7 +7,13 @@ import {
 
 describe('Exports', () => {
   test('action group list', () => {
-    expect(actionGroups).toEqual(['base', 'references', 'addresses', 'custom'])
+    expect(actionGroups).toEqual([
+      'base',
+      'references',
+      'addresses',
+      'custom',
+      'authenticationModes',
+    ])
   })
 
   test('correctly define base actions list', () => {
@@ -32,7 +38,6 @@ describe('Exports', () => {
         action: 'setKey',
         key: 'key',
       },
-      { action: 'setAuthenticationMode', key: 'authenticationMode' },
     ])
   })
 
@@ -536,36 +541,95 @@ describe('Actions', () => {
   })
 
   test('should build setAuthenticationMode sync action', () => {
-    let before = {
-      authenticationMode: 'Password',
+    let before
+    let now
+    let actual
+    let expected
+
+    before = {
+      authMode: 'Password',
     }
-    let now = {
-      authenticationMode: 'ExternalAuth',
+    now = {
+      authMode: 'ExternalAuth',
     }
 
-    let actual = customerSync.buildActions(now, before)
-    let expected = [
+    actual = customerSync.buildActions(now, before)
+
+    expected = [
       {
         action: 'setAuthenticationMode',
-        authenticationMode: now.authenticationMode,
+        authMode: now.authMode,
       },
     ]
     expect(actual).toEqual(expected)
 
     before = {
-      authenticationMode: 'ExternalAuth',
+      authMode: 'ExternalAuth',
     }
     now = {
-      authenticationMode: 'Password',
+      authMode: 'Password',
+      password: 'abc123',
     }
 
     actual = customerSync.buildActions(now, before)
     expected = [
       {
         action: 'setAuthenticationMode',
-        authenticationMode: now.authenticationMode,
+        authMode: now.authMode,
+        password: now.password,
+      },
+    ]
+
+    expect(actual).toEqual(expected)
+
+    before = {}
+    now = {
+      authMode: 'ExternalAuth',
+    }
+
+    actual = customerSync.buildActions(now, before)
+
+    expected = [
+      {
+        action: 'setAuthenticationMode',
+        authMode: now.authMode,
       },
     ]
     expect(actual).toEqual(expected)
+
+    before = {
+      authMode: 'ExternalAuth',
+    }
+    now = {}
+
+    actual = customerSync.buildActions(now, before)
+
+    expected = []
+    expect(actual).toEqual(expected)
+
+    before = {
+      authMode: 'ExternalAuth',
+    }
+    now = {
+      authMode: '',
+    }
+
+    actual = customerSync.buildActions(now, before)
+
+    expected = []
+    expect(actual).toEqual(expected)
+  })
+
+  test('should throw error if password not specified while setting authenticationMode to password', () => {
+    const before = {
+      authMode: 'ExternalAuth',
+    }
+    const now = {
+      authMode: 'Password',
+    }
+
+    expect(() => {
+      customerSync.buildActions(now, before)
+    }).toThrow('Cannot set to Password authentication mode without password')
   })
 })

--- a/packages/sync-actions/test/customer-sync.spec.js
+++ b/packages/sync-actions/test/customer-sync.spec.js
@@ -536,15 +536,31 @@ describe('Actions', () => {
   })
 
   test('should build setAuthenticationMode sync action', () => {
-    const before = {
+    let before = {
       authenticationMode: 'Password',
     }
-    const now = {
+    let now = {
       authenticationMode: 'ExternalAuth',
     }
 
-    const actual = customerSync.buildActions(now, before)
-    const expected = [
+    let actual = customerSync.buildActions(now, before)
+    let expected = [
+      {
+        action: 'setAuthenticationMode',
+        authenticationMode: now.authenticationMode,
+      },
+    ]
+    expect(actual).toEqual(expected)
+
+    before = {
+      authenticationMode: 'ExternalAuth',
+    }
+    now = {
+      authenticationMode: 'Password',
+    }
+
+    actual = customerSync.buildActions(now, before)
+    expected = [
       {
         action: 'setAuthenticationMode',
         authenticationMode: now.authenticationMode,

--- a/packages/sync-actions/test/customer-sync.spec.js
+++ b/packages/sync-actions/test/customer-sync.spec.js
@@ -32,6 +32,7 @@ describe('Exports', () => {
         action: 'setKey',
         key: 'key',
       },
+      { action: 'setAuthenticationMode', key: 'authenticationMode' },
     ])
   })
 
@@ -532,5 +533,23 @@ describe('Actions', () => {
         stores: [],
       },
     ])
+  })
+
+  test('should build setAuthenticationMode sync action', () => {
+    const before = {
+      authenticationMode: 'Password',
+    }
+    const now = {
+      authenticationMode: 'ExternalAuth',
+    }
+
+    const actual = customerSync.buildActions(now, before)
+    const expected = [
+      {
+        action: 'setAuthenticationMode',
+        authenticationMode: now.authenticationMode,
+      },
+    ]
+    expect(actual).toEqual(expected)
   })
 })


### PR DESCRIPTION
#### Summary

Generate `setAuthenticationMode` sync action.

https://docs.commercetools.com/api/history/change-types#setauthenticationmodechange

#### Description

Unit tests and changeset has been added.
