### PR TITLE
feat(sync-actions): provide option to generate empty update actions for ommitted properties

### DIFF
--- a/.changeset/hungry-cats-yell.md
+++ b/.changeset/hungry-cats-yell.md
@@ -1,0 +1,5 @@
+---
+'@commercetools/sync-actions': minor
+---
+
+Introducing configuration to control the behaviour regarding generation of UpdateActions in respect to unsetting fields

--- a/packages/sync-actions/src/attribute-groups-actions.js
+++ b/packages/sync-actions/src/attribute-groups-actions.js
@@ -22,6 +22,8 @@ export function actionsMapBase(diff, oldObj, newObj, config = {}) {
     newObj,
     shouldOmitEmptyString: config.shouldOmitEmptyString,
     shouldUnsetOmittedProperties: config.shouldUnsetOmittedProperties,
+    shouldPreventUnsettingRequiredFields:
+      config.shouldPreventUnsettingRequiredFields,
   })
 }
 

--- a/packages/sync-actions/src/attribute-groups-actions.js
+++ b/packages/sync-actions/src/attribute-groups-actions.js
@@ -21,6 +21,7 @@ export function actionsMapBase(diff, oldObj, newObj, config = {}) {
     oldObj,
     newObj,
     shouldOmitEmptyString: config.shouldOmitEmptyString,
+    shouldUnsetOmittedProperties: config.shouldUnsetOmittedProperties,
   })
 }
 

--- a/packages/sync-actions/src/cart-discounts-actions.js
+++ b/packages/sync-actions/src/cart-discounts-actions.js
@@ -23,5 +23,7 @@ export function actionsMapBase(diff, oldObj, newObj, config = {}) {
     newObj,
     shouldOmitEmptyString: config.shouldOmitEmptyString,
     shouldUnsetOmittedProperties: config.shouldUnsetOmittedProperties,
+    shouldPreventUnsettingRequiredFields:
+      config.shouldPreventUnsettingRequiredFields,
   })
 }

--- a/packages/sync-actions/src/cart-discounts-actions.js
+++ b/packages/sync-actions/src/cart-discounts-actions.js
@@ -22,5 +22,6 @@ export function actionsMapBase(diff, oldObj, newObj, config = {}) {
     oldObj,
     newObj,
     shouldOmitEmptyString: config.shouldOmitEmptyString,
+    shouldUnsetOmittedProperties: config.shouldUnsetOmittedProperties,
   })
 }

--- a/packages/sync-actions/src/category-actions.js
+++ b/packages/sync-actions/src/category-actions.js
@@ -31,6 +31,7 @@ export function actionsMapBase(diff, oldObj, newObj, config = {}) {
     oldObj,
     newObj,
     shouldOmitEmptyString: config.shouldOmitEmptyString,
+    shouldUnsetOmittedProperties: config.shouldUnsetOmittedProperties,
   })
 }
 

--- a/packages/sync-actions/src/category-actions.js
+++ b/packages/sync-actions/src/category-actions.js
@@ -32,6 +32,8 @@ export function actionsMapBase(diff, oldObj, newObj, config = {}) {
     newObj,
     shouldOmitEmptyString: config.shouldOmitEmptyString,
     shouldUnsetOmittedProperties: config.shouldUnsetOmittedProperties,
+    shouldPreventUnsettingRequiredFields:
+      config.shouldPreventUnsettingRequiredFields,
   })
 }
 

--- a/packages/sync-actions/src/channels-actions.js
+++ b/packages/sync-actions/src/channels-actions.js
@@ -16,5 +16,6 @@ export function actionsMapBase(diff, oldObj, newObj, config = {}) {
     oldObj,
     newObj,
     shouldOmitEmptyString: config.shouldOmitEmptyString,
+    shouldUnsetOmittedProperties: config.shouldUnsetOmittedProperties,
   })
 }

--- a/packages/sync-actions/src/channels-actions.js
+++ b/packages/sync-actions/src/channels-actions.js
@@ -17,5 +17,7 @@ export function actionsMapBase(diff, oldObj, newObj, config = {}) {
     newObj,
     shouldOmitEmptyString: config.shouldOmitEmptyString,
     shouldUnsetOmittedProperties: config.shouldUnsetOmittedProperties,
+    shouldPreventUnsettingRequiredFields:
+      config.shouldPreventUnsettingRequiredFields,
   })
 }

--- a/packages/sync-actions/src/customer-actions.js
+++ b/packages/sync-actions/src/customer-actions.js
@@ -70,6 +70,9 @@ export function actionsMapBase(diff, oldObj, newObj, config = {}) {
     oldObj,
     newObj,
     shouldOmitEmptyString: config.shouldOmitEmptyString,
+    shouldUnsetOmittedProperties: config.shouldUnsetOmittedProperties,
+    shouldPreventUnsettingRequiredFields:
+      config.shouldPreventUnsettingRequiredFields,
   })
 }
 
@@ -80,6 +83,9 @@ export function actionsMapSetDefaultBase(diff, oldObj, newObj, config = {}) {
     oldObj,
     newObj,
     shouldOmitEmptyString: config.shouldOmitEmptyString,
+    shouldUnsetOmittedProperties: config.shouldUnsetOmittedProperties,
+    shouldPreventUnsettingRequiredFields:
+      config.shouldPreventUnsettingRequiredFields,
   })
 }
 

