### PR TITLE
refactor(ci): to use github application for pat

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,14 +10,21 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      # Get GitHub token via the CT Changesets App
+      - name: Generate GitHub token (via CT Changesets App)
+        id: generate_github_token
+        uses: tibdex/github-app-token@v2.1.0
+        with:
+          app_id: ${{ secrets.CT_CHANGESETS_APP_ID }}
+          private_key: ${{ secrets.CT_CHANGESETS_APP_PEM }}
+          
       - name: Checkout
         uses: actions/checkout@v2
         with:
-          # Pass a personal access token (using our `ct-release-bot` account) to be able to trigger
-          # other workflows
+          # Pass a personal access token (using our CT Changesets App) to be able to trigger other workflows
           # https://help.github.com/en/actions/reference/events-that-trigger-workflows#triggering-new-workflows-using-a-personal-access-token
           # https://github.community/t/action-does-not-trigger-another-on-push-tag-action/17148/8
-          token: ${{ secrets.RELEASE_GITHUB_TOKEN }}
+          token: ${{ steps.generate_github_token.outputs.token }}
 
       - name: Read .nvmrc
         run: echo ::set-output name=NVMRC::$(cat .nvmrc)
@@ -62,4 +69,4 @@ jobs:
           version: yarn changeset:version-and-format
           commit: 'ci(changesets): version packages'
         env:
-          GITHUB_TOKEN: ${{ secrets.RELEASE_GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.generate_github_token.outputs.token }}


### PR DESCRIPTION
#### Summary

Replaces the usage of a static long-lived PAT with a short-lived (auto revoked) PAT through a GitHub Application called CT Changesets.

This is being rolled out across about 10 repositories. More detail and background on the changes can be found on internal documentation.