### PR TITLE
fix: handle long text values performantly

### DIFF
--- a/.changeset/violet-timers-act.md
+++ b/.changeset/violet-timers-act.md
@@ -1,0 +1,5 @@
+---
+'@commercetools/sync-actions': minor
+---
+
+Handle long text values performantly

--- a/packages/sync-actions/src/utils/diffpatcher.js
+++ b/packages/sync-actions/src/utils/diffpatcher.js
@@ -20,11 +20,14 @@ const diffpatcher = new DiffPatcher({
     includeValueOnMove: false,
   },
   textDiff: {
-    // If the value to diff has a bigger length,
-    // a text diffing algorithm is used
-    // See https://github.com/benjamine/jsondiffpatch/
-    // blob/master/docs/deltas.md#text-diffs
-    minLength: 300,
+    /**
+     * jsondiffpatch uses a very fine-grained diffing algorithm for long strings to easily identify
+     * what changed between strings. However, we don't actually care about what changed, just
+     * if the string changed at all. So we set the minimum length to diff to a very large number to avoid
+     * using the very slow algorithm.
+     * See https://github.com/benjamine/jsondiffpatch/blob/master/docs/deltas.md#text-diffs.
+     */
+    minLength: Number.MAX_SAFE_INTEGER,
   },
 })
 

--- a/packages/sync-actions/test/product-sync-variants.spec.js
+++ b/packages/sync-actions/test/product-sync-variants.spec.js
@@ -116,6 +116,78 @@ describe('Actions', () => {
     ])
   })
 
+  test('should handle long text values performantly', () => {
+    const longText = 'a'.repeat(10_000)
+    const longText2 = 'b'.repeat(10_000)
+    const before = {
+      id: '123',
+      masterVariant: {
+        id: 1,
+        attributes: [
+          { name: 'color', value: longText },
+          { name: 'size', value: longText },
+          { name: 'weight', value: longText },
+        ],
+      },
+      variants: [
+        {
+          id: 2,
+          attributes: [
+            { name: 'color', value: longText },
+            { name: 'size', value: longText },
+            { name: 'weight', value: longText },
+          ],
+        },
+      ],
+    }
+
+    const now = {
+      id: '123',
+      masterVariant: {
+        id: 1,
+        attributes: [
+          { name: 'color', value: longText2 },
+          { name: 'size', value: longText2 },
+          { name: 'weight', value: longText2 },
+        ],
+      },
+      variants: [
+        {
+          id: 2,
+          attributes: [
+            { name: 'color', value: longText2 },
+            { name: 'size', value: longText2 },
+            { name: 'weight', value: longText2 },
+          ],
+        },
+      ],
+    }
+
+    const startTime = Date.now()
+    const actions = productsSync.buildActions(now, before)
+
+    // Should take less than 100ms.
+    expect(Date.now() - startTime).toBeLessThan(100)
+    expect(actions).toEqual([
+      { action: 'setAttribute', variantId: 1, name: 'color', value: longText2 },
+      { action: 'setAttribute', variantId: 1, name: 'size', value: longText2 },
+      {
+        action: 'setAttribute',
+        variantId: 1,
+        name: 'weight',
+        value: longText2,
+      },
+      { action: 'setAttribute', variantId: 2, name: 'color', value: longText2 },
+      { action: 'setAttribute', variantId: 2, name: 'size', value: longText2 },
+      {
+        action: 'setAttribute',
+        variantId: 2,
+        name: 'weight',
+        value: longText2,
+      },
+    ])
+  })
+
   test('should build SameForAll attribute actions', () => {
     const before = {
       id: '123',


### PR DESCRIPTION
#### Summary

Audit Log has run into a few edge cases where clients set VERY long `values` on product attributes. The result is that diffing takes a long time (can be > 7-10s or more).

#### Description

After running down where the delay is coming from, it appears it is due to `jsondiffpatch` uses `diff-match-patch` for long text diffing, which uses a very fine-grained diffing algorithm for long to easily identify what changed between two strings (this is actually the library originally built by google for google docs comparisions). However, we don't actually care about the specifics of what changed between two strings - we only care if the string changed at all. 

This PR adds a test in the first commit which shows the edge case (long values with a failing result b/c it should take ~5ms and it takes 5s). The second commit effectively disables the long text diffing approach by using the max safe integer as the value for `jsondiffpatch` to use `diff-match-patch` instead of the default diff. Now, long text strings diff very quickly.

All tests pass with this change, and based on the [getDeltaValue](https://github.com/commercetools/nodejs/blob/afe751ac52775eaaffa3f5769150e100858c6576/packages/sync-actions/src/utils/diffpatcher.js#L42-L70) method, I don't think there is any impact (the type of text diff used is resolved by that method, so disabling the long diff method will produce the same result - the new state of the string is what the method returns). That said - I'm not as familiar with the intricacies of this library and if disabling the long text diff algorithm produces any unintended consequences, so please think on that. 🙏 

#### Todo

- Tests
  - [x] Unit
  - [ ] Integration
  - [ ] Acceptance
- [ ] Documentation
- [x] `Type` label for the PR