--- a/packages/sync-actions/src/customer-group-actions.js
+++ b/packages/sync-actions/src/customer-group-actions.js
@@ -13,5 +13,7 @@ export function actionsMapBase(diff, oldObj, newObj, config = {}) {
     newObj,
     shouldOmitEmptyString: config.shouldOmitEmptyString,
     shouldUnsetOmittedProperties: config.shouldUnsetOmittedProperties,
+    shouldPreventUnsettingRequiredFields:
+      config.shouldPreventUnsettingRequiredFields,
   })
 }

--- a/packages/sync-actions/src/customer-group-actions.js
+++ b/packages/sync-actions/src/customer-group-actions.js
@@ -12,5 +12,6 @@ export function actionsMapBase(diff, oldObj, newObj, config = {}) {
     oldObj,
     newObj,
     shouldOmitEmptyString: config.shouldOmitEmptyString,
+    shouldUnsetOmittedProperties: config.shouldUnsetOmittedProperties,
   })
 }

--- a/packages/sync-actions/src/discount-codes-actions.js
+++ b/packages/sync-actions/src/discount-codes-actions.js
@@ -24,5 +24,6 @@ export function actionsMapBase(diff, oldObj, newObj, config = {}) {
     oldObj,
     newObj,
     shouldOmitEmptyString: config.shouldOmitEmptyString,
+    shouldUnsetOmittedProperties: config.shouldUnsetOmittedProperties,
   })
 }

--- a/packages/sync-actions/src/discount-codes-actions.js
+++ b/packages/sync-actions/src/discount-codes-actions.js
@@ -25,5 +25,7 @@ export function actionsMapBase(diff, oldObj, newObj, config = {}) {
     newObj,
     shouldOmitEmptyString: config.shouldOmitEmptyString,
     shouldUnsetOmittedProperties: config.shouldUnsetOmittedProperties,
+    shouldPreventUnsettingRequiredFields:
+      config.shouldPreventUnsettingRequiredFields,
   })
 }

--- a/packages/sync-actions/src/inventory-actions.js
+++ b/packages/sync-actions/src/inventory-actions.js
@@ -24,6 +24,7 @@ export function actionsMapBase(diff, oldObj, newObj, config = {}) {
     oldObj,
     newObj,
     shouldOmitEmptyString: config.shouldOmitEmptyString,
+    shouldUnsetOmittedProperties: config.shouldUnsetOmittedProperties,
   })
 }
 

--- a/packages/sync-actions/src/inventory-actions.js
+++ b/packages/sync-actions/src/inventory-actions.js
@@ -25,6 +25,8 @@ export function actionsMapBase(diff, oldObj, newObj, config = {}) {
     newObj,
     shouldOmitEmptyString: config.shouldOmitEmptyString,
     shouldUnsetOmittedProperties: config.shouldUnsetOmittedProperties,
+    shouldPreventUnsettingRequiredFields:
+      config.shouldPreventUnsettingRequiredFields,
   })
 }
 

--- a/packages/sync-actions/src/order-actions.js
+++ b/packages/sync-actions/src/order-actions.js
@@ -34,6 +34,7 @@ export function actionsMapBase(diff, oldObj, newObj, config = {}) {
     oldObj,
     newObj,
     shouldOmitEmptyString: config.shouldOmitEmptyString,
+    shouldUnsetOmittedProperties: config.shouldUnsetOmittedProperties,
   })
 }
 

--- a/packages/sync-actions/src/order-actions.js
+++ b/packages/sync-actions/src/order-actions.js
@@ -35,6 +35,8 @@ export function actionsMapBase(diff, oldObj, newObj, config = {}) {
     newObj,
     shouldOmitEmptyString: config.shouldOmitEmptyString,
     shouldUnsetOmittedProperties: config.shouldUnsetOmittedProperties,
+    shouldPreventUnsettingRequiredFields:
+      config.shouldPreventUnsettingRequiredFields,
   })
 }
 

--- a/packages/sync-actions/src/prices-actions.js
+++ b/packages/sync-actions/src/prices-actions.js
@@ -19,5 +19,7 @@ export function actionsMapBase(diff, oldObj, newObj, config = {}) {
     newObj,
     shouldOmitEmptyString: config.shouldOmitEmptyString,
     shouldUnsetOmittedProperties: config.shouldUnsetOmittedProperties,
+    shouldPreventUnsettingRequiredFields:
+      config.shouldPreventUnsettingRequiredFields,
   })
 }

--- a/packages/sync-actions/src/prices-actions.js
+++ b/packages/sync-actions/src/prices-actions.js
@@ -18,5 +18,6 @@ export function actionsMapBase(diff, oldObj, newObj, config = {}) {
     oldObj,
     newObj,
     shouldOmitEmptyString: config.shouldOmitEmptyString,
+    shouldUnsetOmittedProperties: config.shouldUnsetOmittedProperties,
   })
 }

