### PR TITLE
fix: failing to sync froozen arrays for prices

### DIFF
--- a/.changeset/breezy-glasses-guess.md
+++ b/.changeset/breezy-glasses-guess.md
@@ -1,0 +1,5 @@
+---
+"@commercetools/sync-actions": patch
+---
+
+Fix failing to sync froozen arrays for prices

--- a/packages/sync-actions/src/utils/copy-empty-array-props.js
+++ b/packages/sync-actions/src/utils/copy-empty-array-props.js
@@ -37,6 +37,10 @@ export default function copyEmptyArrayProps(oldObj = {}, newObj = {}) {
                   foundObject,
                   newObj[key][i]
                 )
+                if (Object.isFrozen(merged[key])) {
+                  /* eslint-disable no-param-reassign */
+                  merged[key] = merged[key].slice()
+                }
                 /* eslint-disable no-param-reassign */
                 merged[key][i] = nestedObject
               }

--- a/packages/sync-actions/test/product-sync-prices.spec.js
+++ b/packages/sync-actions/test/product-sync-prices.spec.js
@@ -1071,4 +1071,48 @@ describe('Actions', () => {
       expect(actionNames).toEqual(['changePrice', 'changePrice'])
     })
   })
+
+  describe('with read only prices', () => {
+    const before = {
+      id: '123',
+      masterVariant: {
+        id: 1,
+        prices: Object.freeze([
+          {
+            id: '111',
+            value: { currencyCode: 'EUR', centAmount: 1000 },
+          },
+        ]),
+      },
+    }
+
+    const now = {
+      id: '123',
+      masterVariant: {
+        id: 1,
+        prices: Object.freeze([
+          {
+            id: '111',
+            value: { currencyCode: 'EUR', centAmount: 2000 },
+            country: 'US',
+          },
+        ]),
+      },
+    }
+
+    test('should build actions for prices', () => {
+      const actions = productsSync.buildActions(now, before)
+      expect(actions).toEqual([
+        {
+          action: 'changePrice',
+          priceId: '111',
+          price: {
+            id: '111',
+            value: { currencyCode: 'EUR', centAmount: 2000 },
+            country: 'US',
+          },
+        },
+      ])
+    })
+  })
 })


### PR DESCRIPTION
#### Summary

At times consumers may pass in frozen arrays. Even though this is discouraged it worked before. Syncing frozen arrays doesn't work as we copy properties from one to another. Hence we need to slice a frozen array.

![CleanShot 2023-02-24 at 13 43 47@2x](https://user-images.githubusercontent.com/1877073/221184181-0f6b6359-4c55-4ef2-b2e5-842bbba42c57.png)
![CleanShot 2023-02-24 at 13 44 30@2x](https://user-images.githubusercontent.com/1877073/221184191-515fee0e-f77d-4862-9e00-4315cd5575b4.png)
