### PR TITLE
[PANGOLIN-2857]: Support changes on delivery items (`setDeliveryItems`)

### DIFF
--- a/.changeset/afraid-eels-sleep.md
+++ b/.changeset/afraid-eels-sleep.md
@@ -1,0 +1,5 @@
+---
+"@commercetools/sync-actions": minor
+---
+
+orders sync-actions: support action on delivery items `setDeliveryItems`

--- a/packages/sync-actions/src/order-actions.js
+++ b/packages/sync-actions/src/order-actions.js
@@ -154,24 +154,23 @@ export function actionsMapDeliveryItems(diff, oldObj, newObj, deliveryHashMap) {
 
   let setDeliveryItemsActions = []
 
-  if (deliveries)
-    forEach(deliveries, (delivery, key) => {
-      const { newObj: newDelivery } = extractMatchingPairs(
-        deliveryHashMap,
-        key,
-        oldObj.shippingInfo.deliveries,
-        newObj.shippingInfo.deliveries
+  forEach(deliveries, (delivery, key) => {
+    const { newObj: newDelivery } = extractMatchingPairs(
+      deliveryHashMap,
+      key,
+      oldObj.shippingInfo.deliveries,
+      newObj.shippingInfo.deliveries
+    )
+    if (REGEX_UNDERSCORE_NUMBER.test(key) || REGEX_NUMBER.test(key)) {
+      const [setDeliveryItemsAction] = _buildDeliveryItemsAction(
+        delivery.items,
+        newDelivery
       )
-      if (REGEX_UNDERSCORE_NUMBER.test(key) || REGEX_NUMBER.test(key)) {
-        const [setDeliveryItemsAction] = _buildDeliveryItemsAction(
-          delivery.items,
-          newDelivery
-        )
-        setDeliveryItemsActions = setDeliveryItemsActions.concat(
-          setDeliveryItemsAction
-        )
-      }
-    })
+      setDeliveryItemsActions = setDeliveryItemsActions.concat(
+        setDeliveryItemsAction
+      )
+    }
+  })
 
   return setDeliveryItemsActions
 }

--- a/packages/sync-actions/src/order-actions.js
+++ b/packages/sync-actions/src/order-actions.js
@@ -94,6 +94,23 @@ function _buildDeliveryParcelsAction(
   return [addParcelActions, removeParcelActions]
 }
 
+function _buildDeliveryItemsAction(diffedItems, newDelivery = {}) {
+  const setDeliveryItemsAction = []
+  // If there is a diff it means that there were changes (update, adds or removes)
+  // over the items, which means that `setDeliveryItems` change has happened over
+  // the delivery
+  if (diffedItems && Object.keys(diffedItems).length > 0) {
+    setDeliveryItemsAction.push({
+      action: 'setDeliveryItems',
+      deliveryId: newDelivery.id,
+      deliveryKey: newDelivery.key,
+      items: newDelivery.items,
+    })
+  }
+
+  return [setDeliveryItemsAction]
+}
+
 export function actionsMapParcels(diff, oldObj, newObj, deliveryHashMap) {
   const shippingInfo = diff.shippingInfo
   if (!shippingInfo) return []
@@ -113,14 +130,12 @@ export function actionsMapParcels(diff, oldObj, newObj, deliveryHashMap) {
         newObj.shippingInfo.deliveries
       )
       if (REGEX_UNDERSCORE_NUMBER.test(key) || REGEX_NUMBER.test(key)) {
-        const [
-          addParcelAction,
-          removeParcelAction,
-        ] = _buildDeliveryParcelsAction(
-          delivery.parcels,
-          oldDelivery,
-          newDelivery
-        )
+        const [addParcelAction, removeParcelAction] =
+          _buildDeliveryParcelsAction(
+            delivery.parcels,
+            oldDelivery,
+            newDelivery
+          )
 
         addParcelActions = addParcelActions.concat(addParcelAction)
         removeParcelActions = removeParcelActions.concat(removeParcelAction)
@@ -128,6 +143,37 @@ export function actionsMapParcels(diff, oldObj, newObj, deliveryHashMap) {
     })
 
   return removeParcelActions.concat(addParcelActions)
+}
+
+export function actionsMapDeliveryItems(diff, oldObj, newObj, deliveryHashMap) {
+  const shippingInfo = diff.shippingInfo
+  if (!shippingInfo) return []
+
+  const deliveries = shippingInfo.deliveries
+  if (!deliveries) return []
+
+  let setDeliveryItemsActions = []
+
+  if (deliveries)
+    forEach(deliveries, (delivery, key) => {
+      const { newObj: newDelivery } = extractMatchingPairs(
+        deliveryHashMap,
+        key,
+        oldObj.shippingInfo.deliveries,
+        newObj.shippingInfo.deliveries
+      )
+      if (REGEX_UNDERSCORE_NUMBER.test(key) || REGEX_NUMBER.test(key)) {
+        const [setDeliveryItemsAction] = _buildDeliveryItemsAction(
+          delivery.items,
+          newDelivery
+        )
+        setDeliveryItemsActions = setDeliveryItemsActions.concat(
+          setDeliveryItemsAction
+        )
+      }
+    })
+
+  return setDeliveryItemsActions
 }
 
 export function actionsMapReturnsInfo(diff, oldObj, newObj) {

--- a/packages/sync-actions/src/orders.js
+++ b/packages/sync-actions/src/orders.js
@@ -54,6 +54,17 @@ function createOrderMapActions(
     )
 
     allActions.push(
+      mapActionGroup('items', (): Array<UpdateAction> =>
+        orderActions.actionsMapDeliveryItems(
+          diff,
+          oldObj,
+          newObj,
+          deliveryHashMap
+        )
+      )
+    )
+
+    allActions.push(
       flatten(
         mapActionGroup('returnInfo', (): Array<UpdateAction> =>
           orderActions.actionsMapReturnsInfo(diff, oldObj, newObj)

--- a/packages/sync-actions/test/order-sync.spec.js
+++ b/packages/sync-actions/test/order-sync.spec.js
@@ -88,6 +88,44 @@ describe('Actions', () => {
       ]
       expect(actual).toEqual(expected)
     })
+    test('should build `setDeliveryItems` action', () => {
+      const before = {
+        shippingInfo: {
+          deliveries: [
+            {
+              id: 'delivery-1',
+              items: [
+                { id: 'li-1', qty: 1 },
+                { id: 'li-2', qty: 2 },
+              ],
+              parcels: [],
+            },
+          ],
+        },
+      }
+      const now = {
+        shippingInfo: {
+          deliveries: [
+            {
+              id: 'delivery-1',
+              items: [{ id: 'li-2', qty: 2 }],
+              parcels: [],
+            },
+          ],
+        },
+      }
+
+      const actual = orderSync.buildActions(now, before)
+      const expected = [
+        {
+          action: 'setDeliveryItems',
+          items: now.shippingInfo.deliveries[0].items,
+          deliveryId: now.shippingInfo.deliveries[0].id,
+          deliveryKey: undefined,
+        },
+      ]
+      expect(actual).toEqual(expected)
+    })
   })
 
   describe('parcels', () => {

--- a/packages/sync-actions/test/order-sync.spec.js
+++ b/packages/sync-actions/test/order-sync.spec.js
@@ -183,6 +183,50 @@ describe('Actions', () => {
       ]
       expect(actual).toEqual(expected)
     })
+    describe('performance test', () => {
+      it('should be performant for large arrays', () => {
+        const before = {
+          shippingInfo: {
+            deliveries: Array(100)
+              .fill(null)
+              .map((a, index) => ({
+                parcels: [],
+                items: Array(50)
+                  .fill(null)
+                  .map((b, index2) => {
+                    return {
+                      id: `id-${index}-${index2}`,
+                      qty: 1,
+                    }
+                  }),
+              })),
+          },
+        }
+        const now = {
+          shippingInfo: {
+            deliveries: Array(100)
+              .fill(null)
+              .map((a, index) => ({
+                parcels: [],
+                items: Array(50)
+                  .fill(null)
+                  .map((b, index2) => {
+                    return {
+                      id: `id-${index}-${index2}`,
+                      qty: 2,
+                    }
+                  }),
+              })),
+          },
+        }
+
+        const start = performance.now()
+        orderSync.buildActions(now, before)
+        const end = performance.now()
+
+        expect(end - start).toBeLessThan(500)
+      })
+    })
   })
 
   describe('parcels', () => {
@@ -787,7 +831,7 @@ describe('Actions', () => {
           orderSync.buildActions(now, before)
           const end = performance.now()
 
-          expect(end - start).toBeLessThan(400)
+          expect(end - start).toBeLessThan(500)
         })
       })
     })