--- a/packages/sync-actions/src/product-actions.js
+++ b/packages/sync-actions/src/product-actions.js
@@ -526,15 +526,18 @@ export function actionsMapBase(diff, oldObj, newObj, config = {}) {
     oldObj,
     newObj,
     shouldOmitEmptyString: config.shouldOmitEmptyString,
+    shouldUnsetOmittedProperties: config.shouldUnsetOmittedProperties,
   })
 }
 
-export function actionsMapMeta(diff, oldObj, newObj) {
+export function actionsMapMeta(diff, oldObj, newObj, config = {}) {
   return buildBaseAttributesActions({
     actions: metaActionsList,
     diff,
     oldObj,
     newObj,
+    shouldOmitEmptyString: config.shouldOmitEmptyString,
+    shouldUnsetOmittedProperties: config.shouldUnsetOmittedProperties,
   })
 }
 

--- a/packages/sync-actions/src/product-discounts-actions.js
+++ b/packages/sync-actions/src/product-discounts-actions.js
@@ -19,5 +19,6 @@ export function actionsMapBase(diff, oldObj, newObj, config = {}) {
     oldObj,
     newObj,
     shouldOmitEmptyString: config.shouldOmitEmptyString,
+    shouldUnsetOmittedProperties: config.shouldUnsetOmittedProperties,
   })
 }

--- a/packages/sync-actions/src/product-discounts-actions.js
+++ b/packages/sync-actions/src/product-discounts-actions.js
@@ -20,5 +20,7 @@ export function actionsMapBase(diff, oldObj, newObj, config = {}) {
     newObj,
     shouldOmitEmptyString: config.shouldOmitEmptyString,
     shouldUnsetOmittedProperties: config.shouldUnsetOmittedProperties,
+    shouldPreventUnsettingRequiredFields:
+      config.shouldPreventUnsettingRequiredFields,
   })
 }

--- a/packages/sync-actions/src/product-selections-actions.js
+++ b/packages/sync-actions/src/product-selections-actions.js
@@ -13,5 +13,7 @@ export function actionsMapBase(diff, oldObj, newObj, config = {}) {
     newObj,
     shouldOmitEmptyString: config.shouldOmitEmptyString,
     shouldUnsetOmittedProperties: config.shouldUnsetOmittedProperties,
+    shouldPreventUnsettingRequiredFields:
+      config.shouldPreventUnsettingRequiredFields,
   })
 }

--- a/packages/sync-actions/src/product-selections-actions.js
+++ b/packages/sync-actions/src/product-selections-actions.js
@@ -5,11 +5,13 @@ export const baseActionsList = [
   { action: 'setKey', key: 'key' },
 ]
 
-export function actionsMapBase(diff, oldObj, newObj) {
+export function actionsMapBase(diff, oldObj, newObj, config = {}) {
   return buildBaseAttributesActions({
     actions: baseActionsList,
     diff,
     oldObj,
     newObj,
+    shouldOmitEmptyString: config.shouldOmitEmptyString,
+    shouldUnsetOmittedProperties: config.shouldUnsetOmittedProperties,
   })
 }

--- a/packages/sync-actions/src/product-types-actions.js
+++ b/packages/sync-actions/src/product-types-actions.js
@@ -22,6 +22,7 @@ export function actionsMapBase(diff, previous, next, config = {}) {
     oldObj: previous,
     newObj: next,
     shouldOmitEmptyString: config.shouldOmitEmptyString,
+    shouldUnsetOmittedProperties: config.shouldUnsetOmittedProperties,
   })
 }
 

--- a/packages/sync-actions/src/projects-actions.js
+++ b/packages/sync-actions/src/projects-actions.js
@@ -39,7 +39,7 @@ export function actionsMapBase(diff, oldObj, newObj, config = {}) {
   })
 }
 
-export const actionsMapBusinessUnit = (diff, oldObj, newObj) => {
+export const actionsMapBusinessUnit = (diff, oldObj, newObj, config = {}) => {
   const { businessUnits } = diff
   if (!businessUnits) {
     return []
@@ -50,10 +50,17 @@ export const actionsMapBusinessUnit = (diff, oldObj, newObj) => {
     diff: businessUnits,
     oldObj: oldObj.businessUnits,
     newObj: newObj.businessUnits,
+    shouldOmitEmptyString: config.shouldOmitEmptyString,
+    shouldUnsetOmittedProperties: config.shouldUnsetOmittedProperties,
   })
 }
 
-export function actionsMapSearchIndexingConfiguration(diff, oldObj, newObj) {
+export function actionsMapSearchIndexingConfiguration(
+  diff,
+  oldObj,
+  newObj,
+  config = {}
+) {
   const { searchIndexing } = diff
 
   if (!searchIndexing) {
@@ -70,5 +77,7 @@ export function actionsMapSearchIndexingConfiguration(diff, oldObj, newObj) {
     diff: diff.searchIndexing.customers,
     oldObj: oldObj.searchIndexing.customers,
     newObj: newObj.searchIndexing.customers,
+    shouldOmitEmptyString: config.shouldOmitEmptyString,
+    shouldUnsetOmittedProperties: config.shouldUnsetOmittedProperties,
   })
 }

--- a/packages/sync-actions/src/projects-actions.js
+++ b/packages/sync-actions/src/projects-actions.js
@@ -79,5 +79,7 @@ export function actionsMapSearchIndexingConfiguration(
     newObj: newObj.searchIndexing.customers,
     shouldOmitEmptyString: config.shouldOmitEmptyString,
     shouldUnsetOmittedProperties: config.shouldUnsetOmittedProperties,
+    shouldPreventUnsettingRequiredFields:
+      config.shouldPreventUnsettingRequiredFields,
   })
 }

