### PR TITLE
fix(projects): fix myBusinessUnits and customerSearchStatus action keys

### DIFF
--- a/.changeset/seven-tools-brake.md
+++ b/.changeset/seven-tools-brake.md
@@ -1,0 +1,5 @@
+---
+'@commercetools/sync-actions': minor
+---
+
+Fix action keys for changeMyBusinessUnitStatusOnCreation, setMyBusinessUnitAssociateRoleOnCreation and changeCustomerSearchStatus

--- a/packages/sync-actions/src/projects-actions.js
+++ b/packages/sync-actions/src/projects-actions.js
@@ -7,15 +7,24 @@ export const baseActionsList = [
   { action: 'changeLanguages', key: 'languages' },
   { action: 'changeMessagesConfiguration', key: 'messagesConfiguration' },
   { action: 'setShippingRateInputType', key: 'shippingRateInputType' },
+]
+
+export const myBusinessUnitActionsList = [
   {
     action: 'changeMyBusinessUnitStatusOnCreation',
-    key: 'myBusinessUnitStatusOnCreation',
+    key: 'status',
   },
   {
     action: 'setMyBusinessUnitAssociateRoleOnCreation',
-    key: 'myBusinessUnitAssociateRoleOnCreation',
+    key: 'associateRole',
   },
-  { action: 'changeCustomerSearchStatus', key: 'customerSearchStatus' },
+]
+
+export const customerSearchActionsList = [
+  {
+    action: 'changeCustomerSearchStatus',
+    key: 'status',
+  },
 ]
 
 export function actionsMapBase(diff, oldObj, newObj, config = {}) {
@@ -25,5 +34,23 @@ export function actionsMapBase(diff, oldObj, newObj, config = {}) {
     oldObj,
     newObj,
     shouldOmitEmptyString: config.shouldOmitEmptyString,
+  })
+}
+
+export function actionsMapBusinessUnit(diff, oldObj, newObj) {
+  return buildBaseAttributesActions({
+    actions: myBusinessUnitActionsList,
+    diff,
+    oldObj,
+    newObj,
+  })
+}
+
+export function actionsMapCustomer(diff, oldObj, newObj) {
+  return buildBaseAttributesActions({
+    actions: customerSearchActionsList,
+    diff,
+    oldObj,
+    newObj,
   })
 }

--- a/packages/sync-actions/src/projects-actions.js
+++ b/packages/sync-actions/src/projects-actions.js
@@ -12,11 +12,13 @@ export const baseActionsList = [
 export const myBusinessUnitActionsList = [
   {
     action: 'changeMyBusinessUnitStatusOnCreation',
-    key: 'status',
+    key: 'myBusinessUnitStatusOnCreation',
+    actionKey: 'status',
   },
   {
     action: 'setMyBusinessUnitAssociateRoleOnCreation',
-    key: 'associateRole',
+    key: 'myBusinessUnitAssociateRoleOnCreation',
+    actionKey: 'associateRole',
   },
 ]
 
@@ -37,20 +39,36 @@ export function actionsMapBase(diff, oldObj, newObj, config = {}) {
   })
 }
 
-export function actionsMapBusinessUnit(diff, oldObj, newObj) {
+export const actionsMapBusinessUnit = (diff, oldObj, newObj) => {
+  const { businessUnits } = diff
+  if (!businessUnits) {
+    return []
+  }
+
   return buildBaseAttributesActions({
     actions: myBusinessUnitActionsList,
-    diff,
-    oldObj,
-    newObj,
+    diff: businessUnits,
+    oldObj: oldObj.businessUnits,
+    newObj: newObj.businessUnits,
   })
 }
 
 export function actionsMapCustomer(diff, oldObj, newObj) {
+  const { searchIndexing } = diff
+
+  if (!searchIndexing) {
+    return []
+  }
+
+  const { customers } = searchIndexing
+  if (!customers) {
+    return []
+  }
+
   return buildBaseAttributesActions({
     actions: customerSearchActionsList,
-    diff,
-    oldObj,
-    newObj,
+    diff: diff.searchIndexing.customers,
+    oldObj: oldObj.searchIndexing.customers,
+    newObj: newObj.searchIndexing.customers,
   })
 }

--- a/packages/sync-actions/src/projects-actions.js
+++ b/packages/sync-actions/src/projects-actions.js
@@ -53,7 +53,7 @@ export const actionsMapBusinessUnit = (diff, oldObj, newObj) => {
   })
 }
 