--- a/packages/sync-actions/test/order-sync.spec.js
+++ b/packages/sync-actions/test/order-sync.spec.js
@@ -126,6 +126,63 @@ describe('Actions', () => {
       ]
       expect(actual).toEqual(expected)
     })
+    test('should build multiple `setDeliveryItems` action', () => {
+      const before = {
+        shippingInfo: {
+          deliveries: [
+            {
+              id: 'delivery-1',
+              items: [
+                { id: 'li-1', qty: 1 },
+                { id: 'li-2', qty: 2 },
+              ],
+              parcels: [],
+            },
+            {
+              id: 'delivery-2',
+              items: [],
+              parcels: [],
+            },
+          ],
+        },
+      }
+      const now = {
+        shippingInfo: {
+          deliveries: [
+            {
+              id: 'delivery-1',
+              items: [{ id: 'li-2', qty: 2 }],
+              parcels: [],
+            },
+            {
+              id: 'delivery-2',
+              items: [
+                { id: 'li-1', qty: 1 },
+                { id: 'li-2', qty: 2 },
+              ],
+              parcels: [],
+            },
+          ],
+        },
+      }
+
+      const actual = orderSync.buildActions(now, before)
+      const expected = [
+        {
+          action: 'setDeliveryItems',
+          items: now.shippingInfo.deliveries[0].items,
+          deliveryId: now.shippingInfo.deliveries[0].id,
+          deliveryKey: undefined,
+        },
+        {
+          action: 'setDeliveryItems',
+          items: now.shippingInfo.deliveries[1].items,
+          deliveryId: now.shippingInfo.deliveries[1].id,
+          deliveryKey: undefined,
+        },
+      ]
+      expect(actual).toEqual(expected)
+    })
   })
 
   describe('parcels', () => {


### PR DESCRIPTION
#### Summary

In Audit Log, we have found that the order sync actions does not correctly detect changes related to the items in a delivery.

#### Description

The idea is based on the approach that we already do for `parcels` but applied to `items`. In this case is simpler as there are not add/remove actions, just a `set` action.

#### Todo

- Tests
  - [X] Unit
  - [ ] Integration
  - [ ] Acceptance
- [ ] Documentation
- [X] `Type` label for the PR <!-- Used to automatically generate the changelog -->
  <!-- Two persons should review a PR, don't forget to assign them. -->
  <!-- Please remember to squash merge. -->
  <!-- All contribution guidelines can be found here: https://github.com/commercetools/nodejs/blob/master/CONTRIBUTING.md -->
