### PR TITLE
Add removeStagedChanges action for StandalonePrice

### DIFF
--- a/.changeset/swift-avocados-lay.md
+++ b/.changeset/swift-avocados-lay.md
@@ -1,0 +1,5 @@
+---
+'@commercetools/sync-actions': minor
+---
+
+Add support for Standalone Price 'removeStagedChanges' action.

--- a/packages/sync-actions/src/prices-actions.js
+++ b/packages/sync-actions/src/prices-actions.js
@@ -9,6 +9,7 @@ export const baseActionsList = [
   { action: 'setValidFrom', key: 'validFrom' },
   { action: 'setValidUntil', key: 'validUntil' },
   { action: 'changeActive', key: 'active' },
+  { action: 'removeStagedChanges', key: 'staged' },
 ]
 
 export function actionsMapBase(diff, oldObj, newObj, config = {}) {

--- a/packages/sync-actions/test/price-sync.spec.js
+++ b/packages/sync-actions/test/price-sync.spec.js
@@ -8,14 +8,14 @@ const twoWeeksFromNow = new Date(Date.now() + 12096e5)
 /* eslint-disable max-len */
 describe('price actions', () => {
   test('action group list', () => {
-    expect(actionGroups).toEqual(['base', 'custom'])
+    expect(actionGroups).toStrictEqual(['base', 'custom'])
   })
 
   test('should not build actions if prices are not set', () => {
     const before = {}
     const now = {}
     const actions = pricesSync.buildActions(now, before)
-    expect(actions).toEqual([])
+    expect(actions).toStrictEqual([])
   })
 
   test('should not build actions if now price is not set', () => {
@@ -30,7 +30,7 @@ describe('price actions', () => {
     }
     const now = {}
     const actions = pricesSync.buildActions(now, before)
-    expect(actions).toEqual([])
+    expect(actions).toStrictEqual([])
   })
 
   test('should not build actions if there is no change', () => {
@@ -80,7 +80,7 @@ describe('price actions', () => {
       },
     }
     const actions = pricesSync.buildActions(now, before)
-    expect(actions).toEqual([])
+    expect(actions).toStrictEqual([])
   })
 
   describe('changeValue', () => {
@@ -106,7 +106,7 @@ describe('price actions', () => {
       }
 
       const actions = pricesSync.buildActions(now, before)
-      expect(actions).toEqual([
+      expect(actions).toStrictEqual([
         {
           action: 'changeValue',
           value: {
@@ -143,7 +143,7 @@ describe('price actions', () => {
       }
 
       const actions = pricesSync.buildActions(now, before)
-      expect(actions).toEqual([
+      expect(actions).toStrictEqual([
         {
           action: 'setDiscountedPrice',
           discounted: {
@@ -181,10 +181,9 @@ describe('price actions', () => {
       }
 
       const actions = pricesSync.buildActions(now, before)
-      expect(actions).toEqual([
+      expect(actions).toStrictEqual([
         {
           action: 'setDiscountedPrice',
-          discounted: undefined,
         },
       ])
     })
@@ -215,7 +214,7 @@ describe('price actions', () => {
       }
 
       const actions = pricesSync.buildActions(now, before)
-      expect(actions).toEqual([
+      expect(actions).toStrictEqual([
         {
           action: 'setDiscountedPrice',
           discounted: {
@@ -254,7 +253,7 @@ describe('price actions', () => {
         ],
       }
       const actions = pricesSync.buildActions(now, before)
-      expect(actions).toEqual([
+      expect(actions).toStrictEqual([
         {
           action: 'changeValue',
           value: {
@@ -323,7 +322,7 @@ describe('price actions', () => {
         ],
       }
       const actions = pricesSync.buildActions(now, before)
-      expect(actions).toEqual([
+      expect(actions).toStrictEqual([
         {
           action: 'setPriceTiers',
           tiers: [
@@ -394,7 +393,7 @@ describe('price actions', () => {
       }
 
       const actions = pricesSync.buildActions(now, before)
-      expect(actions).toEqual([
+      expect(actions).toStrictEqual([
         {
           action: 'setPriceTiers',
           tiers: [
@@ -455,10 +454,9 @@ describe('price actions', () => {
       }
 
       const actions = pricesSync.buildActions(now, before)
-      expect(actions).toEqual([
+      expect(actions).toStrictEqual([
         {
           action: 'setPriceTiers',
-          tiers: undefined,
         },
       ])
     })
@@ -525,7 +523,7 @@ describe('price actions', () => {
       }
 
       const actions = pricesSync.buildActions(now, before)
-      expect(actions).toEqual([])
+      expect(actions).toStrictEqual([])
     })
   })
 
@@ -544,7 +542,7 @@ describe('price actions', () => {
       }
 
       const actions = pricesSync.buildActions(now, before)
-      expect(actions).toEqual([
+      expect(actions).toStrictEqual([
         {
           action: 'setKey',
           key,
@@ -568,7 +566,7 @@ describe('price actions', () => {
       }
 
       const actions = pricesSync.buildActions(now, before)
-      expect(actions).toEqual([
+      expect(actions).toStrictEqual([
         {
           action: 'setValidFrom',
           validFrom: twoWeeksFromNow,
@@ -592,7 +590,7 @@ describe('price actions', () => {
       }
 
       const actions = pricesSync.buildActions(now, before)
-      expect(actions).toEqual([
+      expect(actions).toStrictEqual([
         {
           action: 'setValidUntil',
           validUntil: twoWeeksFromNow,
@@ -616,7 +614,7 @@ describe('price actions', () => {
       }
 
       const actions = pricesSync.buildActions(now, before)
-      expect(actions).toEqual([
+      expect(actions).toStrictEqual([
         {
           action: 'setValidFromAndUntil',
           validFrom: twoWeeksFromNow,
@@ -639,7 +637,7 @@ describe('price actions', () => {
       }
 
       const actions = pricesSync.buildActions(now, before)
-      expect(actions).toEqual([
+      expect(actions).toStrictEqual([
         {
           action: 'changeActive',
           active: true,
@@ -673,7 +671,7 @@ describe('price actions', () => {
       }
 
       const actions = pricesSync.buildActions(now, before)
-      expect(actions).toEqual([
+      expect(actions).toStrictEqual([
         {
           action: 'setCustomType',
           type: {
@@ -712,7 +710,7 @@ describe('price actions', () => {
       }
 
       const actions = pricesSync.buildActions(now, before)
-      expect(actions).toEqual([
+      expect(actions).toStrictEqual([
         {
           action: 'setCustomType',
           type: {
@@ -754,7 +752,7 @@ describe('price actions', () => {
       }
 
       const actions = pricesSync.buildActions(now, before)
-      expect(actions).toEqual([
+      expect(actions).toStrictEqual([
         {
           action: 'setCustomType',
         },
@@ -805,7 +803,7 @@ describe('price actions', () => {
       }
 
       const actions = pricesSync.buildActions(now, before)
-      expect(actions).toEqual([
+      expect(actions).toStrictEqual([
         {
           action: 'setCustomField',
           name: 'touchpoints',
@@ -855,7 +853,7 @@ describe('price actions', () => {
       }
 
       const actions = pricesSync.buildActions(now, before)
-      expect(actions).toEqual([
+      expect(actions).toStrictEqual([
         {
           action: 'setCustomField',
           name: 'source',
@@ -906,7 +904,7 @@ describe('price actions', () => {
       }
 
       const actions = pricesSync.buildActions(now, before)
-      expect(actions).toEqual([
+      expect(actions).toStrictEqual([
         {
           action: 'setCustomField',
           name: 'source',
@@ -956,10 +954,9 @@ describe('price actions', () => {
       }
 
       const actions = pricesSync.buildActions(now, before)
-      expect(actions).toEqual([
+      expect(actions).toStrictEqual([
         {
           action: 'removeStagedChanges',
-          staged: undefined,
         },
       ])
     })

--- a/packages/sync-actions/test/price-sync.spec.js
+++ b/packages/sync-actions/test/price-sync.spec.js
@@ -925,4 +925,42 @@ describe('price actions', () => {
       ])
     })
   })
+
+  describe('removeStagedChanges', () => {
+    test('should build `removeStagedChanges` action when staged changes are removed', () => {
+      const before = {
+        id: '1234',
+        value: {
+          type: 'centPrecision',
+          currencyCode: 'USD',
+          centAmount: 5000,
+          fractionDigits: 2,
+        },
+        staged: {
+          type: 'centPrecision',
+          currencyCode: 'USD',
+          centAmount: 6000,
+          fractionDigits: 2,
+        },
+      }
+  
+      const now = {
+        id: '1234',
+        value: {
+          type: 'centPrecision',
+          currencyCode: 'USD',
+          centAmount: 5000,
+          fractionDigits: 2,
+        },
+      }
+  
+      const actions = pricesSync.buildActions(now, before)
+      expect(actions).toEqual([
+        {
+          action: 'removeStagedChanges',
+          key: 'staged',
+        },
+      ])
+    })
+  })
 })

--- a/packages/sync-actions/test/price-sync.spec.js
+++ b/packages/sync-actions/test/price-sync.spec.js
@@ -943,7 +943,7 @@ describe('price actions', () => {
           fractionDigits: 2,
         },
       }
-  
+
       const now = {
         id: '1234',
         value: {
@@ -952,9 +952,9 @@ describe('price actions', () => {
           centAmount: 5000,
           fractionDigits: 2,
         },
-        staged: null
+        staged: null,
       }
-  
+
       const actions = pricesSync.buildActions(now, before)
       expect(actions).toEqual([
         {

--- a/packages/sync-actions/test/price-sync.spec.js
+++ b/packages/sync-actions/test/price-sync.spec.js
@@ -952,13 +952,14 @@ describe('price actions', () => {
           centAmount: 5000,
           fractionDigits: 2,
         },
+        staged: null
       }
   
       const actions = pricesSync.buildActions(now, before)
       expect(actions).toEqual([
         {
           action: 'removeStagedChanges',
-          key: 'staged',
+          staged: undefined,
         },
       ])
     })


### PR DESCRIPTION
#### **Summary**

<!-- Provide a short summary of your changes -->
Following the requirements here https://commercetools.atlassian.net/browse/PRC-2676, 
we want to be able to clear a staged value from an existing standalone price.
This PR adds a `removeStagedChanges` action.

#### Description

<!-- Describe the changes in this PR here and provide some context -->
Docs https://docs.commercetools.com/api/projects/standalone-prices#remove-staged-changes
#### Todo

- Tests
  - [ ] Unit
  - [ ] Integration
  - [ ] Acceptance
- [ ] Documentation
- [ ] `Type` label for the PR <!-- Used to automatically generate the changelog -->
  <!-- Two persons should review a PR, don't forget to assign them. -->
  <!-- Please remember to squash merge. -->
  <!-- All contribution guidelines can be found here: https://github.com/commercetools/nodejs/blob/master/CONTRIBUTING.md -->
