### PR TITLE
Downgrade `jsondiffpatcher` to v0.5.0 prior becoming ESM only

### DIFF
--- a/.renovaterc.json
+++ b/.renovaterc.json
@@ -22,7 +22,7 @@
     },
     {
       "matchPackageNames": ["jsondiffpatch"],
-      "allowedVersions": "<= 0.6.0"
+      "allowedVersions": "<= 0.5.0"
     }
   ],
   "lockFileMaintenance": {

--- a/packages/sync-actions/package.json
+++ b/packages/sync-actions/package.json
@@ -40,7 +40,7 @@
   },
   "dependencies": {
     "fast-equals": "^2.0.0",
-    "jsondiffpatch": "0.6.0",
+    "jsondiffpatch": "0.5.0",
     "lodash.flatten": "^4.4.0",
     "lodash.foreach": "^4.5.0",
     "lodash.intersection": "^4.4.0",

--- a/packages/sync-actions/src/utils/diffpatcher.js
+++ b/packages/sync-actions/src/utils/diffpatcher.js
@@ -1,4 +1,4 @@
-import * as jsondiffpatch from 'jsondiffpatch'
+import { DiffPatcher } from 'jsondiffpatch/dist/jsondiffpatch.cjs'
 
 export function objectHash(obj, index) {
   const objIndex = `$$index:${index}`
@@ -7,7 +7,7 @@ export function objectHash(obj, index) {
     : objIndex
 }
 
-const diffpatcher = jsondiffpatch.create({
+const diffpatcher = new DiffPatcher({
   objectHash,
   arrays: {
     // detect items moved inside the array

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -410,8 +410,8 @@ importers:
         specifier: ^2.0.0
         version: 2.0.4
       jsondiffpatch:
-        specifier: 0.6.2
-        version: 0.6.2
+        specifier: 0.5.0
+        version: 0.5.0
       lodash.flatten:
         specifier: ^4.4.0
         version: 4.4.0
@@ -4094,13 +4094,13 @@ packages:
     engines: {node: '>=6'}
     hasBin: true
 
-  jsondiffpatch@0.6.0:
-    resolution: {integrity: sha512-3QItJOXp2AP1uv7waBkao5nCvhEv+QmJAd38Ybq7wNI74Q+BBmnLn4EDKz6yI9xGAIQoUF87qHt+kc1IVxB4zQ==}
-    engines: {node: ^18.0.0 || >=20.0.0}
+  jsondiffpatch@0.5.0:
+    resolution: {integrity: sha512-Quz3MvAwHxVYNXsOByL7xI5EB2WYOeFswqaHIA3qOK3isRWTxiplBEocmmru6XmxDB2L7jDNYtYA4FyimoAFEw==}
+    engines: {node: '>=8.17.0'}
     hasBin: true
 
-  jsondiffpatch@0.6.2:
-    resolution: {integrity: sha512-c4RkbPb6RXWjkhirwcKK87PuZCITdGRN1usrW4pXKEkwp7Gqf+0pSwQHoh/LtlYNHcxzoF6kok2/EFe6KL0qqQ==}
+  jsondiffpatch@0.6.0:
+    resolution: {integrity: sha512-3QItJOXp2AP1uv7waBkao5nCvhEv+QmJAd38Ybq7wNI74Q+BBmnLn4EDKz6yI9xGAIQoUF87qHt+kc1IVxB4zQ==}
     engines: {node: ^18.0.0 || >=20.0.0}
     hasBin: true
 
@@ -10903,15 +10903,15 @@ snapshots:
 
   json5@2.2.3: {}
 
+  jsondiffpatch@0.5.0:
+    dependencies:
+      chalk: 3.0.0
+      diff-match-patch: 1.0.5
+
   jsondiffpatch@0.6.0:
     dependencies:
       '@types/diff-match-patch': 1.0.36
       chalk: 5.4.1
-      diff-match-patch: 1.0.5
-
-  jsondiffpatch@0.6.2:
-    dependencies:
-      '@types/diff-match-patch': 1.0.36
       diff-match-patch: 1.0.5
 
   jsonfile@4.0.0:


### PR DESCRIPTION
#### Summary

In the major release of packages of this repository in #1930 the `jsondiffpatcher` library was bumped to v0.6.0. This version however is ESM only.

![Screenshot 2025-05-06 at 21 01 34@2x](https://github.com/user-attachments/assets/d424f4b8-3409-4fad-a395-6129186caf77)

That version is also the last version with a good release note. The ESM only mode may work for Node.js environments as all supported environments support ESM but can fail in browsers and testing environments. 

As this library doesn't rely on specifics of the jsondiffpatcher library we can consider downgrading.

The proceeding of this will be discussed internally. 