--- a/packages/sync-actions/src/quote-requests-actions.js
+++ b/packages/sync-actions/src/quote-requests-actions.js
@@ -13,5 +13,7 @@ export function actionsMapBase(diff, oldObj, newObj, config = {}) {
     newObj,
     shouldOmitEmptyString: config.shouldOmitEmptyString,
     shouldUnsetOmittedProperties: config.shouldUnsetOmittedProperties,
+    shouldPreventUnsettingRequiredFields:
+      config.shouldPreventUnsettingRequiredFields,
   })
 }

--- a/packages/sync-actions/src/quote-requests-actions.js
+++ b/packages/sync-actions/src/quote-requests-actions.js
@@ -12,5 +12,6 @@ export function actionsMapBase(diff, oldObj, newObj, config = {}) {
     oldObj,
     newObj,
     shouldOmitEmptyString: config.shouldOmitEmptyString,
+    shouldUnsetOmittedProperties: config.shouldUnsetOmittedProperties,
   })
 }

--- a/packages/sync-actions/src/quotes-actions.js
+++ b/packages/sync-actions/src/quotes-actions.js
@@ -13,5 +13,6 @@ export function actionsMapBase(diff, oldObj, newObj, config = {}) {
     oldObj,
     newObj,
     shouldOmitEmptyString: config.shouldOmitEmptyString,
+    shouldUnsetOmittedProperties: config.shouldUnsetOmittedProperties,
   })
 }

--- a/packages/sync-actions/src/quotes-actions.js
+++ b/packages/sync-actions/src/quotes-actions.js
@@ -14,5 +14,7 @@ export function actionsMapBase(diff, oldObj, newObj, config = {}) {
     newObj,
     shouldOmitEmptyString: config.shouldOmitEmptyString,
     shouldUnsetOmittedProperties: config.shouldUnsetOmittedProperties,
+    shouldPreventUnsettingRequiredFields:
+      config.shouldPreventUnsettingRequiredFields,
   })
 }

--- a/packages/sync-actions/src/shipping-methods-actions.js
+++ b/packages/sync-actions/src/shipping-methods-actions.js
@@ -25,6 +25,7 @@ export function actionsMapBase(diff, oldObj, newObj, config = {}) {
     oldObj,
     newObj,
     shouldOmitEmptyString: config.shouldOmitEmptyString,
+    shouldUnsetOmittedProperties: config.shouldUnsetOmittedProperties,
   })
 }
 

--- a/packages/sync-actions/src/shipping-methods-actions.js
+++ b/packages/sync-actions/src/shipping-methods-actions.js
@@ -26,6 +26,8 @@ export function actionsMapBase(diff, oldObj, newObj, config = {}) {
     newObj,
     shouldOmitEmptyString: config.shouldOmitEmptyString,
     shouldUnsetOmittedProperties: config.shouldUnsetOmittedProperties,
+    shouldPreventUnsettingRequiredFields:
+      config.shouldPreventUnsettingRequiredFields,
   })
 }
 

--- a/packages/sync-actions/src/staged-quotes-actions.js
+++ b/packages/sync-actions/src/staged-quotes-actions.js
@@ -15,5 +15,7 @@ export function actionsMapBase(diff, oldObj, newObj, config = {}) {
     newObj,
     shouldOmitEmptyString: config.shouldOmitEmptyString,
     shouldUnsetOmittedProperties: config.shouldUnsetOmittedProperties,
+    shouldPreventUnsettingRequiredFields:
+      config.shouldPreventUnsettingRequiredFields,
   })
 }

--- a/packages/sync-actions/src/staged-quotes-actions.js
+++ b/packages/sync-actions/src/staged-quotes-actions.js
@@ -14,5 +14,6 @@ export function actionsMapBase(diff, oldObj, newObj, config = {}) {
     oldObj,
     newObj,
     shouldOmitEmptyString: config.shouldOmitEmptyString,
+    shouldUnsetOmittedProperties: config.shouldUnsetOmittedProperties,
   })
 }

--- a/packages/sync-actions/src/state-actions.js
+++ b/packages/sync-actions/src/state-actions.js
@@ -21,6 +21,8 @@ export function actionsMapBase(diff, oldObj, newObj, config = {}) {
     newObj,
     shouldOmitEmptyString: config.shouldOmitEmptyString,
     shouldUnsetOmittedProperties: config.shouldUnsetOmittedProperties,
+    shouldPreventUnsettingRequiredFields:
+      config.shouldPreventUnsettingRequiredFields,
   })
 }
 

--- a/packages/sync-actions/src/state-actions.js
+++ b/packages/sync-actions/src/state-actions.js
@@ -20,6 +20,7 @@ export function actionsMapBase(diff, oldObj, newObj, config = {}) {
     oldObj,
     newObj,
     shouldOmitEmptyString: config.shouldOmitEmptyString,
+    shouldUnsetOmittedProperties: config.shouldUnsetOmittedProperties,
   })
 }
 

