### PR TITLE
feat: add changeactive action and test

### DIFF
--- a/.changeset/shy-onions-explode.md
+++ b/.changeset/shy-onions-explode.md
@@ -1,0 +1,5 @@
+---
+'@commercetools/sync-actions': minor
+---
+
+add changeActive to shipping methods base actions

--- a/packages/sync-actions/src/shipping-methods-actions.js
+++ b/packages/sync-actions/src/shipping-methods-actions.js
@@ -15,6 +15,7 @@ export const baseActionsList = [
   { action: 'changeIsDefault', key: 'isDefault' },
   { action: 'setPredicate', key: 'predicate' },
   { action: 'changeTaxCategory', key: 'taxCategory' },
+  { action: 'changeActive', key: 'active' },
 ]
 
 export function actionsMapBase(diff, oldObj, newObj, config = {}) {

--- a/packages/sync-actions/test/shipping-methods.spec.js
+++ b/packages/sync-actions/test/shipping-methods.spec.js
@@ -16,6 +16,7 @@ describe('Exports', () => {
       { action: 'changeIsDefault', key: 'isDefault' },
       { action: 'setPredicate', key: 'predicate' },
       { action: 'changeTaxCategory', key: 'taxCategory' },
+      { action: 'changeActive', key: 'active' },
     ])
   })
 })
@@ -53,6 +54,24 @@ describe('Actions', () => {
         {
           action: 'changeName',
           name: now.name,
+        },
+      ]
+      expect(actual).toEqual(expected)
+    })
+
+    test('should build `changeActive` action', () => {
+      const before = {
+        active: false,
+      }
+      const now = {
+        active: true,
+      }
+
+      const actual = shippingMethodsSync.buildActions(now, before)
+      const expected = [
+        {
+          action: 'changeActive',
+          active: now.active,
         },
       ]
       expect(actual).toEqual(expected)


### PR DESCRIPTION
#### Summary
This PR adds the action for `changeActive` to the `baseActionsList` for Shipping Methods.

#### Todo

- Tests
  - [x] Unit
  - [ ] Integration
  - [ ] Acceptance
- [ ] Documentation
- [ ] `Type` label for the PR <!-- Used to automatically generate the changelog -->
  <!-- Two persons should review a PR, don't forget to assign them. -->
  <!-- Please remember to squash merge. -->
  <!-- All contribution guidelines can be found here: https://github.com/commercetools/nodejs/blob/master/CONTRIBUTING.md -->
