### PR TITLE
Downgrade `jsondiffpatch` to `v0.6.2`

### DIFF
--- a/.changeset/curvy-lizards-wonder.md
+++ b/.changeset/curvy-lizards-wonder.md
@@ -1,0 +1,5 @@
+---
+'@commercetools/sync-actions': patch
+---
+
+Downgrade jsondiffpatch to fix ESM bundling issue.

--- a/.renovaterc.json
+++ b/.renovaterc.json
@@ -19,6 +19,10 @@
     {
       "matchPackageNames": ["flow-bin"],
       "allowedVersions": "0.141.0"
+    },
+    {
+      "matchPackageNames": ["jsondiffpatch"],
+      "allowedVersions": "<= 0.7.2"
     }
   ],
   "lockFileMaintenance": {

--- a/.renovaterc.json
+++ b/.renovaterc.json
@@ -22,7 +22,7 @@
     },
     {
       "matchPackageNames": ["jsondiffpatch"],
-      "allowedVersions": "<= 0.7.2"
+      "allowedVersions": "<= 0.6.2"
     }
   ],
   "lockFileMaintenance": {

--- a/packages/sync-actions/package.json
+++ b/packages/sync-actions/package.json
@@ -40,7 +40,7 @@
   },
   "dependencies": {
     "fast-equals": "^2.0.0",
-    "jsondiffpatch": "0.7.3",
+    "jsondiffpatch": "0.7.2",
     "lodash.flatten": "^4.4.0",
     "lodash.foreach": "^4.5.0",
     "lodash.intersection": "^4.4.0",

--- a/packages/sync-actions/package.json
+++ b/packages/sync-actions/package.json
@@ -40,7 +40,7 @@
   },
   "dependencies": {
     "fast-equals": "^2.0.0",
-    "jsondiffpatch": "0.7.2",
+    "jsondiffpatch": "0.6.2",
     "lodash.flatten": "^4.4.0",
     "lodash.foreach": "^4.5.0",
     "lodash.intersection": "^4.4.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -410,8 +410,8 @@ importers:
         specifier: ^2.0.0
         version: 2.0.4
       jsondiffpatch:
-        specifier: 0.7.3
-        version: 0.7.3
+        specifier: 0.6.2
+        version: 0.6.2
       lodash.flatten:
         specifier: ^4.4.0
         version: 4.4.0
@@ -1382,9 +1382,6 @@ packages:
   '@commitlint/types@19.8.0':
     resolution: {integrity: sha512-LRjP623jPyf3Poyfb0ohMj8I3ORyBDOwXAgxxVPbSD0unJuW2mJWeiRfaQinjtccMqC5Wy1HOMfa4btKjbNxbg==}
     engines: {node: '>=v18'}
-
-  '@dmsnell/diff-match-patch@1.1.0':
-    resolution: {integrity: sha512-yejLPmM5pjsGvxS9gXablUSbInW7H976c/FJ4iQxWIm7/38xBySRemTPDe34lhg1gVLbJntX0+sH0jYfU+PN9A==}
 
   '@eslint/eslintrc@0.4.3':
     resolution: {integrity: sha512-J6KFFz5QCYUJq3pf0mjEcCJVERbzv71PUIDczuh9JkwGEzced6CO5ADLHB1rbf/+oPBtoPfMYNOpGDzCANlbXw==}
@@ -4102,8 +4099,8 @@ packages:
     engines: {node: ^18.0.0 || >=20.0.0}
     hasBin: true
 
-  jsondiffpatch@0.7.3:
-    resolution: {integrity: sha512-zd4dqFiXSYyant2WgSXAZ9+yYqilNVvragVNkNRn2IFZKgjyULNrKRznqN4Zon0MkLueCg+3QaPVCnDAVP20OQ==}
+  jsondiffpatch@0.6.2:
+    resolution: {integrity: sha512-c4RkbPb6RXWjkhirwcKK87PuZCITdGRN1usrW4pXKEkwp7Gqf+0pSwQHoh/LtlYNHcxzoF6kok2/EFe6KL0qqQ==}
     engines: {node: ^18.0.0 || >=20.0.0}
     hasBin: true
 
@@ -7355,8 +7352,6 @@ snapshots:
     dependencies:
       '@types/conventional-commits-parser': 5.0.1
       chalk: 5.4.1
-
-  '@dmsnell/diff-match-patch@1.1.0': {}
 
   '@eslint/eslintrc@0.4.3':
     dependencies:
@@ -10910,9 +10905,10 @@ snapshots:
       chalk: 5.4.1
       diff-match-patch: 1.0.5
 
-  jsondiffpatch@0.7.3:
+  jsondiffpatch@0.6.2:
     dependencies:
-      '@dmsnell/diff-match-patch': 1.1.0
+      '@types/diff-match-patch': 1.0.36
+      diff-match-patch: 1.0.5
 
   jsonfile@4.0.0:
     optionalDependencies:


### PR DESCRIPTION
#### Summary

This downgrades the underlying library of `jsondiffpatch` to v0.6.2 as any future version can cause issues in non ESM contexts. 

The issue appears to be in this version. As the changelog of the library is not well maintained the root cause is hard to track down.

![Screenshot 2025-05-06 at 12 56 32@2x](https://github.com/user-attachments/assets/c332d2a6-eba1-4479-b8cf-dd4b3c3958b8)

From the last versions this is the last working for us

![Screenshot 2025-05-06 at 12 54 50@2x](https://github.com/user-attachments/assets/c9896164-c84a-4aed-bd54-8e774ad48d35)

Without this change in Jest you would see something like

![Screenshot 2025-05-06 at 12 57 10@2x](https://github.com/user-attachments/assets/f3f5f1ba-3ac3-436a-9d27-7134682d1719)
