### PR TITLE
feat(customers): add missing search and bu actions

### DIFF
--- a/.changeset/curvy-seas-protect.md
+++ b/.changeset/curvy-seas-protect.md
@@ -1,0 +1,5 @@
+---
+'@commercetools/sync-actions': minor
+---
+
+Add sync actions changeMyBusinessUnitStatusOnCreation, setMyBusinessUnitAssociateRoleOnCreation and changeCustomerSearchStatus

--- a/packages/sync-actions/src/projects-actions.js
+++ b/packages/sync-actions/src/projects-actions.js
@@ -7,6 +7,15 @@ export const baseActionsList = [
   { action: 'changeLanguages', key: 'languages' },
   { action: 'changeMessagesConfiguration', key: 'messagesConfiguration' },
   { action: 'setShippingRateInputType', key: 'shippingRateInputType' },
+  {
+    action: 'changeMyBusinessUnitStatusOnCreation',
+    key: 'myBusinessUnitStatusOnCreation',
+  },
+  {
+    action: 'setMyBusinessUnitAssociateRoleOnCreation',
+    key: 'myBusinessUnitAssociateRoleOnCreation',
+  },
+  { action: 'changeCustomerSearchStatus', key: 'customerSearchStatus' },
 ]
 
 export function actionsMapBase(diff, oldObj, newObj, config = {}) {

--- a/packages/sync-actions/test/projects-sync.spec.js
+++ b/packages/sync-actions/test/projects-sync.spec.js
@@ -64,6 +64,39 @@ describe('Exports', () => {
         ])
       )
     })
+
+    test('should contain `changeMyBusinessUnitStatusOnCreation` action', () => {
+      expect(baseActionsList).toEqual(
+        expect.arrayContaining([
+          {
+            action: 'changeMyBusinessUnitStatusOnCreation',
+            key: 'myBusinessUnitStatusOnCreation',
+          },
+        ])
+      )
+    })
+
+    test('should contain `setMyBusinessUnitAssociateRoleOnCreation` action', () => {
+      expect(baseActionsList).toEqual(
+        expect.arrayContaining([
+          {
+            action: 'setMyBusinessUnitAssociateRoleOnCreation',
+            key: 'myBusinessUnitAssociateRoleOnCreation',
+          },
+        ])
+      )
+    })
+
+    test('should contain `changeCustomerSearchStatus` action', () => {
+      expect(baseActionsList).toEqual(
+        expect.arrayContaining([
+          {
+            action: 'changeCustomerSearchStatus',
+            key: 'customerSearchStatus',
+          },
+        ])
+      )
+    })
   })
 })
 
@@ -207,6 +240,55 @@ describe('Actions', () => {
     const expected = [
       {
         action: 'changeMessagesConfiguration',
+        ...now,
+      },
+    ]
+    expect(actual).toEqual(expected)
+  })
+
+  test('should build `changeMyBusinessUnitStatusOnCreation` action', () => {
+    const before = { myBusinessUnitStatusOnCreation: 'Active' }
+    const now = { myBusinessUnitStatusOnCreation: 'Deactive' }
+    const actual = projectsSync.buildActions(now, before)
+    const expected = [
+      {
+        action: 'changeMyBusinessUnitStatusOnCreation',
+        ...now,
+      },
+    ]
+    expect(actual).toEqual(expected)
+  })
+
+  test('should build `setMyBusinessUnitAssociateRoleOnCreation` action', () => {
+    const before = {
+      myBusinessUnitAssociateRoleOnCreation: {
+        typeId: 'associate-role',
+        key: 'old-role',
+      },
+    }
+    const now = {
+      myBusinessUnitAssociateRoleOnCreation: {
+        typeId: 'associate-role',
+        key: 'new-role',
+      },
+    }
+    const actual = projectsSync.buildActions(now, before)
+    const expected = [
+      {
+        action: 'setMyBusinessUnitAssociateRoleOnCreation',
+        ...now,
+      },
+    ]
+    expect(actual).toEqual(expected)
+  })
+
+  test('should build `changeCustomerSearchStatus` action', () => {
+    const before = { customerSearchStatus: 'Activated' }
+    const now = { customerSearchStatus: 'Deactivated' }
+    const actual = projectsSync.buildActions(now, before)
+    const expected = [
+      {
+        action: 'changeCustomerSearchStatus',
         ...now,
       },
     ]


### PR DESCRIPTION
#### Summary

Adds missings project actions.

#### Description
Some missing actions added to the `baseActionsList` in the `projects-actions.js` file.
The missing actions are `changeMyBusinessUnitStatusOnCreation`, `setMyBusinessUnitAssociateRoleOnCreation`, and `changeCustomerSearchStatus`.

#### Todo

- Tests
  - [x] Unit
  - [ ] Integration
  - [ ] Acceptance
- [ ] Documentation
- [x] `Type` label for the PR <!-- Used to automatically generate the changelog -->
  <!-- Two persons should review a PR, don't forget to assign them. -->
  <!-- Please remember to squash merge. -->
  <!-- All contribution guidelines can be found here: https://github.com/commercetools/nodejs/blob/master/CONTRIBUTING.md -->