--- a/packages/sync-actions/src/stores-actions.js
+++ b/packages/sync-actions/src/stores-actions.js
@@ -15,5 +15,7 @@ export function actionsMapBase(diff, oldObj, newObj, config = {}) {
     newObj,
     shouldOmitEmptyString: config.shouldOmitEmptyString,
     shouldUnsetOmittedProperties: config.shouldUnsetOmittedProperties,
+    shouldPreventUnsettingRequiredFields:
+      config.shouldPreventUnsettingRequiredFields,
   })
 }

--- a/packages/sync-actions/src/stores-actions.js
+++ b/packages/sync-actions/src/stores-actions.js
@@ -7,11 +7,13 @@ export const baseActionsList = [
   { action: 'setSupplyChannels', key: 'supplyChannels' },
 ]
 
-export function actionsMapBase(diff, oldObj, newObj) {
+export function actionsMapBase(diff, oldObj, newObj, config = {}) {
   return buildBaseAttributesActions({
     actions: baseActionsList,
     diff,
     oldObj,
     newObj,
+    shouldOmitEmptyString: config.shouldOmitEmptyString,
+    shouldUnsetOmittedProperties: config.shouldUnsetOmittedProperties,
   })
 }

--- a/packages/sync-actions/src/stores.js
+++ b/packages/sync-actions/src/stores.js
@@ -1,6 +1,11 @@
 /* @flow */
 import flatten from 'lodash.flatten'
-import type { SyncAction, UpdateAction, ActionGroup } from 'types/sdk'
+import type {
+  SyncAction,
+  UpdateAction,
+  ActionGroup,
+  SyncActionConfig,
+} from 'types/sdk'
 import createBuildActions from './utils/create-build-actions'
 import createMapActionGroup from './utils/create-map-action-group'
 import actionsMapCustom from './utils/action-map-custom'
@@ -41,14 +46,18 @@ function createStoresMapActions(
   }
 }
 
-export default (actionGroupList: Array<ActionGroup>): SyncAction => {
+export default (
+  actionGroupList: Array<ActionGroup>,
+  options: SyncActionConfig = {}
+): SyncAction => {
   const mapActionGroup = createMapActionGroup(actionGroupList)
   const doMapActions = createStoresMapActions(mapActionGroup)
   const onBeforeApplyingDiff = null
   const buildActions = createBuildActions(
     diffpatcher.diff,
     doMapActions,
-    onBeforeApplyingDiff
+    onBeforeApplyingDiff,
+    options
   )
 
   return { buildActions }

--- a/packages/sync-actions/src/tax-categories-actions.js
+++ b/packages/sync-actions/src/tax-categories-actions.js
@@ -21,6 +21,8 @@ export function actionsMapBase(diff, oldObj, newObj, config = {}) {
     newObj,
     shouldOmitEmptyString: config.shouldOmitEmptyString,
     shouldUnsetOmittedProperties: config.shouldUnsetOmittedProperties,
+    shouldPreventUnsettingRequiredFields:
+      config.shouldPreventUnsettingRequiredFields,
   })
 }
 

--- a/packages/sync-actions/src/tax-categories-actions.js
+++ b/packages/sync-actions/src/tax-categories-actions.js
@@ -20,6 +20,7 @@ export function actionsMapBase(diff, oldObj, newObj, config = {}) {
     oldObj,
     newObj,
     shouldOmitEmptyString: config.shouldOmitEmptyString,
+    shouldUnsetOmittedProperties: config.shouldUnsetOmittedProperties,
   })
 }
 

--- a/packages/sync-actions/src/types-actions.js
+++ b/packages/sync-actions/src/types-actions.js
@@ -29,6 +29,7 @@ export function actionsMapBase(diff, oldObj, newObj, config = {}) {
     oldObj,
     newObj,
     shouldOmitEmptyString: config.shouldOmitEmptyString,
+    shouldUnsetOmittedProperties: config.shouldUnsetOmittedProperties,
   })
 }
 

--- a/packages/sync-actions/src/types-actions.js
+++ b/packages/sync-actions/src/types-actions.js
@@ -30,6 +30,8 @@ export function actionsMapBase(diff, oldObj, newObj, config = {}) {
     newObj,
     shouldOmitEmptyString: config.shouldOmitEmptyString,
     shouldUnsetOmittedProperties: config.shouldUnsetOmittedProperties,
+    shouldPreventUnsettingRequiredFields:
+      config.shouldPreventUnsettingRequiredFields,
   })
 }
 

--- a/packages/sync-actions/src/utils/common-actions.js
+++ b/packages/sync-actions/src/utils/common-actions.js
@@ -18,6 +18,7 @@ export const createIsEmptyValue = (emptyValues) => (value) =>
  * @param  {Object} options.oldObj - the object that needs to be updated
  * @param  {Object} options.newObj - the new representation of the object
  * @param {Boolean} options.shouldOmitEmptyString - a flag to determine if we should treat an empty string a NON-value