-export function actionsMapCustomer(diff, oldObj, newObj) {
+export function actionsMapSearchIndexingConfiguration(diff, oldObj, newObj) {
   const { searchIndexing } = diff
 
   if (!searchIndexing) {

--- a/packages/sync-actions/src/projects.js
+++ b/packages/sync-actions/src/projects.js
@@ -8,7 +8,7 @@ import {
 } from './projects-actions'
 import * as diffpatcher from './utils/diffpatcher'
 
-export const actionGroups = ['base', 'myBusinessUnit', 'customerSearch']
+export const actionGroups = ['base']
 
 function createChannelsMapActions(mapActionGroup, syncActionConfig) {
   return function doMapActions(diff, newObj, oldObj) {
@@ -21,15 +21,11 @@ function createChannelsMapActions(mapActionGroup, syncActionConfig) {
     )
 
     allActions.push(
-      mapActionGroup('myBusinessUnit', () =>
-        actionsMapBusinessUnit(diff, oldObj, newObj)
-      )
+      mapActionGroup('base', () => actionsMapBusinessUnit(diff, oldObj, newObj))
     )
 
     allActions.push(
-      mapActionGroup('customerSearch', () =>
-        actionsMapCustomer(diff, oldObj, newObj)
-      )
+      mapActionGroup('base', () => actionsMapCustomer(diff, oldObj, newObj))
     )
 
     return flatten(allActions)

--- a/packages/sync-actions/src/projects.js
+++ b/packages/sync-actions/src/projects.js
@@ -1,10 +1,14 @@
 import flatten from 'lodash.flatten'
 import createBuildActions from './utils/create-build-actions'
 import createMapActionGroup from './utils/create-map-action-group'
-import { actionsMapBase } from './projects-actions'
+import {
+  actionsMapBase,
+  actionsMapBusinessUnit,
+  actionsMapCustomer,
+} from './projects-actions'
 import * as diffpatcher from './utils/diffpatcher'
 
-export const actionGroups = ['base']
+export const actionGroups = ['base', 'myBusinessUnit', 'customerSearch']
 
 function createChannelsMapActions(mapActionGroup, syncActionConfig) {
   return function doMapActions(diff, newObj, oldObj) {
@@ -13,6 +17,18 @@ function createChannelsMapActions(mapActionGroup, syncActionConfig) {
     allActions.push(
       mapActionGroup('base', () =>
         actionsMapBase(diff, oldObj, newObj, syncActionConfig)
+      )
+    )
+
+    allActions.push(
+      mapActionGroup('myBusinessUnit', () =>
+        actionsMapBusinessUnit(diff, oldObj, newObj)
+      )
+    )
+
+    allActions.push(
+      mapActionGroup('customerSearch', () =>
+        actionsMapCustomer(diff, oldObj, newObj)
       )
     )
 

--- a/packages/sync-actions/src/projects.js
+++ b/packages/sync-actions/src/projects.js
@@ -4,11 +4,15 @@ import createMapActionGroup from './utils/create-map-action-group'
 import {
   actionsMapBase,
   actionsMapBusinessUnit,
-  actionsMapCustomer,
+  actionsMapSearchIndexingConfiguration,
 } from './projects-actions'
 import * as diffpatcher from './utils/diffpatcher'
 
-export const actionGroups = ['base']
+export const actionGroups = [
+  'base',
+  'businessUnit',
+  'searchIndexingConfiguration',
+]
 
 function createChannelsMapActions(mapActionGroup, syncActionConfig) {
   return function doMapActions(diff, newObj, oldObj) {
@@ -21,11 +25,15 @@ function createChannelsMapActions(mapActionGroup, syncActionConfig) {
     )
 
     allActions.push(
-      mapActionGroup('base', () => actionsMapBusinessUnit(diff, oldObj, newObj))
+      mapActionGroup('businessUnit', () =>
+        actionsMapBusinessUnit(diff, oldObj, newObj)
+      )
     )
 
     allActions.push(
-      mapActionGroup('base', () => actionsMapCustomer(diff, oldObj, newObj))
+      mapActionGroup('searchIndexingConfiguration', () =>
+        actionsMapSearchIndexingConfiguration(diff, oldObj, newObj)
+      )
     )
 
     return flatten(allActions)

--- a/packages/sync-actions/test/projects-sync.spec.js
+++ b/packages/sync-actions/test/projects-sync.spec.js
@@ -7,7 +7,11 @@ import {
 
 describe('Exports', () => {
   test('action group list', () => {
-    expect(actionGroups).toEqual(['base'])
+    expect(actionGroups).toEqual([
+      'base',
+      'businessUnit',
+      'searchIndexingConfiguration',
+    ])
   })
 
   describe('action list', () => {

--- a/packages/sync-actions/test/projects-sync.spec.js
+++ b/packages/sync-actions/test/projects-sync.spec.js
@@ -1,9 +1,13 @@
 import createProjectsSync, { actionGroups } from '../src/projects'
-import { baseActionsList } from '../src/projects-actions'
+import {
+  baseActionsList,
+  myBusinessUnitActionsList,
+  customerSearchActionsList,
+} from '../src/projects-actions'
 
 describe('Exports', () => {
   test('action group list', () => {
-    expect(actionGroups).toEqual(['base'])
+    expect(actionGroups).toEqual(['base', 'myBusinessUnit', 'customerSearch'])
   })
 
   describe('action list', () => {
@@ -66,33 +70,33 @@ describe('Exports', () => {
     })
 
     test('should contain `changeMyBusinessUnitStatusOnCreation` action', () => {
-      expect(baseActionsList).toEqual(
+      expect(myBusinessUnitActionsList).toEqual(
         expect.arrayContaining([
           {
             action: 'changeMyBusinessUnitStatusOnCreation',
-            key: 'myBusinessUnitStatusOnCreation',
+            key: 'status',
           },
         ])
       )
     })
 
     test('should contain `setMyBusinessUnitAssociateRoleOnCreation` action', () => {
-      expect(baseActionsList).toEqual(
+      expect(myBusinessUnitActionsList).toEqual(
         expect.arrayContaining([
           {
             action: 'setMyBusinessUnitAssociateRoleOnCreation',
-            key: 'myBusinessUnitAssociateRoleOnCreation',
+            key: 'associateRole',
           },
         ])
       )
     })
 
     test('should contain `changeCustomerSearchStatus` action', () => {
-      expect(baseActionsList).toEqual(
+      expect(customerSearchActionsList).toEqual(
         expect.arrayContaining([
           {
             action: 'changeCustomerSearchStatus',
-            key: 'customerSearchStatus',
+            key: 'status',
           },
         ])
       )
@@ -247,8 +251,14 @@ describe('Actions', () => {
   })
 
   test('should build `changeMyBusinessUnitStatusOnCreation` action', () => {
-    const before = { myBusinessUnitStatusOnCreation: 'Active' }
-    const now = { myBusinessUnitStatusOnCreation: 'Deactive' }
+    const actionGroupList = [
+      { type: 'base', group: 'allow' },
+      { type: 'myBusinessUnit', group: 'allow' },
+      { type: 'customerSearch', group: 'ignore' },
+    ]
+    projectsSync = createProjectsSync(actionGroupList)
+    const before = { status: 'Active' }
+    const now = { status: 'Deactive' }
     const actual = projectsSync.buildActions(now, before)
     const expected = [
       {
@@ -261,13 +271,13 @@ describe('Actions', () => {
 
   test('should build `setMyBusinessUnitAssociateRoleOnCreation` action', () => {
     const before = {
-      myBusinessUnitAssociateRoleOnCreation: {
+      associateRole: {
         typeId: 'associate-role',
         key: 'old-role',
       },
     }
     const now = {
-      myBusinessUnitAssociateRoleOnCreation: {
+      associateRole: {
         typeId: 'associate-role',
         key: 'new-role',
       },
@@ -283,8 +293,20 @@ describe('Actions', () => {
   })
 
   test('should build `changeCustomerSearchStatus` action', () => {
-    const before = { customerSearchStatus: 'Activated' }
-    const now = { customerSearchStatus: 'Deactivated' }
+    const actionGroupList = [
+      { type: 'base', group: 'allow' },
+      { type: 'myBusinessUnit', group: 'ignore' },
+      { type: 'customerSearch', group: 'allow' },
+    ]
+    projectsSync = createProjectsSync(actionGroupList)
+    const before = {
+      action: 'changeCustomerSearchStatus',
+      status: 'Activated',
+    }
+    const now = {
+      action: 'changeCustomerSearchStatus',
+      status: 'Deactivated',
+    }
     const actual = projectsSync.buildActions(now, before)
     const expected = [
       {

--- a/packages/sync-actions/test/projects-sync.spec.js
+++ b/packages/sync-actions/test/projects-sync.spec.js
@@ -7,7 +7,7 @@ import {
 
 describe('Exports', () => {
   test('action group list', () => {
-    expect(actionGroups).toEqual(['base', 'myBusinessUnit', 'customerSearch'])
+    expect(actionGroups).toEqual(['base'])
   })
 
   describe('action list', () => {
@@ -74,7 +74,8 @@ describe('Exports', () => {
         expect.arrayContaining([
           {
             action: 'changeMyBusinessUnitStatusOnCreation',
-            key: 'status',
+            key: 'myBusinessUnitStatusOnCreation',
+            actionKey: 'status',
           },
         ])
       )
@@ -85,7 +86,8 @@ describe('Exports', () => {
         expect.arrayContaining([
           {
             action: 'setMyBusinessUnitAssociateRoleOnCreation',
-            key: 'associateRole',
+            key: 'myBusinessUnitAssociateRoleOnCreation',
+            actionKey: 'associateRole',
           },
         ])
       )
@@ -251,19 +253,17 @@ describe('Actions', () => {
   })
 
   test('should build `changeMyBusinessUnitStatusOnCreation` action', () => {
-    const actionGroupList = [
-      { type: 'base', group: 'allow' },
-      { type: 'myBusinessUnit', group: 'allow' },
-      { type: 'customerSearch', group: 'ignore' },
-    ]
-    projectsSync = createProjectsSync(actionGroupList)
-    const before = { status: 'Active' }
-    const now = { status: 'Deactive' }
+    const before = {
+      businessUnits: { myBusinessUnitStatusOnCreation: 'Active' },
+    }
+    const now = {
+      businessUnits: { myBusinessUnitStatusOnCreation: 'Inactive' },
+    }
     const actual = projectsSync.buildActions(now, before)
     const expected = [
       {
         action: 'changeMyBusinessUnitStatusOnCreation',
-        ...now,
+        status: 'Inactive',
       },
     ]
     expect(actual).toEqual(expected)
@@ -271,47 +271,63 @@ describe('Actions', () => {
 
   test('should build `setMyBusinessUnitAssociateRoleOnCreation` action', () => {
     const before = {
-      associateRole: {
-        typeId: 'associate-role',
-        key: 'old-role',
+      businessUnits: {
+        myBusinessUnitAssociateRoleOnCreation: {
+          typeId: 'associate-role',
+          key: 'old-role',
+        },
       },
     }
     const now = {
-      associateRole: {
-        typeId: 'associate-role',
-        key: 'new-role',
+      businessUnits: {
+        myBusinessUnitAssociateRoleOnCreation: {
+          typeId: 'associate-role',
+          key: 'new-role',
+        },
       },
     }
     const actual = projectsSync.buildActions(now, before)
     const expected = [
       {
         action: 'setMyBusinessUnitAssociateRoleOnCreation',
-        ...now,
+        associateRole: {
+          typeId: 'associate-role',
+          key: 'new-role',
+        },
       },
     ]
     expect(actual).toEqual(expected)
   })
 
   test('should build `changeCustomerSearchStatus` action', () => {
-    const actionGroupList = [
-      { type: 'base', group: 'allow' },
-      { type: 'myBusinessUnit', group: 'ignore' },
-      { type: 'customerSearch', group: 'allow' },
-    ]
-    projectsSync = createProjectsSync(actionGroupList)
     const before = {
-      action: 'changeCustomerSearchStatus',
-      status: 'Activated',
+      searchIndexing: {
+        customers: {
+          status: 'Activated',
+          lastModifiedAt: '2024-05-31T08:20:26.187Z',
+          lastModifiedBy: {
+            isPlatformClient: true,
+          },
+        },
+      },
     }
+
     const now = {
-      action: 'changeCustomerSearchStatus',
-      status: 'Deactivated',
+      searchIndexing: {
+        customers: {
+          status: 'Deactivated',
+          lastModifiedAt: '2024-05-31T08:20:26.187Z',
+          lastModifiedBy: {
+            isPlatformClient: true,
+          },
+        },
+      },
     }
     const actual = projectsSync.buildActions(now, before)
     const expected = [
       {
         action: 'changeCustomerSearchStatus',
-        ...now,
+        status: 'Deactivated',
       },
     ]
     expect(actual).toEqual(expected)


### PR DESCRIPTION
Summary
Fix myBusinessUnit and customerSearch project actions.

Description
Some project actions I added recently had the wrong keys. I fixed those and split the actions into groups myBusinessUnit and customerSearch because changeMyBusinessUnitStatusOnCreation and changeCustomerSearchStatus have the same key: `status`. 

#### Todo

- Tests
  - [x] Unit
  - [ ] Integration
  - [ ] Acceptance
- [ ] Documentation
- [ ] `Type` label for the PR <!-- Used to automatically generate the changelog -->
  <!-- Two persons should review a PR, don't forget to assign them. -->
  <!-- Please remember to squash merge. -->
  <!-- All contribution guidelines can be found here: https://github.com/commercetools/nodejs/blob/master/CONTRIBUTING.md -->
