### PR TITLE
Ma fix sync set price tier

### DIFF
--- a/.changeset/tough-lions-flow.md
+++ b/.changeset/tough-lions-flow.md
@@ -1,0 +1,5 @@
+---
+'@commercetools/sync-actions': patch
+---
+
+Add support for StandalonePrice `setPriceTier`

--- a/packages/sync-actions/src/prices-actions.js
+++ b/packages/sync-actions/src/prices-actions.js
@@ -4,7 +4,7 @@ export const baseActionsList = [
   { action: 'changeValue', key: 'value' },
   { action: 'setDiscountedPrice', key: 'discounted' },
   // TODO: Later add more accurate actions `addPriceTier`, `removePriceTier`
-  { action: 'setPriceTiers', key: 'tiers' },
+  { action: 'setPriceTier', key: 'tiers' },
   { action: 'setKey', key: 'key' },
   { action: 'setValidFrom', key: 'validFrom' },
   { action: 'setValidUntil', key: 'validUntil' },

--- a/packages/sync-actions/test/price-sync.spec.js
+++ b/packages/sync-actions/test/price-sync.spec.js
@@ -230,8 +230,8 @@ describe('price actions', () => {
     })
   })
 
-  describe('setPriceTiers', () => {
-    test('should  build `setPriceTiers` action if price tier are set', () => {
+  describe('setPriceTier', () => {
+    test('should  build `setPriceTier` action if price tier are set', () => {
       const before = {}
       const now = {
         id: '9fe6610f',
@@ -265,7 +265,7 @@ describe('price actions', () => {
           },
         },
         {
-          action: 'setPriceTiers',
+          action: 'setPriceTier',
           tiers: [
             {
               minimumQuantity: 5,
@@ -281,7 +281,7 @@ describe('price actions', () => {
       ])
     })
 
-    test('should  build `setPriceTiers` action for price tier change', () => {
+    test('should  build `setPriceTier` action for price tier change', () => {
       const before = {
         id: '9fe6610f',
         value: {
@@ -325,7 +325,7 @@ describe('price actions', () => {
       const actions = pricesSync.buildActions(now, before)
       expect(actions).toEqual([
         {
-          action: 'setPriceTiers',
+          action: 'setPriceTier',
           tiers: [
             {
               minimumQuantity: 5,
@@ -341,7 +341,7 @@ describe('price actions', () => {
       ])
     })
 
-    test('should build `setPriceTiers` action for removed price tier', () => {
+    test('should build `setPriceTier` action for removed price tier', () => {
       const before = {
         id: '9fe6610f',
         value: {
@@ -396,7 +396,7 @@ describe('price actions', () => {
       const actions = pricesSync.buildActions(now, before)
       expect(actions).toEqual([
         {
-          action: 'setPriceTiers',
+          action: 'setPriceTier',
           tiers: [
             {
               minimumQuantity: 5,
@@ -412,7 +412,7 @@ describe('price actions', () => {
       ])
     })
 
-    test('should build `setPriceTiers` action when removed all price tier', () => {
+    test('should build `setPriceTier` action when removed all price tier', () => {
       const before = {
         id: '9fe6610f',
         value: {
@@ -457,13 +457,13 @@ describe('price actions', () => {
       const actions = pricesSync.buildActions(now, before)
       expect(actions).toEqual([
         {
-          action: 'setPriceTiers',
+          action: 'setPriceTier',
           tiers: undefined,
         },
       ])
     })
 
-    test('should not build `setPriceTiers` action when price tiers on now and then are equal', () => {
+    test('should not build `setPriceTier` action when price tiers on now and then are equal', () => {
       const before = {
         id: '9fe6610f',
         value: {


### PR DESCRIPTION
#### Summary

<!-- Provide a short summary of your changes -->

#### Description

<!-- Describe the changes in this PR here and provide some context -->

this pr fixes the typo on setPriceTiers -> setPriceTier this is the correct acction : https://docs.commercetools.com/api/projects/standalone-prices#set-price-tiers

#### Todo

- Tests
  - [ ] Unit
  - [ ] Integration
  - [ ] Acceptance
- [ ] Documentation
- [ ] `Type` label for the PR <!-- Used to automatically generate the changelog -->
  <!-- Two persons should review a PR, don't forget to assign them. -->
  <!-- Please remember to squash merge. -->
  <!-- All contribution guidelines can be found here: https://github.com/commercetools/nodejs/blob/master/CONTRIBUTING.md -->