+ * @param {Boolean} options.shouldUnsetOmittedProperties - a flag to determine if we should unset fields which are omitted in the newObj
  */
 export function buildBaseAttributesActions({
   actions,
@@ -25,6 +26,7 @@ export function buildBaseAttributesActions({
   oldObj,
   newObj,
   shouldOmitEmptyString,
+  shouldUnsetOmittedProperties,
 }) {
   const isEmptyValue = createIsEmptyValue(
     shouldOmitEmptyString ? [undefined, null, ''] : [undefined, null]
@@ -38,6 +40,7 @@ export function buildBaseAttributesActions({
       const now = newObj[key]
       const isNotDefinedBefore = isEmptyValue(oldObj[key])
       const isNotDefinedNow = isEmptyValue(newObj[key])
+      const isOmitted = !{}.hasOwnProperty.call(newObj, key)
       if (!delta) return undefined
 
       if (isNotDefinedNow && isNotDefinedBefore) return undefined
@@ -47,10 +50,10 @@ export function buildBaseAttributesActions({
         return { action: item.action, [actionKey]: now }
 
       /* no new value */
-      if (isNotDefinedNow && !{}.hasOwnProperty.call(newObj, key))
+      if (isNotDefinedNow && isOmitted && !shouldUnsetOmittedProperties)
         return undefined
 
-      if (isNotDefinedNow && {}.hasOwnProperty.call(newObj, key))
+      if (isNotDefinedNow)
         // value unset
         return { action: item.action }
 

--- a/packages/sync-actions/src/utils/common-actions.js
+++ b/packages/sync-actions/src/utils/common-actions.js
@@ -45,7 +45,7 @@ export function buildBaseAttributesActions({
       const now = newObj[key]
       const isNotDefinedBefore = isEmptyValue(oldObj[key])
       const isNotDefinedNow = isEmptyValue(newObj[key])
-      const isOmitted = !{}.hasOwnProperty.call(newObj, key)
+      const isOmitted = !Object.keys(newObj).includes(key)
       if (!delta) return undefined
 
       if (

--- a/packages/sync-actions/src/utils/common-actions.js
+++ b/packages/sync-actions/src/utils/common-actions.js
@@ -8,6 +8,9 @@ const normalizeValue = (value) =>
 export const createIsEmptyValue = (emptyValues) => (value) =>
   emptyValues.some((emptyValue) => emptyValue === normalizeValue(value))
 
+/* actions that start with 'set' can generate undefined valued */
+export const isOptionalField = (action) => action.startsWith('set')
+
 /**
  * Builds actions for simple object properties, given a list of actions
  * E.g. [{ action: `changeName`, key: 'name' }]
@@ -19,6 +22,7 @@ export const createIsEmptyValue = (emptyValues) => (value) =>
  * @param  {Object} options.newObj - the new representation of the object
  * @param {Boolean} options.shouldOmitEmptyString - a flag to determine if we should treat an empty string a NON-value
  * @param {Boolean} options.shouldUnsetOmittedProperties - a flag to determine if we should unset fields which are omitted in the newObj
+ * @param {Boolean} options.shouldPreventUnsettingRequiredFields - a flag to determine if required fields should be unset
  */
 export function buildBaseAttributesActions({
   actions,
@@ -27,6 +31,7 @@ export function buildBaseAttributesActions({
   newObj,
   shouldOmitEmptyString,
   shouldUnsetOmittedProperties,
+  shouldPreventUnsettingRequiredFields,
 }) {
   const isEmptyValue = createIsEmptyValue(
     shouldOmitEmptyString ? [undefined, null, ''] : [undefined, null]
@@ -42,6 +47,13 @@ export function buildBaseAttributesActions({
       const isNotDefinedNow = isEmptyValue(newObj[key])
       const isOmitted = !{}.hasOwnProperty.call(newObj, key)
       if (!delta) return undefined
+
+      if (
+        isNotDefinedNow &&
+        !isOptionalField(item.action) &&
+        shouldPreventUnsettingRequiredFields
+      )
+        return undefined
 
       if (isNotDefinedNow && isNotDefinedBefore) return undefined
 

--- a/packages/sync-actions/src/zones-actions.js
+++ b/packages/sync-actions/src/zones-actions.js
@@ -22,6 +22,8 @@ export function actionsMapBase(diff, oldObj, newObj, config = {}) {
     newObj,
     shouldOmitEmptyString: config.shouldOmitEmptyString,
     shouldUnsetOmittedProperties: config.shouldUnsetOmittedProperties,
+    shouldPreventUnsettingRequiredFields:
+      config.shouldPreventUnsettingRequiredFields,
   })
 }
 

--- a/packages/sync-actions/src/zones-actions.js
+++ b/packages/sync-actions/src/zones-actions.js
@@ -21,6 +21,7 @@ export function actionsMapBase(diff, oldObj, newObj, config = {}) {
     oldObj,
     newObj,
     shouldOmitEmptyString: config.shouldOmitEmptyString,
+    shouldUnsetOmittedProperties: config.shouldUnsetOmittedProperties,
   })
 }
 

--- a/packages/sync-actions/test/price-sync.spec.js
+++ b/packages/sync-actions/test/price-sync.spec.js
@@ -575,6 +575,29 @@ describe('price actions', () => {
         },
       ])
     })
+    test('should build `setValidFromAndUntil` empty action when `shouldUnsetOmittedProperties=true`', () => {
+      const priceSyncer = pricesSyncFn([], {
+        shouldUnsetOmittedProperties: true,
+      })
+      const before = {
+        id: '1010',
+        validFrom: dateNow,
+        validUntil: dateNow,
+      }
+
+      const now = {
+        id: '1010',
+      }
+
+      const actions = priceSyncer.buildActions(now, before)
+      expect(actions).toEqual([
+        {
+          action: 'setValidFromAndUntil',
+          validFrom: undefined,
+          validUntil: undefined,
+        },
+      ])
+    })
   })
 
   describe('setValidUntil', () => {

--- a/packages/sync-actions/test/utils/common-actions.spec.js
+++ b/packages/sync-actions/test/utils/common-actions.spec.js
@@ -161,6 +161,71 @@ describe('Common actions', () => {
         expect(actions).toEqual([])
       })
     })
+    describe('`shouldPreventUnsettingRequiredFields`', () => {
+      test('if true => should not generate unset actions for required fields', () => {
+        before = {
+          name: { en: 'Foo' },
+          description: 'description',
+          externalId: '123',
+          slug: { en: 'foo' },
+          customerNumber: 'customer-number',
+          quantityOnStock: 1,
+        }
+        now = {
+          name: null,
+          description: null,
+          externalId: null,
+          slug: null,
+          customerNumber: null,
+          quantityOnStock: null,
+        }
+        actions = buildBaseAttributesActions({
+          actions: testActions,
+          diff: diffpatcher.diff(before, now),
+          oldObj: before,
+          newObj: now,
+          shouldPreventUnsettingRequiredFields: true,
+        })
+        expect(actions).toEqual([
+          { action: 'setDescription' },
+          { action: 'setExternalId' },
+          { action: 'setCustomerNumber' },
+        ])
+      })
+      test('if false => should generate unset actions for required fields', () => {
+        before = {
+          name: { en: 'Foo' },
+          description: 'description',
+          externalId: '123',
+          slug: { en: 'foo' },
+          customerNumber: 'customer-number',
+          quantityOnStock: 1,
+        }
+        now = {
+          name: null,
+          description: null,
+          externalId: null,
+          slug: null,
+          customerNumber: null,
+          quantityOnStock: null,
+        }
+        actions = buildBaseAttributesActions({
+          actions: testActions,
+          diff: diffpatcher.diff(before, now),
+          oldObj: before,
+          newObj: now,
+          shouldPreventUnsettingRequiredFields: false,
+        })
+        expect(actions).toEqual([
+          { action: 'changeName' },
+          { action: 'setDescription' },
+          { action: 'setExternalId' },
+          { action: 'changeSlug' },
+          { action: 'setCustomerNumber' },
+          { action: 'changeQuantity' },
+        ])
+      })
+    })
   })
 
   describe('::buildReferenceActions', () => {

--- a/packages/sync-actions/test/utils/common-actions.spec.js
+++ b/packages/sync-actions/test/utils/common-actions.spec.js
@@ -35,10 +35,6 @@ describe('Common actions', () => {
         key: 'customerNumber',
       },
       {
-        action: 'setCustomerNumber',
-        key: 'customerNumber',
-      },
-      {
         action: 'changeQuantity',
         key: 'quantityOnStock',
         actionKey: 'quantity',
@@ -114,6 +110,55 @@ describe('Common actions', () => {
             key: '',
           },
         ])
+      })
+    })
+    describe('`shouldUnsetOmittedProperties`', () => {
+      test('if true => should generate unset actions for omitted properties', () => {
+        before = {
+          name: { en: 'Foo' },
+          description: 'description',
+          externalId: '123',
+          slug: { en: 'foo' },
+          customerNumber: 'customer-number',
+          quantityOnStock: 1,
+        }
+        now = {}
+        actions = buildBaseAttributesActions({
+          actions: testActions,
+          diff: diffpatcher.diff(before, now),
+          oldObj: before,
+          newObj: now,
+          shouldOmitEmptyString: false,
+          shouldUnsetOmittedProperties: true,
+        })
+        expect(actions).toEqual([
+          { action: 'changeName' },
+          { action: 'setDescription' },
+          { action: 'setExternalId' },
+          { action: 'changeSlug' },
+          { action: 'setCustomerNumber' },
+          { action: 'changeQuantity' },
+        ])
+      })
+      test('if false => should not generate unset actions for omitted properties', () => {
+        before = {
+          name: { en: 'Foo' },
+          description: 'description',
+          externalId: '123',
+          slug: { en: 'foo' },
+          customerNumber: 'customer-number',
+          quantityOnStock: 1,
+        }
+        now = {}
+        actions = buildBaseAttributesActions({
+          actions: testActions,
+          diff: diffpatcher.diff(before, now),
+          oldObj: before,
+          newObj: now,
+          shouldOmitEmptyString: false,
+          shouldUnsetOmittedProperties: false,
+        })
+        expect(actions).toEqual([])
       })
     })
   })

--- a/types/sdk.js
+++ b/types/sdk.js
@@ -435,6 +435,7 @@ export type SyncAction = {
 }
 export type SyncActionConfig = {
   shouldOmitEmptyString: boolean,
+  shouldUnsetOmittedProperties: boolean,
 }
 export type ActionGroup = {
   type: string,

--- a/types/sdk.js
+++ b/types/sdk.js
@@ -436,6 +436,7 @@ export type SyncAction = {
 export type SyncActionConfig = {
   shouldOmitEmptyString: boolean,
   shouldUnsetOmittedProperties: boolean,
+  shouldPreventUnsettingRequiredFields: boolean
 }
 export type ActionGroup = {
   type: string,


### PR DESCRIPTION
#### Summary

The import-api is committed to unset properties of a resource if the supplied request omits the specified keys.

The sync-actions currently only generate unset actions if the supplied key is present but null. This PR introduces two flags, that controls this behaviour. The default behaviour is kept the same, if this flags are not supplied.

More information can be found in the respective [SUPPORT ticket](https://commercetools.atlassian.net/browse/SUPPORT-30603?focusedCommentId=888857)

Upon approval, I will run a changeset command and include it in this PR.

#### Description

##### shouldUnsetOmittedProperties

This flag controls, wether an omitted property should lead to generating an updateAction:
 
This is how it is intended to work:

```typescript

describe('`shouldUnsetOmittedProperties`', () => {
      test('if true => should generate unset actions for omitted properties', () => {
        before = {
          name: { en: 'Foo' },
          description: 'description',
          externalId: '123',
          slug: { en: 'foo' },
          customerNumber: 'customer-number',
          quantityOnStock: 1,
        }
        now = {}
        actions = buildBaseAttributesActions({
          actions: testActions,
          diff: diffpatcher.diff(before, now),
          oldObj: before,
          newObj: now,
          shouldOmitEmptyString: false,
          shouldUnsetOmittedProperties: true,
        })
        expect(actions).toEqual([
          { action: 'changeName' },
          { action: 'setDescription' },
          { action: 'setExternalId' },
          { action: 'changeSlug' },
          { action: 'setCustomerNumber' },
          { action: 'changeQuantity' },
        ])
      })
      test('if false => should not generate unset actions for omitted properties', () => {
        before = {
          name: { en: 'Foo' },
          description: 'description',
          externalId: '123',
          slug: { en: 'foo' },
          customerNumber: 'customer-number',
          quantityOnStock: 1,
        }
        now = {}
        actions = buildBaseAttributesActions({
          actions: testActions,
          diff: diffpatcher.diff(before, now),
          oldObj: before,
          newObj: now,
          shouldOmitEmptyString: false,
          shouldUnsetOmittedProperties: false,
        })
        expect(actions).toEqual([])
      })
    })
```
##### shouldPreventUnsettingRequiredFields

This flag controls, wether required fields should be unset.

The convention in update actions, according to my research through the doc, is, that update actions that start with `set...` are allowed to unset. 
 
This is how it is intended to work:

```typescript

describe('`shouldPreventUnsettingRequiredFields`', () => {
      test('if true => should not generate unset actions for required fields', () => {
        before = {
          name: { en: 'Foo' },
          description: 'description',
          externalId: '123',
          slug: { en: 'foo' },
          customerNumber: 'customer-number',
          quantityOnStock: 1,
        }
        now = {
          name: null,
          description: null,
          externalId: null,
          slug: null,
          customerNumber: null,
          quantityOnStock: null,
        }
        actions = buildBaseAttributesActions({
          actions: testActions,
          diff: diffpatcher.diff(before, now),
          oldObj: before,
          newObj: now,
          shouldPreventUnsettingRequiredFields: true,
        })
        expect(actions).toEqual([
          { action: 'setDescription' },
          { action: 'setExternalId' },
          { action: 'setCustomerNumber' },
        ])
      })
      test('if false => should generate unset actions for required fields', () => {
        before = {
          name: { en: 'Foo' },
          description: 'description',
          externalId: '123',
          slug: { en: 'foo' },
          customerNumber: 'customer-number',
          quantityOnStock: 1,
        }
        now = {
          name: null,
          description: null,
          externalId: null,
          slug: null,
          customerNumber: null,
          quantityOnStock: null,
        }
        actions = buildBaseAttributesActions({
          actions: testActions,
          diff: diffpatcher.diff(before, now),
          oldObj: before,
          newObj: now,
          shouldPreventUnsettingRequiredFields: false,
        })
        expect(actions).toEqual([
          { action: 'changeName' },
          { action: 'setDescription' },
          { action: 'setExternalId' },
          { action: 'changeSlug' },
          { action: 'setCustomerNumber' },
          { action: 'changeQuantity' },
        ])
      })
    })
  })
```
#### Todo

- Tests
  - [ ] Unit
  - [ ] Integration
  - [ ] Acceptance
- [ ] Documentation
- [ ] `Type` label for the PR <!-- Used to automatically generate the changelog -->
  <!-- Two persons should review a PR, don't forget to assign them. -->
  <!-- Please remember to squash merge. -->
  <!-- All contribution guidelines can be found here: https://github.com/commercetools/nodejs/blob/master/CONTRIBUTING.md -->
