### PR TITLE
docs: add deprecation notice to legacy sdks

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,9 @@ We'd love to have your helping hand on this ecosystem! Please see [CONTRIBUTING.
 
 ### SDK
 
+> [!WARNING]  
+> These packages have been replaced by the [TypeScript SDK](https://docs.commercetools.com/sdk/typescript-sdk) is in maintenance mode as such this tool will no longer receive bug fixes, security patches, or new features.
+
 | Package                                                            | Version                                                                                                   | Dependencies                                                                                                                            |
 | ------------------------------------------------------------------ | --------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------- |
 | [`sdk-auth`](/packages/sdk-auth)                                   | [![sdk-auth Version][sdk-auth-icon]][sdk-auth-version]                                                    | [![sdk-auth Dependencies Status][sdk-auth-dependencies-icon]][sdk-auth-dependencies]                                                    |

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ We'd love to have your helping hand on this ecosystem! Please see [CONTRIBUTING.
 ### SDK
 
 > [!WARNING]  
-> These packages have been replaced by the [TypeScript SDK](https://docs.commercetools.com/sdk/typescript-sdk) is in maintenance mode as such this tool will no longer receive bug fixes, security patches, or new features.
+> These packages have been replaced by the <a href="https://docs.commercetools.com/sdk/typescript-sdk">TypeScript SDK</a> is in maintenance mode as such this tool will no longer receive bug fixes, security patches, or new features.
 
 | Package                                                            | Version                                                                                                   | Dependencies                                                                                                                            |
 | ------------------------------------------------------------------ | --------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------- |

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ We'd love to have your helping hand on this ecosystem! Please see [CONTRIBUTING.
 ### SDK
 
 > [!WARNING]  
-> These packages have been replaced by the <a href="https://docs.commercetools.com/sdk/typescript-sdk">TypeScript SDK</a> is in maintenance mode as such this tool will no longer receive bug fixes, security patches, or new features.
+> These packages have been replaced by the [TypeScript SDK](https://docs.commercetools.com/sdk/typescript-sdk) is in maintenance mode as such this tool will no longer receive new features or bug fixes.
 
 | Package                                                            | Version                                                                                                   | Dependencies                                                                                                                            |
 | ------------------------------------------------------------------ | --------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------- |

--- a/docs/sdk/api/getCredentials.md
+++ b/docs/sdk/api/getCredentials.md
@@ -4,7 +4,7 @@ Retrieve commercetools project credentials from environment variables or file sy
 
 ## ⚠️ In maintenance mode ⚠️
 
-This package has been replaced by the <a href="https://docs.commercetools.com/sdk/typescript-sdk">TypeScript SDK</a> is in maintenance mode as such this tool will no longer receive bug fixes, security patches, or new features.
+This package has been replaced by the <a href="https://docs.commercetools.com/sdk/typescript-sdk">TypeScript SDK</a> is in maintenance mode as such this tool will no longer receive new features or bug fixes.
 
 We recommend to use the <a href="https://docs.commercetools.com/sdk/typescript-sdk">TypeScript SDK</a> for any new implementation and plan migrating to it.
 

--- a/docs/sdk/api/getCredentials.md
+++ b/docs/sdk/api/getCredentials.md
@@ -2,6 +2,12 @@
 
 Retrieve commercetools project credentials from environment variables or file system.
 
+## ⚠️ In maintenance mode ⚠️
+
+This package has been replaced by the [TypeScript SDK](https://docs.commercetools.com/sdk/typescript-sdk) is in maintenance mode as such this tool will no longer receive bug fixes, security patches, or new features.
+
+We recommend to use the [TypeScript SDK](https://docs.commercetools.com/sdk/typescript-sdk) for any new implementation and plan migrating to it.
+
 ## Install
 
 ```bash

--- a/docs/sdk/api/getCredentials.md
+++ b/docs/sdk/api/getCredentials.md
@@ -2,7 +2,7 @@
 
 Retrieve commercetools project credentials from environment variables or file system.
 
-## ⚠️ In maintenance mode ⚠️
+## ⚠️ In Maintenance Mode ⚠️
 
 This package has been replaced by the <a href="https://docs.commercetools.com/sdk/typescript-sdk">TypeScript SDK</a> is in maintenance mode as such this tool will no longer receive new features or bug fixes.
 

--- a/docs/sdk/api/getCredentials.md
+++ b/docs/sdk/api/getCredentials.md
@@ -4,9 +4,9 @@ Retrieve commercetools project credentials from environment variables or file sy
 
 ## ⚠️ In maintenance mode ⚠️
 
-This package has been replaced by the [TypeScript SDK](https://docs.commercetools.com/sdk/typescript-sdk) is in maintenance mode as such this tool will no longer receive bug fixes, security patches, or new features.
+This package has been replaced by the <a href="https://docs.commercetools.com/sdk/typescript-sdk">TypeScript SDK</a> is in maintenance mode as such this tool will no longer receive bug fixes, security patches, or new features.
 
-We recommend to use the [TypeScript SDK](https://docs.commercetools.com/sdk/typescript-sdk) for any new implementation and plan migrating to it.
+We recommend to use the <a href="https://docs.commercetools.com/sdk/typescript-sdk">TypeScript SDK</a> for any new implementation and plan migrating to it.
 
 ## Install
 

--- a/docs/sdk/api/httpUserAgent.md
+++ b/docs/sdk/api/httpUserAgent.md
@@ -2,7 +2,7 @@
 
 Creates a proper HTTP User-Agent. Can be used everywhere.
 
-## ⚠️ In maintenance mode ⚠️
+## ⚠️ In Maintenance Mode ⚠️
 
 This package has been replaced by the <a href="https://docs.commercetools.com/sdk/typescript-sdk">TypeScript SDK</a> is in maintenance mode as such this tool will no longer receive new features or bug fixes.
 

--- a/docs/sdk/api/httpUserAgent.md
+++ b/docs/sdk/api/httpUserAgent.md
@@ -4,9 +4,9 @@ Creates a proper HTTP User-Agent. Can be used everywhere.
 
 ## ⚠️ In maintenance mode ⚠️
 
-This package has been replaced by the [TypeScript SDK](https://docs.commercetools.com/sdk/typescript-sdk) is in maintenance mode as such this tool will no longer receive bug fixes, security patches, or new features.
+This package has been replaced by the <a href="https://docs.commercetools.com/sdk/typescript-sdk">TypeScript SDK</a> is in maintenance mode as such this tool will no longer receive bug fixes, security patches, or new features.
 
-We recommend to use the [TypeScript SDK](https://docs.commercetools.com/sdk/typescript-sdk) for any new implementation and plan migrating to it.
+We recommend to use the <a href="https://docs.commercetools.com/sdk/typescript-sdk">TypeScript SDK</a> for any new implementation and plan migrating to it.
 
 ## Install
 

--- a/docs/sdk/api/httpUserAgent.md
+++ b/docs/sdk/api/httpUserAgent.md
@@ -2,6 +2,12 @@
 
 Creates a proper HTTP User-Agent. Can be used everywhere.
 
+## ⚠️ In maintenance mode ⚠️
+
+This package has been replaced by the [TypeScript SDK](https://docs.commercetools.com/sdk/typescript-sdk) is in maintenance mode as such this tool will no longer receive bug fixes, security patches, or new features.
+
+We recommend to use the [TypeScript SDK](https://docs.commercetools.com/sdk/typescript-sdk) for any new implementation and plan migrating to it.
+
 ## Install
 
 #### Node.js

--- a/docs/sdk/api/httpUserAgent.md
+++ b/docs/sdk/api/httpUserAgent.md
@@ -4,7 +4,7 @@ Creates a proper HTTP User-Agent. Can be used everywhere.
 
 ## ⚠️ In maintenance mode ⚠️
 
-This package has been replaced by the <a href="https://docs.commercetools.com/sdk/typescript-sdk">TypeScript SDK</a> is in maintenance mode as such this tool will no longer receive bug fixes, security patches, or new features.
+This package has been replaced by the <a href="https://docs.commercetools.com/sdk/typescript-sdk">TypeScript SDK</a> is in maintenance mode as such this tool will no longer receive new features or bug fixes.
 
 We recommend to use the <a href="https://docs.commercetools.com/sdk/typescript-sdk">TypeScript SDK</a> for any new implementation and plan migrating to it.
 

--- a/docs/sdk/api/sdkAuth.md
+++ b/docs/sdk/api/sdkAuth.md
@@ -2,7 +2,7 @@
 
 Auth module for different [authorization flows](https://docs.commercetools.com/api/authorization) of commercetools platform API
 
-## ⚠️ In maintenance mode ⚠️
+## ⚠️ In Maintenance Mode ⚠️
 
 This package has been replaced by the <a href="https://docs.commercetools.com/sdk/typescript-sdk">TypeScript SDK</a> is in maintenance mode as such this tool will no longer receive new features or bug fixes.
 

--- a/docs/sdk/api/sdkAuth.md
+++ b/docs/sdk/api/sdkAuth.md
@@ -4,7 +4,7 @@ Auth module for different [authorization flows](https://docs.commercetools.com/a
 
 ## ⚠️ In maintenance mode ⚠️
 
-This package has been replaced by the <a href="https://docs.commercetools.com/sdk/typescript-sdk">TypeScript SDK</a> is in maintenance mode as such this tool will no longer receive bug fixes, security patches, or new features.
+This package has been replaced by the <a href="https://docs.commercetools.com/sdk/typescript-sdk">TypeScript SDK</a> is in maintenance mode as such this tool will no longer receive new features or bug fixes.
 
 We recommend to use the <a href="https://docs.commercetools.com/sdk/typescript-sdk">TypeScript SDK</a> for any new implementation and plan migrating to it.
 

--- a/docs/sdk/api/sdkAuth.md
+++ b/docs/sdk/api/sdkAuth.md
@@ -2,6 +2,12 @@
 
 Auth module for different [authorization flows](https://docs.commercetools.com/api/authorization) of commercetools platform API
 
+## ⚠️ In maintenance mode ⚠️
+
+This package has been replaced by the [TypeScript SDK](https://docs.commercetools.com/sdk/typescript-sdk) is in maintenance mode as such this tool will no longer receive bug fixes, security patches, or new features.
+
+We recommend to use the [TypeScript SDK](https://docs.commercetools.com/sdk/typescript-sdk) for any new implementation and plan migrating to it.
+
 ## Install
 
 #### Node.js

--- a/docs/sdk/api/sdkAuth.md
+++ b/docs/sdk/api/sdkAuth.md
@@ -4,9 +4,9 @@ Auth module for different [authorization flows](https://docs.commercetools.com/a
 
 ## ⚠️ In maintenance mode ⚠️
 
-This package has been replaced by the [TypeScript SDK](https://docs.commercetools.com/sdk/typescript-sdk) is in maintenance mode as such this tool will no longer receive bug fixes, security patches, or new features.
+This package has been replaced by the <a href="https://docs.commercetools.com/sdk/typescript-sdk">TypeScript SDK</a> is in maintenance mode as such this tool will no longer receive bug fixes, security patches, or new features.
 
-We recommend to use the [TypeScript SDK](https://docs.commercetools.com/sdk/typescript-sdk) for any new implementation and plan migrating to it.
+We recommend to use the <a href="https://docs.commercetools.com/sdk/typescript-sdk">TypeScript SDK</a> for any new implementation and plan migrating to it.
 
 ## Install
 

--- a/docs/sdk/api/sdkClient.md
+++ b/docs/sdk/api/sdkClient.md
@@ -4,7 +4,7 @@ Core package to enable executing HTTP [request](/sdk/Glossary#clientrequest). To
 
 ## ⚠️ In maintenance mode ⚠️
 
-This package has been replaced by the <a href="https://docs.commercetools.com/sdk/typescript-sdk">TypeScript SDK</a> is in maintenance mode as such this tool will no longer receive bug fixes, security patches, or new features.
+This package has been replaced by the <a href="https://docs.commercetools.com/sdk/typescript-sdk">TypeScript SDK</a> is in maintenance mode as such this tool will no longer receive new features or bug fixes.
 
 We recommend to use the <a href="https://docs.commercetools.com/sdk/typescript-sdk">TypeScript SDK</a> for any new implementation and plan migrating to it.
 

--- a/docs/sdk/api/sdkClient.md
+++ b/docs/sdk/api/sdkClient.md
@@ -2,6 +2,12 @@
 
 Core package to enable executing HTTP [request](/sdk/Glossary#clientrequest). To be used together with middlewares.
 
+## ⚠️ In maintenance mode ⚠️
+
+This package has been replaced by the [TypeScript SDK](https://docs.commercetools.com/sdk/typescript-sdk) is in maintenance mode as such this tool will no longer receive bug fixes, security patches, or new features.
+
+We recommend to use the [TypeScript SDK](https://docs.commercetools.com/sdk/typescript-sdk) for any new implementation and plan migrating to it.
+
 ## Install
 
 #### Node.js

--- a/docs/sdk/api/sdkClient.md
+++ b/docs/sdk/api/sdkClient.md
@@ -2,7 +2,7 @@
 
 Core package to enable executing HTTP [request](/sdk/Glossary#clientrequest). To be used together with middlewares.
 
-## ⚠️ In maintenance mode ⚠️
+## ⚠️ In Maintenance Mode ⚠️
 
 This package has been replaced by the <a href="https://docs.commercetools.com/sdk/typescript-sdk">TypeScript SDK</a> is in maintenance mode as such this tool will no longer receive new features or bug fixes.
 

--- a/docs/sdk/api/sdkClient.md
+++ b/docs/sdk/api/sdkClient.md
@@ -4,9 +4,9 @@ Core package to enable executing HTTP [request](/sdk/Glossary#clientrequest). To
 
 ## ⚠️ In maintenance mode ⚠️
 
-This package has been replaced by the [TypeScript SDK](https://docs.commercetools.com/sdk/typescript-sdk) is in maintenance mode as such this tool will no longer receive bug fixes, security patches, or new features.
+This package has been replaced by the <a href="https://docs.commercetools.com/sdk/typescript-sdk">TypeScript SDK</a> is in maintenance mode as such this tool will no longer receive bug fixes, security patches, or new features.
 
-We recommend to use the [TypeScript SDK](https://docs.commercetools.com/sdk/typescript-sdk) for any new implementation and plan migrating to it.
+We recommend to use the <a href="https://docs.commercetools.com/sdk/typescript-sdk">TypeScript SDK</a> for any new implementation and plan migrating to it.
 
 ## Install
 

--- a/docs/sdk/api/sdkMiddlewareAuth.md
+++ b/docs/sdk/api/sdkMiddlewareAuth.md
@@ -2,6 +2,12 @@
 
 Middleware to authenticate the [request](/sdk/Glossary#clientrequest) using one of the supported _auth flows_.
 
+## ⚠️ In maintenance mode ⚠️
+
+This package has been replaced by the [TypeScript SDK](https://docs.commercetools.com/sdk/typescript-sdk) is in maintenance mode as such this tool will no longer receive bug fixes, security patches, or new features.
+
+We recommend to use the [TypeScript SDK](https://docs.commercetools.com/sdk/typescript-sdk) for any new implementation and plan migrating to it.
+
 ## Install
 
 #### Node.js

--- a/docs/sdk/api/sdkMiddlewareAuth.md
+++ b/docs/sdk/api/sdkMiddlewareAuth.md
@@ -4,7 +4,7 @@ Middleware to authenticate the [request](/sdk/Glossary#clientrequest) using one 
 
 ## ⚠️ In maintenance mode ⚠️
 
-This package has been replaced by the <a href="https://docs.commercetools.com/sdk/typescript-sdk">TypeScript SDK</a> is in maintenance mode as such this tool will no longer receive bug fixes, security patches, or new features.
+This package has been replaced by the <a href="https://docs.commercetools.com/sdk/typescript-sdk">TypeScript SDK</a> is in maintenance mode as such this tool will no longer receive new features or bug fixes.
 
 We recommend to use the <a href="https://docs.commercetools.com/sdk/typescript-sdk">TypeScript SDK</a> for any new implementation and plan migrating to it.
 

--- a/docs/sdk/api/sdkMiddlewareAuth.md
+++ b/docs/sdk/api/sdkMiddlewareAuth.md
@@ -2,7 +2,7 @@
 
 Middleware to authenticate the [request](/sdk/Glossary#clientrequest) using one of the supported _auth flows_.
 
-## ⚠️ In maintenance mode ⚠️
+## ⚠️ In Maintenance Mode ⚠️
 
 This package has been replaced by the <a href="https://docs.commercetools.com/sdk/typescript-sdk">TypeScript SDK</a> is in maintenance mode as such this tool will no longer receive new features or bug fixes.
 

--- a/docs/sdk/api/sdkMiddlewareAuth.md
+++ b/docs/sdk/api/sdkMiddlewareAuth.md
@@ -4,9 +4,9 @@ Middleware to authenticate the [request](/sdk/Glossary#clientrequest) using one 
 
 ## ⚠️ In maintenance mode ⚠️
 
-This package has been replaced by the [TypeScript SDK](https://docs.commercetools.com/sdk/typescript-sdk) is in maintenance mode as such this tool will no longer receive bug fixes, security patches, or new features.
+This package has been replaced by the <a href="https://docs.commercetools.com/sdk/typescript-sdk">TypeScript SDK</a> is in maintenance mode as such this tool will no longer receive bug fixes, security patches, or new features.
 
-We recommend to use the [TypeScript SDK](https://docs.commercetools.com/sdk/typescript-sdk) for any new implementation and plan migrating to it.
+We recommend to use the <a href="https://docs.commercetools.com/sdk/typescript-sdk">TypeScript SDK</a> for any new implementation and plan migrating to it.
 
 ## Install
 

--- a/docs/sdk/api/sdkMiddlewareCorrelationId.md
+++ b/docs/sdk/api/sdkMiddlewareCorrelationId.md
@@ -4,9 +4,9 @@ Middleware add a correlation id to [requests](/sdk/Glossary#clientrequest).
 
 ## ⚠️ In maintenance mode ⚠️
 
-This package has been replaced by the [TypeScript SDK](https://docs.commercetools.com/sdk/typescript-sdk) is in maintenance mode as such this tool will no longer receive bug fixes, security patches, or new features.
+This package has been replaced by the <a href="https://docs.commercetools.com/sdk/typescript-sdk">TypeScript SDK</a> is in maintenance mode as such this tool will no longer receive bug fixes, security patches, or new features.
 
-We recommend to use the [TypeScript SDK](https://docs.commercetools.com/sdk/typescript-sdk) for any new implementation and plan migrating to it.
+We recommend to use the <a href="https://docs.commercetools.com/sdk/typescript-sdk">TypeScript SDK</a> for any new implementation and plan migrating to it.
 
 ## Install
 

--- a/docs/sdk/api/sdkMiddlewareCorrelationId.md
+++ b/docs/sdk/api/sdkMiddlewareCorrelationId.md
@@ -2,7 +2,7 @@
 
 Middleware add a correlation id to [requests](/sdk/Glossary#clientrequest).
 
-## ⚠️ In maintenance mode ⚠️
+## ⚠️ In Maintenance Mode ⚠️
 
 This package has been replaced by the <a href="https://docs.commercetools.com/sdk/typescript-sdk">TypeScript SDK</a> is in maintenance mode as such this tool will no longer receive new features or bug fixes.
 

--- a/docs/sdk/api/sdkMiddlewareCorrelationId.md
+++ b/docs/sdk/api/sdkMiddlewareCorrelationId.md
@@ -4,7 +4,7 @@ Middleware add a correlation id to [requests](/sdk/Glossary#clientrequest).
 
 ## ⚠️ In maintenance mode ⚠️
 
-This package has been replaced by the <a href="https://docs.commercetools.com/sdk/typescript-sdk">TypeScript SDK</a> is in maintenance mode as such this tool will no longer receive bug fixes, security patches, or new features.
+This package has been replaced by the <a href="https://docs.commercetools.com/sdk/typescript-sdk">TypeScript SDK</a> is in maintenance mode as such this tool will no longer receive new features or bug fixes.
 
 We recommend to use the <a href="https://docs.commercetools.com/sdk/typescript-sdk">TypeScript SDK</a> for any new implementation and plan migrating to it.
 

--- a/docs/sdk/api/sdkMiddlewareCorrelationId.md
+++ b/docs/sdk/api/sdkMiddlewareCorrelationId.md
@@ -2,6 +2,12 @@
 
 Middleware add a correlation id to [requests](/sdk/Glossary#clientrequest).
 
+## ⚠️ In maintenance mode ⚠️
+
+This package has been replaced by the [TypeScript SDK](https://docs.commercetools.com/sdk/typescript-sdk) is in maintenance mode as such this tool will no longer receive bug fixes, security patches, or new features.
+
+We recommend to use the [TypeScript SDK](https://docs.commercetools.com/sdk/typescript-sdk) for any new implementation and plan migrating to it.
+
 ## Install
 
 #### Node.js

--- a/docs/sdk/api/sdkMiddlewareHttp.md
+++ b/docs/sdk/api/sdkMiddlewareHttp.md
@@ -4,9 +4,9 @@ Middleware to send the actual HTTP [request](/sdk/Glossary#clientrequest).
 
 ## ⚠️ In maintenance mode ⚠️
 
-This package has been replaced by the [TypeScript SDK](https://docs.commercetools.com/sdk/typescript-sdk) is in maintenance mode as such this tool will no longer receive bug fixes, security patches, or new features.
+This package has been replaced by the <a href="https://docs.commercetools.com/sdk/typescript-sdk">TypeScript SDK</a> is in maintenance mode as such this tool will no longer receive bug fixes, security patches, or new features.
 
-We recommend to use the [TypeScript SDK](https://docs.commercetools.com/sdk/typescript-sdk) for any new implementation and plan migrating to it.
+We recommend to use the <a href="https://docs.commercetools.com/sdk/typescript-sdk">TypeScript SDK</a> for any new implementation and plan migrating to it.
 
 ## Install
 

--- a/docs/sdk/api/sdkMiddlewareHttp.md
+++ b/docs/sdk/api/sdkMiddlewareHttp.md
@@ -2,7 +2,7 @@
 
 Middleware to send the actual HTTP [request](/sdk/Glossary#clientrequest).
 
-## ⚠️ In maintenance mode ⚠️
+## ⚠️ In Maintenance Mode ⚠️
 
 This package has been replaced by the <a href="https://docs.commercetools.com/sdk/typescript-sdk">TypeScript SDK</a> is in maintenance mode as such this tool will no longer receive new features or bug fixes.
 

--- a/docs/sdk/api/sdkMiddlewareHttp.md
+++ b/docs/sdk/api/sdkMiddlewareHttp.md
@@ -4,7 +4,7 @@ Middleware to send the actual HTTP [request](/sdk/Glossary#clientrequest).
 
 ## ⚠️ In maintenance mode ⚠️
 
-This package has been replaced by the <a href="https://docs.commercetools.com/sdk/typescript-sdk">TypeScript SDK</a> is in maintenance mode as such this tool will no longer receive bug fixes, security patches, or new features.
+This package has been replaced by the <a href="https://docs.commercetools.com/sdk/typescript-sdk">TypeScript SDK</a> is in maintenance mode as such this tool will no longer receive new features or bug fixes.
 
 We recommend to use the <a href="https://docs.commercetools.com/sdk/typescript-sdk">TypeScript SDK</a> for any new implementation and plan migrating to it.
 

--- a/docs/sdk/api/sdkMiddlewareHttp.md
+++ b/docs/sdk/api/sdkMiddlewareHttp.md
@@ -2,6 +2,12 @@
 
 Middleware to send the actual HTTP [request](/sdk/Glossary#clientrequest).
 
+## ⚠️ In maintenance mode ⚠️
+
+This package has been replaced by the [TypeScript SDK](https://docs.commercetools.com/sdk/typescript-sdk) is in maintenance mode as such this tool will no longer receive bug fixes, security patches, or new features.
+
+We recommend to use the [TypeScript SDK](https://docs.commercetools.com/sdk/typescript-sdk) for any new implementation and plan migrating to it.
+
 ## Install
 
 #### Node.js

--- a/docs/sdk/api/sdkMiddlewareLogger.md
+++ b/docs/sdk/api/sdkMiddlewareLogger.md
@@ -2,7 +2,7 @@
 
 Middleware to log incoming [request](/sdk/Glossary#clientrequest) and [response](/sdk/Glossary#clientrequest) objects.
 
-## ⚠️ In maintenance mode ⚠️
+## ⚠️ In Maintenance Mode ⚠️
 
 This package has been replaced by the <a href="https://docs.commercetools.com/sdk/typescript-sdk">TypeScript SDK</a> is in maintenance mode as such this tool will no longer receive new features or bug fixes.
 

--- a/docs/sdk/api/sdkMiddlewareLogger.md
+++ b/docs/sdk/api/sdkMiddlewareLogger.md
@@ -4,9 +4,9 @@ Middleware to log incoming [request](/sdk/Glossary#clientrequest) and [response]
 
 ## ⚠️ In maintenance mode ⚠️
 
-This package has been replaced by the [TypeScript SDK](https://docs.commercetools.com/sdk/typescript-sdk) is in maintenance mode as such this tool will no longer receive bug fixes, security patches, or new features.
+This package has been replaced by the <a href="https://docs.commercetools.com/sdk/typescript-sdk">TypeScript SDK</a> is in maintenance mode as such this tool will no longer receive bug fixes, security patches, or new features.
 
-We recommend to use the [TypeScript SDK](https://docs.commercetools.com/sdk/typescript-sdk) for any new implementation and plan migrating to it.
+We recommend to use the <a href="https://docs.commercetools.com/sdk/typescript-sdk">TypeScript SDK</a> for any new implementation and plan migrating to it.
 
 ## Install
 

--- a/docs/sdk/api/sdkMiddlewareLogger.md
+++ b/docs/sdk/api/sdkMiddlewareLogger.md
@@ -4,7 +4,7 @@ Middleware to log incoming [request](/sdk/Glossary#clientrequest) and [response]
 
 ## ⚠️ In maintenance mode ⚠️
 
-This package has been replaced by the <a href="https://docs.commercetools.com/sdk/typescript-sdk">TypeScript SDK</a> is in maintenance mode as such this tool will no longer receive bug fixes, security patches, or new features.
+This package has been replaced by the <a href="https://docs.commercetools.com/sdk/typescript-sdk">TypeScript SDK</a> is in maintenance mode as such this tool will no longer receive new features or bug fixes.
 
 We recommend to use the <a href="https://docs.commercetools.com/sdk/typescript-sdk">TypeScript SDK</a> for any new implementation and plan migrating to it.
 

--- a/docs/sdk/api/sdkMiddlewareLogger.md
+++ b/docs/sdk/api/sdkMiddlewareLogger.md
@@ -2,6 +2,12 @@
 
 Middleware to log incoming [request](/sdk/Glossary#clientrequest) and [response](/sdk/Glossary#clientrequest) objects.
 
+## ⚠️ In maintenance mode ⚠️
+
+This package has been replaced by the [TypeScript SDK](https://docs.commercetools.com/sdk/typescript-sdk) is in maintenance mode as such this tool will no longer receive bug fixes, security patches, or new features.
+
+We recommend to use the [TypeScript SDK](https://docs.commercetools.com/sdk/typescript-sdk) for any new implementation and plan migrating to it.
+
 ## Install
 
 #### Node.js

--- a/docs/sdk/api/sdkMiddlewareQueue.md
+++ b/docs/sdk/api/sdkMiddlewareQueue.md
@@ -4,9 +4,9 @@ Middleware to throttle concurrent [request](/sdk/Glossary#clientrequest) to a ce
 
 ## ⚠️ In maintenance mode ⚠️
 
-This package has been replaced by the [TypeScript SDK](https://docs.commercetools.com/sdk/typescript-sdk) is in maintenance mode as such this tool will no longer receive bug fixes, security patches, or new features.
+This package has been replaced by the <a href="https://docs.commercetools.com/sdk/typescript-sdk">TypeScript SDK</a> is in maintenance mode as such this tool will no longer receive bug fixes, security patches, or new features.
 
-We recommend to use the [TypeScript SDK](https://docs.commercetools.com/sdk/typescript-sdk) for any new implementation and plan migrating to it.
+We recommend to use the <a href="https://docs.commercetools.com/sdk/typescript-sdk">TypeScript SDK</a> for any new implementation and plan migrating to it.
 
 ## Install
 

--- a/docs/sdk/api/sdkMiddlewareQueue.md
+++ b/docs/sdk/api/sdkMiddlewareQueue.md
@@ -2,6 +2,12 @@
 
 Middleware to throttle concurrent [request](/sdk/Glossary#clientrequest) to a certain limit. Useful to reduce concurrent HTTP requests.
 
+## ⚠️ In maintenance mode ⚠️
+
+This package has been replaced by the [TypeScript SDK](https://docs.commercetools.com/sdk/typescript-sdk) is in maintenance mode as such this tool will no longer receive bug fixes, security patches, or new features.
+
+We recommend to use the [TypeScript SDK](https://docs.commercetools.com/sdk/typescript-sdk) for any new implementation and plan migrating to it.
+
 ## Install
 
 #### Node.js

--- a/docs/sdk/api/sdkMiddlewareQueue.md
+++ b/docs/sdk/api/sdkMiddlewareQueue.md
@@ -4,7 +4,7 @@ Middleware to throttle concurrent [request](/sdk/Glossary#clientrequest) to a ce
 
 ## ⚠️ In maintenance mode ⚠️
 
-This package has been replaced by the <a href="https://docs.commercetools.com/sdk/typescript-sdk">TypeScript SDK</a> is in maintenance mode as such this tool will no longer receive bug fixes, security patches, or new features.
+This package has been replaced by the <a href="https://docs.commercetools.com/sdk/typescript-sdk">TypeScript SDK</a> is in maintenance mode as such this tool will no longer receive new features or bug fixes.
 
 We recommend to use the <a href="https://docs.commercetools.com/sdk/typescript-sdk">TypeScript SDK</a> for any new implementation and plan migrating to it.
 

--- a/docs/sdk/api/sdkMiddlewareQueue.md
+++ b/docs/sdk/api/sdkMiddlewareQueue.md
@@ -2,7 +2,7 @@
 
 Middleware to throttle concurrent [request](/sdk/Glossary#clientrequest) to a certain limit. Useful to reduce concurrent HTTP requests.
 
-## ⚠️ In maintenance mode ⚠️
+## ⚠️ In Maintenance Mode ⚠️
 
 This package has been replaced by the <a href="https://docs.commercetools.com/sdk/typescript-sdk">TypeScript SDK</a> is in maintenance mode as such this tool will no longer receive new features or bug fixes.
 

--- a/docs/sdk/api/sdkMiddlewareUserAgent.md
+++ b/docs/sdk/api/sdkMiddlewareUserAgent.md
@@ -2,6 +2,12 @@
 
 Middleware to automatically set the `User-Agent` to the [request](/sdk/Glossary#clientrequest).
 
+## ⚠️ In maintenance mode ⚠️
+
+This package has been replaced by the [TypeScript SDK](https://docs.commercetools.com/sdk/typescript-sdk) is in maintenance mode as such this tool will no longer receive bug fixes, security patches, or new features.
+
+We recommend to use the [TypeScript SDK](https://docs.commercetools.com/sdk/typescript-sdk) for any new implementation and plan migrating to it.
+
 ## Install
 
 #### Node.js

--- a/docs/sdk/api/sdkMiddlewareUserAgent.md
+++ b/docs/sdk/api/sdkMiddlewareUserAgent.md
@@ -4,7 +4,7 @@ Middleware to automatically set the `User-Agent` to the [request](/sdk/Glossary#
 
 ## ⚠️ In maintenance mode ⚠️
 
-This package has been replaced by the <a href="https://docs.commercetools.com/sdk/typescript-sdk">TypeScript SDK</a> is in maintenance mode as such this tool will no longer receive bug fixes, security patches, or new features.
+This package has been replaced by the <a href="https://docs.commercetools.com/sdk/typescript-sdk">TypeScript SDK</a> is in maintenance mode as such this tool will no longer receive new features or bug fixes.
 
 We recommend to use the <a href="https://docs.commercetools.com/sdk/typescript-sdk">TypeScript SDK</a> for any new implementation and plan migrating to it.
 

--- a/docs/sdk/api/sdkMiddlewareUserAgent.md
+++ b/docs/sdk/api/sdkMiddlewareUserAgent.md
@@ -4,9 +4,9 @@ Middleware to automatically set the `User-Agent` to the [request](/sdk/Glossary#
 
 ## ⚠️ In maintenance mode ⚠️
 
-This package has been replaced by the [TypeScript SDK](https://docs.commercetools.com/sdk/typescript-sdk) is in maintenance mode as such this tool will no longer receive bug fixes, security patches, or new features.
+This package has been replaced by the <a href="https://docs.commercetools.com/sdk/typescript-sdk">TypeScript SDK</a> is in maintenance mode as such this tool will no longer receive bug fixes, security patches, or new features.
 
-We recommend to use the [TypeScript SDK](https://docs.commercetools.com/sdk/typescript-sdk) for any new implementation and plan migrating to it.
+We recommend to use the <a href="https://docs.commercetools.com/sdk/typescript-sdk">TypeScript SDK</a> for any new implementation and plan migrating to it.
 
 ## Install
 

--- a/docs/sdk/api/sdkMiddlewareUserAgent.md
+++ b/docs/sdk/api/sdkMiddlewareUserAgent.md
@@ -2,7 +2,7 @@
 
 Middleware to automatically set the `User-Agent` to the [request](/sdk/Glossary#clientrequest).
 
-## ⚠️ In maintenance mode ⚠️
+## ⚠️ In Maintenance Mode ⚠️
 
 This package has been replaced by the <a href="https://docs.commercetools.com/sdk/typescript-sdk">TypeScript SDK</a> is in maintenance mode as such this tool will no longer receive new features or bug fixes.
 

--- a/packages/get-credentials/readme.md
+++ b/packages/get-credentials/readme.md
@@ -3,10 +3,10 @@
 <div style="background-color: yellow; color: black; padding: 10px; text-align: center; font-weight: bold;">
   <h2>⚠️ In maintenance mode  ⚠️</h2>
   <p>
-    This package has been replaced by the [TypeScript SDK](https://docs.commercetools.com/sdk/typescript-sdk) is in maintenance mode as such this tool will no longer receive bug fixes, security patches, or new features.
+    This package has been replaced by the <a href="https://docs.commercetools.com/sdk/typescript-sdk">TypeScript SDK</a> is in maintenance mode as such this tool will no longer receive bug fixes, security patches, or new features.
   </p>
   <p>
-    We recommend to use the [TypeScript SDK](https://docs.commercetools.com/sdk/typescript-sdk) for any new implementation and plan migrating to it.
+    We recommend to use the <a href="https://docs.commercetools.com/sdk/typescript-sdk">TypeScript SDK</a> for any new implementation and plan migrating to it.
   </p>
 </div>
 

--- a/packages/get-credentials/readme.md
+++ b/packages/get-credentials/readme.md
@@ -1,7 +1,7 @@
 # get-credentials
 
 <div style="background-color: yellow; color: black; padding: 10px; text-align: center; font-weight: bold;">
-  <h2>⚠️ In maintenance mode  ⚠️</h2>
+  <h2>⚠️ In Maintenance Mode ⚠️</h2>
   <p>
     This package has been replaced by the <a href="https://docs.commercetools.com/sdk/typescript-sdk">TypeScript SDK</a> is in maintenance mode as such this tool will no longer receive new features or bug fixes.
   </p>

--- a/packages/get-credentials/readme.md
+++ b/packages/get-credentials/readme.md
@@ -3,7 +3,7 @@
 <div style="background-color: yellow; color: black; padding: 10px; text-align: center; font-weight: bold;">
   <h2>⚠️ In maintenance mode  ⚠️</h2>
   <p>
-    This package has been replaced by the <a href="https://docs.commercetools.com/sdk/typescript-sdk">TypeScript SDK</a> is in maintenance mode as such this tool will no longer receive bug fixes, security patches, or new features.
+    This package has been replaced by the <a href="https://docs.commercetools.com/sdk/typescript-sdk">TypeScript SDK</a> is in maintenance mode as such this tool will no longer receive new features or bug fixes.
   </p>
   <p>
     We recommend to use the <a href="https://docs.commercetools.com/sdk/typescript-sdk">TypeScript SDK</a> for any new implementation and plan migrating to it.

--- a/packages/get-credentials/readme.md
+++ b/packages/get-credentials/readme.md
@@ -1,5 +1,15 @@
 # get-credentials
 
+<div style="background-color: yellow; color: black; padding: 10px; text-align: center; font-weight: bold;">
+  <h2>⚠️ In maintenance mode  ⚠️</h2>
+  <p>
+    This package has been replaced by the [TypeScript SDK](https://docs.commercetools.com/sdk/typescript-sdk) is in maintenance mode as such this tool will no longer receive bug fixes, security patches, or new features.
+  </p>
+  <p>
+    We recommend to use the [TypeScript SDK](https://docs.commercetools.com/sdk/typescript-sdk) for any new implementation and plan migrating to it.
+  </p>
+</div>
+
 Retrieve commercetools platform credentials from environment variables or file system.
 
 https://commercetools.github.io/nodejs/sdk/api/getCredentials.html

--- a/packages/http-user-agent/README.md
+++ b/packages/http-user-agent/README.md
@@ -1,7 +1,7 @@
 # commercetools-http-user-agent
 
 <div style="background-color: yellow; color: black; padding: 10px; text-align: center; font-weight: bold;">
-  <h2>⚠️ In maintenance mode  ⚠️</h2>
+  <h2>⚠️ In Maintenance Mode ⚠️</h2>
   <p>
     This package has been replaced by the <a href="https://docs.commercetools.com/sdk/typescript-sdk">TypeScript SDK</a> is in maintenance mode as such this tool will no longer receive new features or bug fixes.
   </p>

--- a/packages/http-user-agent/README.md
+++ b/packages/http-user-agent/README.md
@@ -3,10 +3,10 @@
 <div style="background-color: yellow; color: black; padding: 10px; text-align: center; font-weight: bold;">
   <h2>⚠️ In maintenance mode  ⚠️</h2>
   <p>
-    This package has been replaced by the [TypeScript SDK](https://docs.commercetools.com/sdk/typescript-sdk) is in maintenance mode as such this tool will no longer receive bug fixes, security patches, or new features.
+    This package has been replaced by the <a href="https://docs.commercetools.com/sdk/typescript-sdk">TypeScript SDK</a> is in maintenance mode as such this tool will no longer receive bug fixes, security patches, or new features.
   </p>
   <p>
-    We recommend to use the [TypeScript SDK](https://docs.commercetools.com/sdk/typescript-sdk) for any new implementation and plan migrating to it.
+    We recommend to use the <a href="https://docs.commercetools.com/sdk/typescript-sdk">TypeScript SDK</a> for any new implementation and plan migrating to it.
   </p>
 </div>
 

--- a/packages/http-user-agent/README.md
+++ b/packages/http-user-agent/README.md
@@ -1,5 +1,15 @@
 # commercetools-http-user-agent
 
+<div style="background-color: yellow; color: black; padding: 10px; text-align: center; font-weight: bold;">
+  <h2>⚠️ In maintenance mode  ⚠️</h2>
+  <p>
+    This package has been replaced by the [TypeScript SDK](https://docs.commercetools.com/sdk/typescript-sdk) is in maintenance mode as such this tool will no longer receive bug fixes, security patches, or new features.
+  </p>
+  <p>
+    We recommend to use the [TypeScript SDK](https://docs.commercetools.com/sdk/typescript-sdk) for any new implementation and plan migrating to it.
+  </p>
+</div>
+
 Creates a proper HTTP User-Agent
 
 https://commercetools.github.io/nodejs/sdk/api/httpUserAgent.html

--- a/packages/http-user-agent/README.md
+++ b/packages/http-user-agent/README.md
@@ -3,7 +3,7 @@
 <div style="background-color: yellow; color: black; padding: 10px; text-align: center; font-weight: bold;">
   <h2>⚠️ In maintenance mode  ⚠️</h2>
   <p>
-    This package has been replaced by the <a href="https://docs.commercetools.com/sdk/typescript-sdk">TypeScript SDK</a> is in maintenance mode as such this tool will no longer receive bug fixes, security patches, or new features.
+    This package has been replaced by the <a href="https://docs.commercetools.com/sdk/typescript-sdk">TypeScript SDK</a> is in maintenance mode as such this tool will no longer receive new features or bug fixes.
   </p>
   <p>
     We recommend to use the <a href="https://docs.commercetools.com/sdk/typescript-sdk">TypeScript SDK</a> for any new implementation and plan migrating to it.

--- a/packages/sdk-auth/README.md
+++ b/packages/sdk-auth/README.md
@@ -3,10 +3,10 @@
 <div style="background-color: yellow; color: black; padding: 10px; text-align: center; font-weight: bold;">
   <h2>⚠️ In maintenance mode  ⚠️</h2>
   <p>
-    This package has been replaced by the [TypeScript SDK](https://docs.commercetools.com/sdk/typescript-sdk) is in maintenance mode as such this tool will no longer receive bug fixes, security patches, or new features.
+    This package has been replaced by the <a href="https://docs.commercetools.com/sdk/typescript-sdk">TypeScript SDK</a> is in maintenance mode as such this tool will no longer receive bug fixes, security patches, or new features.
   </p>
   <p>
-    We recommend to use the [TypeScript SDK](https://docs.commercetools.com/sdk/typescript-sdk) for any new implementation and plan migrating to it.
+    We recommend to use the <a href="https://docs.commercetools.com/sdk/typescript-sdk">TypeScript SDK</a> for any new implementation and plan migrating to it.
   </p>
 </div>
 

--- a/packages/sdk-auth/README.md
+++ b/packages/sdk-auth/README.md
@@ -3,7 +3,7 @@
 <div style="background-color: yellow; color: black; padding: 10px; text-align: center; font-weight: bold;">
   <h2>⚠️ In maintenance mode  ⚠️</h2>
   <p>
-    This package has been replaced by the <a href="https://docs.commercetools.com/sdk/typescript-sdk">TypeScript SDK</a> is in maintenance mode as such this tool will no longer receive bug fixes, security patches, or new features.
+    This package has been replaced by the <a href="https://docs.commercetools.com/sdk/typescript-sdk">TypeScript SDK</a> is in maintenance mode as such this tool will no longer receive new features or bug fixes.
   </p>
   <p>
     We recommend to use the <a href="https://docs.commercetools.com/sdk/typescript-sdk">TypeScript SDK</a> for any new implementation and plan migrating to it.

--- a/packages/sdk-auth/README.md
+++ b/packages/sdk-auth/README.md
@@ -1,5 +1,15 @@
 # commercetools-sdk-auth
 
+<div style="background-color: yellow; color: black; padding: 10px; text-align: center; font-weight: bold;">
+  <h2>⚠️ In maintenance mode  ⚠️</h2>
+  <p>
+    This package has been replaced by the [TypeScript SDK](https://docs.commercetools.com/sdk/typescript-sdk) is in maintenance mode as such this tool will no longer receive bug fixes, security patches, or new features.
+  </p>
+  <p>
+    We recommend to use the [TypeScript SDK](https://docs.commercetools.com/sdk/typescript-sdk) for any new implementation and plan migrating to it.
+  </p>
+</div>
+
 Auth module for working with commercetools platform API
 
 https://commercetools.github.io/nodejs/sdk/api/sdkAuth.html

--- a/packages/sdk-auth/README.md
+++ b/packages/sdk-auth/README.md
@@ -1,7 +1,7 @@
 # commercetools-sdk-auth
 
 <div style="background-color: yellow; color: black; padding: 10px; text-align: center; font-weight: bold;">
-  <h2>⚠️ In maintenance mode  ⚠️</h2>
+  <h2>⚠️ In Maintenance Mode ⚠️</h2>
   <p>
     This package has been replaced by the <a href="https://docs.commercetools.com/sdk/typescript-sdk">TypeScript SDK</a> is in maintenance mode as such this tool will no longer receive new features or bug fixes.
   </p>

--- a/packages/sdk-client/README.md
+++ b/packages/sdk-client/README.md
@@ -1,5 +1,15 @@
 # commercetools-sdk-client
 
+<div style="background-color: yellow; color: black; padding: 10px; text-align: center; font-weight: bold;">
+  <h2>⚠️ In maintenance mode  ⚠️</h2>
+  <p>
+    This package has been replaced by the [TypeScript SDK](https://docs.commercetools.com/sdk/typescript-sdk) is in maintenance mode as such this tool will no longer receive bug fixes, security patches, or new features.
+  </p>
+  <p>
+    We recommend to use the [TypeScript SDK](https://docs.commercetools.com/sdk/typescript-sdk) for any new implementation and plan migrating to it.
+  </p>
+</div>
+
 SDK Client for usage of commercetools platform API
 
 https://commercetools.github.io/nodejs/sdk/api/sdkClient.html

--- a/packages/sdk-client/README.md
+++ b/packages/sdk-client/README.md
@@ -3,10 +3,10 @@
 <div style="background-color: yellow; color: black; padding: 10px; text-align: center; font-weight: bold;">
   <h2>⚠️ In maintenance mode  ⚠️</h2>
   <p>
-    This package has been replaced by the [TypeScript SDK](https://docs.commercetools.com/sdk/typescript-sdk) is in maintenance mode as such this tool will no longer receive bug fixes, security patches, or new features.
+    This package has been replaced by the <a href="https://docs.commercetools.com/sdk/typescript-sdk">TypeScript SDK</a> is in maintenance mode as such this tool will no longer receive bug fixes, security patches, or new features.
   </p>
   <p>
-    We recommend to use the [TypeScript SDK](https://docs.commercetools.com/sdk/typescript-sdk) for any new implementation and plan migrating to it.
+    We recommend to use the <a href="https://docs.commercetools.com/sdk/typescript-sdk">TypeScript SDK</a> for any new implementation and plan migrating to it.
   </p>
 </div>
 

--- a/packages/sdk-client/README.md
+++ b/packages/sdk-client/README.md
@@ -3,7 +3,7 @@
 <div style="background-color: yellow; color: black; padding: 10px; text-align: center; font-weight: bold;">
   <h2>⚠️ In maintenance mode  ⚠️</h2>
   <p>
-    This package has been replaced by the <a href="https://docs.commercetools.com/sdk/typescript-sdk">TypeScript SDK</a> is in maintenance mode as such this tool will no longer receive bug fixes, security patches, or new features.
+    This package has been replaced by the <a href="https://docs.commercetools.com/sdk/typescript-sdk">TypeScript SDK</a> is in maintenance mode as such this tool will no longer receive new features or bug fixes.
   </p>
   <p>
     We recommend to use the <a href="https://docs.commercetools.com/sdk/typescript-sdk">TypeScript SDK</a> for any new implementation and plan migrating to it.

--- a/packages/sdk-client/README.md
+++ b/packages/sdk-client/README.md
@@ -1,7 +1,7 @@
 # commercetools-sdk-client
 
 <div style="background-color: yellow; color: black; padding: 10px; text-align: center; font-weight: bold;">
-  <h2>⚠️ In maintenance mode  ⚠️</h2>
+  <h2>⚠️ In Maintenance Mode ⚠️</h2>
   <p>
     This package has been replaced by the <a href="https://docs.commercetools.com/sdk/typescript-sdk">TypeScript SDK</a> is in maintenance mode as such this tool will no longer receive new features or bug fixes.
   </p>

--- a/packages/sdk-middleware-auth/README.md
+++ b/packages/sdk-middleware-auth/README.md
@@ -1,5 +1,15 @@
 # commercetools-sdk-middlware-auth
 
+<div style="background-color: yellow; color: black; padding: 10px; text-align: center; font-weight: bold;">
+  <h2>⚠️ In maintenance mode  ⚠️</h2>
+  <p>
+    This package has been replaced by the [TypeScript SDK](https://docs.commercetools.com/sdk/typescript-sdk) is in maintenance mode as such this tool will no longer receive bug fixes, security patches, or new features.
+  </p>
+  <p>
+    We recommend to use the [TypeScript SDK](https://docs.commercetools.com/sdk/typescript-sdk) for any new implementation and plan migrating to it.
+  </p>
+</div>
+
 Auth middlewares collection for usage with `@commercetools/sdk-client`
 
 https://commercetools.github.io/nodejs/sdk/api/sdkMiddlewareAuth.html

--- a/packages/sdk-middleware-auth/README.md
+++ b/packages/sdk-middleware-auth/README.md
@@ -3,10 +3,10 @@
 <div style="background-color: yellow; color: black; padding: 10px; text-align: center; font-weight: bold;">
   <h2>⚠️ In maintenance mode  ⚠️</h2>
   <p>
-    This package has been replaced by the [TypeScript SDK](https://docs.commercetools.com/sdk/typescript-sdk) is in maintenance mode as such this tool will no longer receive bug fixes, security patches, or new features.
+    This package has been replaced by the <a href="https://docs.commercetools.com/sdk/typescript-sdk">TypeScript SDK</a> is in maintenance mode as such this tool will no longer receive bug fixes, security patches, or new features.
   </p>
   <p>
-    We recommend to use the [TypeScript SDK](https://docs.commercetools.com/sdk/typescript-sdk) for any new implementation and plan migrating to it.
+    We recommend to use the <a href="https://docs.commercetools.com/sdk/typescript-sdk">TypeScript SDK</a> for any new implementation and plan migrating to it.
   </p>
 </div>
 

--- a/packages/sdk-middleware-auth/README.md
+++ b/packages/sdk-middleware-auth/README.md
@@ -1,7 +1,7 @@
 # commercetools-sdk-middlware-auth
 
 <div style="background-color: yellow; color: black; padding: 10px; text-align: center; font-weight: bold;">
-  <h2>⚠️ In maintenance mode  ⚠️</h2>
+  <h2>⚠️ In Maintenance Mode ⚠️</h2>
   <p>
     This package has been replaced by the <a href="https://docs.commercetools.com/sdk/typescript-sdk">TypeScript SDK</a> is in maintenance mode as such this tool will no longer receive new features or bug fixes.
   </p>

--- a/packages/sdk-middleware-auth/README.md
+++ b/packages/sdk-middleware-auth/README.md
@@ -3,7 +3,7 @@
 <div style="background-color: yellow; color: black; padding: 10px; text-align: center; font-weight: bold;">
   <h2>⚠️ In maintenance mode  ⚠️</h2>
   <p>
-    This package has been replaced by the <a href="https://docs.commercetools.com/sdk/typescript-sdk">TypeScript SDK</a> is in maintenance mode as such this tool will no longer receive bug fixes, security patches, or new features.
+    This package has been replaced by the <a href="https://docs.commercetools.com/sdk/typescript-sdk">TypeScript SDK</a> is in maintenance mode as such this tool will no longer receive new features or bug fixes.
   </p>
   <p>
     We recommend to use the <a href="https://docs.commercetools.com/sdk/typescript-sdk">TypeScript SDK</a> for any new implementation and plan migrating to it.

--- a/packages/sdk-middleware-correlation-id/README.md
+++ b/packages/sdk-middleware-correlation-id/README.md
@@ -1,5 +1,15 @@
 # commercetools-sdk-middlware-correlation-id
 
+<div style="background-color: yellow; color: black; padding: 10px; text-align: center; font-weight: bold;">
+  <h2>⚠️ In maintenance mode  ⚠️</h2>
+  <p>
+    This package has been replaced by the [TypeScript SDK](https://docs.commercetools.com/sdk/typescript-sdk) is in maintenance mode as such this tool will no longer receive bug fixes, security patches, or new features.
+  </p>
+  <p>
+    We recommend to use the [TypeScript SDK](https://docs.commercetools.com/sdk/typescript-sdk) for any new implementation and plan migrating to it.
+  </p>
+</div>
+
 Middleware for adding a correlation id to requests with `@commercetools/sdk-client`
 
 https://commercetools.github.io/nodejs/sdk/api/sdkMiddlewareCorrelationId.html

--- a/packages/sdk-middleware-correlation-id/README.md
+++ b/packages/sdk-middleware-correlation-id/README.md
@@ -3,10 +3,10 @@
 <div style="background-color: yellow; color: black; padding: 10px; text-align: center; font-weight: bold;">
   <h2>⚠️ In maintenance mode  ⚠️</h2>
   <p>
-    This package has been replaced by the [TypeScript SDK](https://docs.commercetools.com/sdk/typescript-sdk) is in maintenance mode as such this tool will no longer receive bug fixes, security patches, or new features.
+    This package has been replaced by the <a href="https://docs.commercetools.com/sdk/typescript-sdk">TypeScript SDK</a> is in maintenance mode as such this tool will no longer receive bug fixes, security patches, or new features.
   </p>
   <p>
-    We recommend to use the [TypeScript SDK](https://docs.commercetools.com/sdk/typescript-sdk) for any new implementation and plan migrating to it.
+    We recommend to use the <a href="https://docs.commercetools.com/sdk/typescript-sdk">TypeScript SDK</a> for any new implementation and plan migrating to it.
   </p>
 </div>
 

--- a/packages/sdk-middleware-correlation-id/README.md
+++ b/packages/sdk-middleware-correlation-id/README.md
@@ -1,7 +1,7 @@
 # commercetools-sdk-middlware-correlation-id
 
 <div style="background-color: yellow; color: black; padding: 10px; text-align: center; font-weight: bold;">
-  <h2>⚠️ In maintenance mode  ⚠️</h2>
+  <h2>⚠️ In Maintenance Mode ⚠️</h2>
   <p>
     This package has been replaced by the <a href="https://docs.commercetools.com/sdk/typescript-sdk">TypeScript SDK</a> is in maintenance mode as such this tool will no longer receive new features or bug fixes.
   </p>

--- a/packages/sdk-middleware-correlation-id/README.md
+++ b/packages/sdk-middleware-correlation-id/README.md
@@ -3,7 +3,7 @@
 <div style="background-color: yellow; color: black; padding: 10px; text-align: center; font-weight: bold;">
   <h2>⚠️ In maintenance mode  ⚠️</h2>
   <p>
-    This package has been replaced by the <a href="https://docs.commercetools.com/sdk/typescript-sdk">TypeScript SDK</a> is in maintenance mode as such this tool will no longer receive bug fixes, security patches, or new features.
+    This package has been replaced by the <a href="https://docs.commercetools.com/sdk/typescript-sdk">TypeScript SDK</a> is in maintenance mode as such this tool will no longer receive new features or bug fixes.
   </p>
   <p>
     We recommend to use the <a href="https://docs.commercetools.com/sdk/typescript-sdk">TypeScript SDK</a> for any new implementation and plan migrating to it.

--- a/packages/sdk-middleware-http/README.md
+++ b/packages/sdk-middleware-http/README.md
@@ -3,10 +3,10 @@
 <div style="background-color: yellow; color: black; padding: 10px; text-align: center; font-weight: bold;">
   <h2>⚠️ In maintenance mode  ⚠️</h2>
   <p>
-    This package has been replaced by the [TypeScript SDK](https://docs.commercetools.com/sdk/typescript-sdk) is in maintenance mode as such this tool will no longer receive bug fixes, security patches, or new features.
+    This package has been replaced by the <a href="https://docs.commercetools.com/sdk/typescript-sdk">TypeScript SDK</a> is in maintenance mode as such this tool will no longer receive bug fixes, security patches, or new features.
   </p>
   <p>
-    We recommend to use the [TypeScript SDK](https://docs.commercetools.com/sdk/typescript-sdk) for any new implementation and plan migrating to it.
+    We recommend to use the <a href="https://docs.commercetools.com/sdk/typescript-sdk">TypeScript SDK</a> for any new implementation and plan migrating to it.
   </p>
 </div>
 

--- a/packages/sdk-middleware-http/README.md
+++ b/packages/sdk-middleware-http/README.md
@@ -1,5 +1,15 @@
 # commercetools-sdk-middlware-http
 
+<div style="background-color: yellow; color: black; padding: 10px; text-align: center; font-weight: bold;">
+  <h2>⚠️ In maintenance mode  ⚠️</h2>
+  <p>
+    This package has been replaced by the [TypeScript SDK](https://docs.commercetools.com/sdk/typescript-sdk) is in maintenance mode as such this tool will no longer receive bug fixes, security patches, or new features.
+  </p>
+  <p>
+    We recommend to use the [TypeScript SDK](https://docs.commercetools.com/sdk/typescript-sdk) for any new implementation and plan migrating to it.
+  </p>
+</div>
+
 Middleware for making http requests for usage with `@commercetools/sdk-client`
 
 https://commercetools.github.io/nodejs/sdk/api/sdkMiddlewareHttp.html

--- a/packages/sdk-middleware-http/README.md
+++ b/packages/sdk-middleware-http/README.md
@@ -3,7 +3,7 @@
 <div style="background-color: yellow; color: black; padding: 10px; text-align: center; font-weight: bold;">
   <h2>⚠️ In maintenance mode  ⚠️</h2>
   <p>
-    This package has been replaced by the <a href="https://docs.commercetools.com/sdk/typescript-sdk">TypeScript SDK</a> is in maintenance mode as such this tool will no longer receive bug fixes, security patches, or new features.
+    This package has been replaced by the <a href="https://docs.commercetools.com/sdk/typescript-sdk">TypeScript SDK</a> is in maintenance mode as such this tool will no longer receive new features or bug fixes.
   </p>
   <p>
     We recommend to use the <a href="https://docs.commercetools.com/sdk/typescript-sdk">TypeScript SDK</a> for any new implementation and plan migrating to it.

--- a/packages/sdk-middleware-http/README.md
+++ b/packages/sdk-middleware-http/README.md
@@ -1,7 +1,7 @@
 # commercetools-sdk-middlware-http
 
 <div style="background-color: yellow; color: black; padding: 10px; text-align: center; font-weight: bold;">
-  <h2>⚠️ In maintenance mode  ⚠️</h2>
+  <h2>⚠️ In Maintenance Mode ⚠️</h2>
   <p>
     This package has been replaced by the <a href="https://docs.commercetools.com/sdk/typescript-sdk">TypeScript SDK</a> is in maintenance mode as such this tool will no longer receive new features or bug fixes.
   </p>

--- a/packages/sdk-middleware-logger/README.md
+++ b/packages/sdk-middleware-logger/README.md
@@ -1,7 +1,7 @@
 # commercetools-sdk-middlware-logger
 
 <div style="background-color: yellow; color: black; padding: 10px; text-align: center; font-weight: bold;">
-  <h2>⚠️ In maintenance mode  ⚠️</h2>
+  <h2>⚠️ In Maintenance Mode ⚠️</h2>
   <p>
     This package has been replaced by the <a href="https://docs.commercetools.com/sdk/typescript-sdk">TypeScript SDK</a> is in maintenance mode as such this tool will no longer receive new features or bug fixes.
   </p>

--- a/packages/sdk-middleware-logger/README.md
+++ b/packages/sdk-middleware-logger/README.md
@@ -1,5 +1,15 @@
 # commercetools-sdk-middlware-logger
 
+<div style="background-color: yellow; color: black; padding: 10px; text-align: center; font-weight: bold;">
+  <h2>⚠️ In maintenance mode  ⚠️</h2>
+  <p>
+    This package has been replaced by the [TypeScript SDK](https://docs.commercetools.com/sdk/typescript-sdk) is in maintenance mode as such this tool will no longer receive bug fixes, security patches, or new features.
+  </p>
+  <p>
+    We recommend to use the [TypeScript SDK](https://docs.commercetools.com/sdk/typescript-sdk) for any new implementation and plan migrating to it.
+  </p>
+</div>
+
 Middleware for queueing requests for usage with `@commercetools/sdk-client`
 
 https://commercetools.github.io/nodejs/sdk/api/sdkMiddlewareLogger.html

--- a/packages/sdk-middleware-logger/README.md
+++ b/packages/sdk-middleware-logger/README.md
@@ -3,10 +3,10 @@
 <div style="background-color: yellow; color: black; padding: 10px; text-align: center; font-weight: bold;">
   <h2>⚠️ In maintenance mode  ⚠️</h2>
   <p>
-    This package has been replaced by the [TypeScript SDK](https://docs.commercetools.com/sdk/typescript-sdk) is in maintenance mode as such this tool will no longer receive bug fixes, security patches, or new features.
+    This package has been replaced by the <a href="https://docs.commercetools.com/sdk/typescript-sdk">TypeScript SDK</a> is in maintenance mode as such this tool will no longer receive bug fixes, security patches, or new features.
   </p>
   <p>
-    We recommend to use the [TypeScript SDK](https://docs.commercetools.com/sdk/typescript-sdk) for any new implementation and plan migrating to it.
+    We recommend to use the <a href="https://docs.commercetools.com/sdk/typescript-sdk">TypeScript SDK</a> for any new implementation and plan migrating to it.
   </p>
 </div>
 

--- a/packages/sdk-middleware-logger/README.md
+++ b/packages/sdk-middleware-logger/README.md
@@ -3,7 +3,7 @@
 <div style="background-color: yellow; color: black; padding: 10px; text-align: center; font-weight: bold;">
   <h2>⚠️ In maintenance mode  ⚠️</h2>
   <p>
-    This package has been replaced by the <a href="https://docs.commercetools.com/sdk/typescript-sdk">TypeScript SDK</a> is in maintenance mode as such this tool will no longer receive bug fixes, security patches, or new features.
+    This package has been replaced by the <a href="https://docs.commercetools.com/sdk/typescript-sdk">TypeScript SDK</a> is in maintenance mode as such this tool will no longer receive new features or bug fixes.
   </p>
   <p>
     We recommend to use the <a href="https://docs.commercetools.com/sdk/typescript-sdk">TypeScript SDK</a> for any new implementation and plan migrating to it.

--- a/packages/sdk-middleware-queue/README.md
+++ b/packages/sdk-middleware-queue/README.md
@@ -1,5 +1,15 @@
 # commercetools-sdk-middlware-queue
 
+<div style="background-color: yellow; color: black; padding: 10px; text-align: center; font-weight: bold;">
+  <h2>⚠️ In maintenance mode  ⚠️</h2>
+  <p>
+    This package has been replaced by the [TypeScript SDK](https://docs.commercetools.com/sdk/typescript-sdk) is in maintenance mode as such this tool will no longer receive bug fixes, security patches, or new features.
+  </p>
+  <p>
+    We recommend to use the [TypeScript SDK](https://docs.commercetools.com/sdk/typescript-sdk) for any new implementation and plan migrating to it.
+  </p>
+</div>
+
 Middleware for queueing requests for usage with `@commercetools/sdk-client`
 
 https://commercetools.github.io/nodejs/sdk/api/sdkMiddlewareQueue.html

--- a/packages/sdk-middleware-queue/README.md
+++ b/packages/sdk-middleware-queue/README.md
@@ -3,10 +3,10 @@
 <div style="background-color: yellow; color: black; padding: 10px; text-align: center; font-weight: bold;">
   <h2>⚠️ In maintenance mode  ⚠️</h2>
   <p>
-    This package has been replaced by the [TypeScript SDK](https://docs.commercetools.com/sdk/typescript-sdk) is in maintenance mode as such this tool will no longer receive bug fixes, security patches, or new features.
+    This package has been replaced by the <a href="https://docs.commercetools.com/sdk/typescript-sdk">TypeScript SDK</a> is in maintenance mode as such this tool will no longer receive bug fixes, security patches, or new features.
   </p>
   <p>
-    We recommend to use the [TypeScript SDK](https://docs.commercetools.com/sdk/typescript-sdk) for any new implementation and plan migrating to it.
+    We recommend to use the <a href="https://docs.commercetools.com/sdk/typescript-sdk">TypeScript SDK</a> for any new implementation and plan migrating to it.
   </p>
 </div>
 

--- a/packages/sdk-middleware-queue/README.md
+++ b/packages/sdk-middleware-queue/README.md
@@ -1,7 +1,7 @@
 # commercetools-sdk-middlware-queue
 
 <div style="background-color: yellow; color: black; padding: 10px; text-align: center; font-weight: bold;">
-  <h2>⚠️ In maintenance mode  ⚠️</h2>
+  <h2>⚠️ In Maintenance Mode ⚠️</h2>
   <p>
     This package has been replaced by the <a href="https://docs.commercetools.com/sdk/typescript-sdk">TypeScript SDK</a> is in maintenance mode as such this tool will no longer receive new features or bug fixes.
   </p>

--- a/packages/sdk-middleware-queue/README.md
+++ b/packages/sdk-middleware-queue/README.md
@@ -3,7 +3,7 @@
 <div style="background-color: yellow; color: black; padding: 10px; text-align: center; font-weight: bold;">
   <h2>⚠️ In maintenance mode  ⚠️</h2>
   <p>
-    This package has been replaced by the <a href="https://docs.commercetools.com/sdk/typescript-sdk">TypeScript SDK</a> is in maintenance mode as such this tool will no longer receive bug fixes, security patches, or new features.
+    This package has been replaced by the <a href="https://docs.commercetools.com/sdk/typescript-sdk">TypeScript SDK</a> is in maintenance mode as such this tool will no longer receive new features or bug fixes.
   </p>
   <p>
     We recommend to use the <a href="https://docs.commercetools.com/sdk/typescript-sdk">TypeScript SDK</a> for any new implementation and plan migrating to it.

--- a/packages/sdk-middleware-user-agent/README.md
+++ b/packages/sdk-middleware-user-agent/README.md
@@ -3,10 +3,10 @@
 <div style="background-color: yellow; color: black; padding: 10px; text-align: center; font-weight: bold;">
   <h2>⚠️ In maintenance mode  ⚠️</h2>
   <p>
-    This package has been replaced by the [TypeScript SDK](https://docs.commercetools.com/sdk/typescript-sdk) is in maintenance mode as such this tool will no longer receive bug fixes, security patches, or new features.
+    This package has been replaced by the <a href="https://docs.commercetools.com/sdk/typescript-sdk">TypeScript SDK</a> is in maintenance mode as such this tool will no longer receive bug fixes, security patches, or new features.
   </p>
   <p>
-    We recommend to use the [TypeScript SDK](https://docs.commercetools.com/sdk/typescript-sdk) for any new implementation and plan migrating to it.
+    We recommend to use the <a href="https://docs.commercetools.com/sdk/typescript-sdk">TypeScript SDK</a> for any new implementation and plan migrating to it.
   </p>
 </div>
 

--- a/packages/sdk-middleware-user-agent/README.md
+++ b/packages/sdk-middleware-user-agent/README.md
@@ -1,7 +1,7 @@
 # commercetools-sdk-middlware-user-agent
 
 <div style="background-color: yellow; color: black; padding: 10px; text-align: center; font-weight: bold;">
-  <h2>⚠️ In maintenance mode  ⚠️</h2>
+  <h2>⚠️ In Maintenance Mode ⚠️</h2>
   <p>
     This package has been replaced by the <a href="https://docs.commercetools.com/sdk/typescript-sdk">TypeScript SDK</a> is in maintenance mode as such this tool will no longer receive new features or bug fixes.
   </p>

--- a/packages/sdk-middleware-user-agent/README.md
+++ b/packages/sdk-middleware-user-agent/README.md
@@ -3,7 +3,7 @@
 <div style="background-color: yellow; color: black; padding: 10px; text-align: center; font-weight: bold;">
   <h2>⚠️ In maintenance mode  ⚠️</h2>
   <p>
-    This package has been replaced by the <a href="https://docs.commercetools.com/sdk/typescript-sdk">TypeScript SDK</a> is in maintenance mode as such this tool will no longer receive bug fixes, security patches, or new features.
+    This package has been replaced by the <a href="https://docs.commercetools.com/sdk/typescript-sdk">TypeScript SDK</a> is in maintenance mode as such this tool will no longer receive new features or bug fixes.
   </p>
   <p>
     We recommend to use the <a href="https://docs.commercetools.com/sdk/typescript-sdk">TypeScript SDK</a> for any new implementation and plan migrating to it.

--- a/packages/sdk-middleware-user-agent/README.md
+++ b/packages/sdk-middleware-user-agent/README.md
@@ -1,5 +1,15 @@
 # commercetools-sdk-middlware-user-agent
 
+<div style="background-color: yellow; color: black; padding: 10px; text-align: center; font-weight: bold;">
+  <h2>⚠️ In maintenance mode  ⚠️</h2>
+  <p>
+    This package has been replaced by the [TypeScript SDK](https://docs.commercetools.com/sdk/typescript-sdk) is in maintenance mode as such this tool will no longer receive bug fixes, security patches, or new features.
+  </p>
+  <p>
+    We recommend to use the [TypeScript SDK](https://docs.commercetools.com/sdk/typescript-sdk) for any new implementation and plan migrating to it.
+  </p>
+</div>
+
 Middleware for setting the User-Agent on the HTTP request for usage with `@commercetools/sdk-client`
 
 https://commercetools.github.io/nodejs/sdk/api/sdkMiddlewareUserAgent.html

--- a/packages/sdk-types/README.md
+++ b/packages/sdk-types/README.md
@@ -3,10 +3,10 @@
 <div style="background-color: yellow; color: black; padding: 10px; text-align: center; font-weight: bold;">
   <h2>⚠️ In maintenance mode  ⚠️</h2>
   <p>
-    This package has been replaced by the [TypeScript SDK](https://docs.commercetools.com/sdk/typescript-sdk) is in maintenance mode as such this tool will no longer receive bug fixes, security patches, or new features.
+    This package has been replaced by the <a href="https://docs.commercetools.com/sdk/typescript-sdk">TypeScript SDK</a> is in maintenance mode as such this tool will no longer receive bug fixes, security patches, or new features.
   </p>
   <p>
-    We recommend to use the [TypeScript SDK](https://docs.commercetools.com/sdk/typescript-sdk) for any new implementation and plan migrating to it.
+    We recommend to use the <a href="https://docs.commercetools.com/sdk/typescript-sdk">TypeScript SDK</a> for any new implementation and plan migrating to it.
   </p>
 </div>
 

--- a/packages/sdk-types/README.md
+++ b/packages/sdk-types/README.md
@@ -1,5 +1,15 @@
 # commercetools-sdk-types
 
+<div style="background-color: yellow; color: black; padding: 10px; text-align: center; font-weight: bold;">
+  <h2>⚠️ In maintenance mode  ⚠️</h2>
+  <p>
+    This package has been replaced by the [TypeScript SDK](https://docs.commercetools.com/sdk/typescript-sdk) is in maintenance mode as such this tool will no longer receive bug fixes, security patches, or new features.
+  </p>
+  <p>
+    We recommend to use the [TypeScript SDK](https://docs.commercetools.com/sdk/typescript-sdk) for any new implementation and plan migrating to it.
+  </p>
+</div>
+
 TypeScript declarations for SDK packages
 
 ## Install

--- a/packages/sdk-types/README.md
+++ b/packages/sdk-types/README.md
@@ -1,7 +1,7 @@
 # commercetools-sdk-types
 
 <div style="background-color: yellow; color: black; padding: 10px; text-align: center; font-weight: bold;">
-  <h2>⚠️ In maintenance mode  ⚠️</h2>
+  <h2>⚠️ In Maintenance Mode ⚠️</h2>
   <p>
     This package has been replaced by the <a href="https://docs.commercetools.com/sdk/typescript-sdk">TypeScript SDK</a> is in maintenance mode as such this tool will no longer receive new features or bug fixes.
   </p>

--- a/packages/sdk-types/README.md
+++ b/packages/sdk-types/README.md
@@ -3,7 +3,7 @@
 <div style="background-color: yellow; color: black; padding: 10px; text-align: center; font-weight: bold;">
   <h2>⚠️ In maintenance mode  ⚠️</h2>
   <p>
-    This package has been replaced by the <a href="https://docs.commercetools.com/sdk/typescript-sdk">TypeScript SDK</a> is in maintenance mode as such this tool will no longer receive bug fixes, security patches, or new features.
+    This package has been replaced by the <a href="https://docs.commercetools.com/sdk/typescript-sdk">TypeScript SDK</a> is in maintenance mode as such this tool will no longer receive new features or bug fixes.
   </p>
   <p>
     We recommend to use the <a href="https://docs.commercetools.com/sdk/typescript-sdk">TypeScript SDK</a> for any new implementation and plan migrating to it.


### PR DESCRIPTION
#### Summary

These packages have been replaced by the TypeScript SDK. We should inform users stumbling upon this repository of it.