### PR TITLE
Fix Unhandled Promise Rejection Error

### DIFF
--- a/packages/product-json-to-xlsx/test/writer.spec.js
+++ b/packages/product-json-to-xlsx/test/writer.spec.js
@@ -35,7 +35,7 @@ async function analyzeExcelStream(stream) {
   const workbook = new Excel.Workbook()
   await workbook.xlsx.read(stream)
 
-  analyzeExcelWorkbook(workbook)
+  return analyzeExcelWorkbook(workbook)
 }
 
 describe('Writer', () => {

--- a/packages/sdk-middleware-http/test/http.spec.js
+++ b/packages/sdk-middleware-http/test/http.spec.js
@@ -1578,4 +1578,34 @@ describe('Http', () => {
       httpMiddleware(next)(request, response)
     })
   })
+
+  test('should handle error when parsing an invalid response object', () => {
+    expect(true).toEqual(true)
+    return new Promise((resolve, reject) => {
+
+      const response = { resolve, reject }
+      const request = createTestRequest({ uri: '/foo/bar' })
+
+      const next = (req, res) => {
+        expect(res).toEqual({
+          ...response,
+          error: expect.any(Error),
+          statusCode: 500
+        })
+        resolve()
+      }
+
+      // Use default options
+      const httpMiddleware = createHttpMiddleware({
+        host: testHost,
+        enableRetry: false,
+        fetch: jest.fn(() =>
+          Promise.resolve({
+            text: jest.fn(() => Promise.resolve({}))
+          }))
+      })
+
+      httpMiddleware(next)(request, response)
+    })
+  })
 })

--- a/packages/sdk-middleware-http/test/http.spec.js
+++ b/packages/sdk-middleware-http/test/http.spec.js
@@ -1590,7 +1590,7 @@ describe('Http', () => {
         expect(res).toEqual({
           ...response,
           error: expect.any(Error),
-          statusCode: 500
+          statusCode: 0
         })
         resolve()
       }
@@ -1601,7 +1601,49 @@ describe('Http', () => {
         enableRetry: false,
         fetch: jest.fn(() =>
           Promise.resolve({
-            text: jest.fn(() => Promise.resolve({}))
+            ok: true,
+            text: jest.fn(() =>
+              Promise.reject(new Error('malformed response'))
+            )
+          }))
+      })
+
+      httpMiddleware(next)(request, response)
+    })
+  })
+
+  test('should handle error when parsing an invalid response object - retry', () => {
+    expect(true).toEqual(true)
+    return new Promise((resolve, reject) => {
+
+      const response = { resolve, reject }
+      const request = createTestRequest({ uri: '/foo/bar' })
+
+      const next = (req, res) => {
+        expect(res).toEqual({
+          ...response,
+          error: expect.any(Error),
+          statusCode: 0
+        })
+        resolve()
+      }
+
+      // Use default options
+      const httpMiddleware = createHttpMiddleware({
+        host: testHost,
+        enableRetry: true,
+        credentialsMode: 'omit',
+        retryConfig: {
+          maxRetries: 2,
+          retryDelay: 100,
+          backoff: false,
+        },
+        fetch: jest.fn(() =>
+          Promise.resolve({
+            ok: true,
+            text: jest.fn(() =>
+              Promise.reject(new Error('malformed response'))
+            )
           }))
       })
 


### PR DESCRIPTION
#### Summary
Fix error causing SDK to crash if a promise rejection error occurs due to improper serialization of response body.

#### Completed tasks
- [x] add a catch block to handle uncaught promise errors
- [x] add tests
