### PR TITLE
Fix product action groups category order hints

### DIFF
--- a/.changeset/olive-poets-impress.md
+++ b/.changeset/olive-poets-impress.md
@@ -1,0 +1,5 @@
+---
+"@commercetools/sync-actions": patch
+---
+
+Fix product action groups category order hints

--- a/packages/sync-actions/src/products.js
+++ b/packages/sync-actions/src/products.js
@@ -131,7 +131,7 @@ function createProductMapActions(
     )
 
     allActions.push(
-      mapActionGroup('categories', (): Array<UpdateAction> =>
+      mapActionGroup('categoryOrderHints', (): Array<UpdateAction> =>
         productActions.actionsMapCategoryOrderHints(diff, oldObj)
       )
     )


### PR DESCRIPTION
#### Summary

<!-- Provide a short summary of your changes -->

#### Description

<!-- Describe the changes in this PR here and provide some context -->
Map the `categoryOrderHints` actionGroup to the corresponding `actionsMapCategoryOrderHints` function.

- [test: categoryOrderHints actionGroup](https://github.com/commercetools/nodejs/commit/15652b2edb31d915c89671417acad42b524aa186)
Check how the tests are [failing](https://app.circleci.com/pipelines/github/commercetools/nodejs/4452/workflows/0c7180c8-fac8-4b27-9003-3fedd47a666c/jobs/24159?utm_campaign=vcs-integration-link&utm_medium=referral&utm_source=github-checks-link&utm_content=summary)
- [fix: align categoryOrderHints with the corresponding actionGroup](https://github.com/commercetools/nodejs/commit/ee7b0f2eba1031c12e6f40d4c782449957d3b548)
now tests are passing
#### Todo

- Tests
  - [x] Unit
  - [ ] Integration
  - [ ] Acceptance
- [ ] Documentation
- [ ] `Type` label for the PR <!-- Used to automatically generate the changelog -->
  <!-- Two persons should review a PR, don't forget to assign them. -->
  <!-- Please remember to squash merge. -->
  <!-- All contribution guidelines can be found here: https://github.com/commercetools/nodejs/blob/master/CONTRIBUTING.md -->
