### PR TITLE
PDM-236 Add support for product level attributes

### DIFF
--- a/.changeset/warm-webs-dream.md
+++ b/.changeset/warm-webs-dream.md
@@ -1,0 +1,5 @@
+---
+'@commercetools/sync-actions': minor
+---
+
+Add support for product level attributes

--- a/packages/sync-actions/src/product-actions.js
+++ b/packages/sync-actions/src/product-actions.js
@@ -26,6 +26,7 @@ export const baseActionsList = [
   { action: 'setSearchKeywords', key: 'searchKeywords' },
   { action: 'setKey', key: 'key' },
   { action: 'setPriceMode', key: 'priceMode' },
+  { action: 'setProductAttribute', key: 'attributes' }
 ]
 
 export const baseAssetActionsList = [

--- a/packages/sync-actions/src/product-actions.js
+++ b/packages/sync-actions/src/product-actions.js
@@ -758,7 +758,7 @@ export function actionsMapAssets(diff, oldObj, newObj, variantHashMap) {
   return allAssetsActions
 }
 
-export function actionsMapAttributes(
+export function actionsMapVariantAttributes(
   diff,
   oldObj,
   newObj,

--- a/packages/sync-actions/src/product-actions.js
+++ b/packages/sync-actions/src/product-actions.js
@@ -26,7 +26,6 @@ export const baseActionsList = [
   { action: 'setSearchKeywords', key: 'searchKeywords' },
   { action: 'setKey', key: 'key' },
   { action: 'setPriceMode', key: 'priceMode' },
-  { action: 'setProductAttribute', key: 'attributes' }
 ]
 
 export const baseAssetActionsList = [

--- a/packages/sync-actions/src/product-actions.js
+++ b/packages/sync-actions/src/product-actions.js
@@ -91,15 +91,28 @@ function _buildKeyActions(variantDiff, oldVariant) {
   return null
 }
 
+function _buildNewSetProductAttributeAction(attr) {
+  const attributeName = attr && attr.name
+  if (!attributeName) return undefined
+
+  const action = {
+    action: 'setProductAttribute',
+    name: attributeName,
+    value: attr.value,
+  }
+
+  return action
+}
+
 function _buildNewSetAttributeAction(variantId, attr, sameForAllAttributeNames) {
   const attributeName = attr && attr.name
   if (!attributeName) return undefined
 
   let action = {
     action: 'setAttribute',
-    variantId: id,
+    variantId: variantId,
     name: attributeName,
-    value: el.value,
+    value: attr.value,
   }
 
   if (sameForAllAttributeNames.indexOf(attributeName) !== -1) {

--- a/packages/sync-actions/src/product-actions.js
+++ b/packages/sync-actions/src/product-actions.js
@@ -91,8 +91,8 @@ function _buildKeyActions(variantDiff, oldVariant) {
   return null
 }
 
-function _buildNewSetAttributeAction(id, el, sameForAllAttributeNames) {
-  const attributeName = el && el.name
+function _buildNewSetAttributeAction(variantId, attr, sameForAllAttributeNames) {
+  const attributeName = attr && attr.name
   if (!attributeName) return undefined
 
   let action = {

--- a/packages/sync-actions/src/product-actions.js
+++ b/packages/sync-actions/src/product-actions.js
@@ -758,6 +758,18 @@ export function actionsMapAssets(diff, oldObj, newObj, variantHashMap) {
   return allAssetsActions
 }
 
+export function actionsMapProductAttributes(
+  diffedProductData,
+  oldProductData,
+  newProductData,
+) {
+  return _buildProductAttributesActions(
+    diffedProductData.attributes,
+    oldProductData,
+    newProductData
+  )
+}
+
 export function actionsMapVariantAttributes(
   diff,
   oldObj,

--- a/packages/sync-actions/src/product-actions.js
+++ b/packages/sync-actions/src/product-actions.js
@@ -363,6 +363,72 @@ function _buildVariantPricesAction(
   return [addPriceActions, changePriceActions, removePriceActions]
 }
 
+function _buildProductAttributesActions(
+  diffedAttributes,
+  oldProductData,
+  newProductData
+) {
+  const actions = []
+
+  if (!diffedAttributes) return actions
+
+  forEach(diffedAttributes, (value, key) => {
+    // What does this test tell us?
+    if (REGEX_NUMBER.test(key)) {
+      // What does this test tell us?
+      if (Array.isArray(value)) {
+        // Whats the difference between _buildNew... and _build... ?
+        const setAction = _buildNewSetProductAttributeAction(
+          diffpatcher.getDeltaValue(value)
+        )
+        if (setAction) actions.push(setAction)
+      // What does this test tell us?
+      } else if (newProductData.attributes) {
+        const setAction = _buildSetProductAttributeAction(
+          value.value,
+          oldProductData,
+          newProductData.attributes[key]
+        )
+        if (setAction) actions.push(setAction)
+      }
+    // What does this test tell us?
+    } else if (REGEX_UNDERSCORE_NUMBER.test(key)) {
+      if (Array.isArray(value)) {
+        // What does this test tell us?
+        // Ignore pure array moves!
+        if (value.length === 3 && value[2] === 3) return
+
+        let deltaValue = diffpatcher.getDeltaValue(value)
+
+        // What happens here?
+        if (!deltaValue)
+          if (value[0] && value[0].name)
+            // unset attribute if
+            deltaValue = { name: value[0].name }
+          else deltaValue = undefined
+
+        const setAction = _buildNewSetProductAttributeAction(
+          deltaValue
+        )
+
+        if (setAction) actions.push(setAction)
+      } else {
+        const index = key.substring(1) // what happens here? Shouldn't this always be underscore?
+        if (newProductData.attributes) {
+          const setAction = _buildSetProductAttributeAction(
+            value.value,
+            oldProductData,
+            newProductData.attributes[index]
+          )
+          if (setAction) actions.push(setAction)
+        }
+      }
+    }
+  })
+
+  return actions
+}
+
 function _buildVariantAttributesActions(
   attributes,
   oldVariant,

--- a/packages/sync-actions/src/product-actions.js
+++ b/packages/sync-actions/src/product-actions.js
@@ -161,6 +161,23 @@ function _buildAttributeValue(diffedValue, oldAttributeValue, newAttributeValue)
   return value
 }
 
+function _buildSetProductAttributeAction(diffedValue, oldProductData, newAttribute) {
+  if (!newAttribute) return undefined
+
+  const action = {
+    action: 'setProductAttribute',
+    name: newAttribute.name,
+  }
+
+  // Used as original object for patching long diff text
+  const oldAttribute =
+    oldProductData.attributes.find((a) => a.name === newAttribute.name) || {}
+
+  action.value = _buildAttributeValue(diffedValue, oldAttribute.value, newAttribute.value)
+
+  return action
+}
+
 function _buildSetAttributeAction(
   diffedValue,
   oldVariant,

--- a/packages/sync-actions/src/product-actions.js
+++ b/packages/sync-actions/src/product-actions.js
@@ -104,13 +104,17 @@ function _buildNewSetProductAttributeAction(attr) {
   return action
 }
 
-function _buildNewSetAttributeAction(variantId, attr, sameForAllAttributeNames) {
+function _buildNewSetAttributeAction(
+  variantId,
+  attr,
+  sameForAllAttributeNames
+) {
   const attributeName = attr && attr.name
   if (!attributeName) return undefined
 
   let action = {
     action: 'setAttribute',
-    variantId: variantId,
+    variantId,
     name: attributeName,
     value: attr.value,
   }
@@ -123,7 +127,11 @@ function _buildNewSetAttributeAction(variantId, attr, sameForAllAttributeNames) 
   return action
 }
 
-function _buildAttributeValue(diffedValue, oldAttributeValue, newAttributeValue) {
+function _buildAttributeValue(
+  diffedValue,
+  oldAttributeValue,
+  newAttributeValue
+) {
   let value
 
   if (Array.isArray(diffedValue))
@@ -174,7 +182,11 @@ function _buildAttributeValue(diffedValue, oldAttributeValue, newAttributeValue)
   return value
 }
 
-function _buildSetProductAttributeAction(diffedValue, oldProductData, newAttribute) {
+function _buildSetProductAttributeAction(
+  diffedValue,
+  oldProductData,
+  newAttribute
+) {
   if (!newAttribute) return undefined
 
   const action = {
@@ -186,7 +198,11 @@ function _buildSetProductAttributeAction(diffedValue, oldProductData, newAttribu
   const oldAttribute =
     oldProductData.attributes.find((a) => a.name === newAttribute.name) || {}
 
-  action.value = _buildAttributeValue(diffedValue, oldAttribute.value, newAttribute.value)
+  action.value = _buildAttributeValue(
+    diffedValue,
+    oldAttribute.value,
+    newAttribute.value
+  )
 
   return action
 }
@@ -214,7 +230,11 @@ function _buildSetAttributeAction(
     delete action.variantId
   }
 
-  action.value = _buildAttributeValue(diffedValue, oldAttribute.value, attribute.value)
+  action.value = _buildAttributeValue(
+    diffedValue,
+    oldAttribute.value,
+    attribute.value
+  )
 
   return action
 }
@@ -373,16 +393,12 @@ function _buildProductAttributesActions(
   if (!diffedAttributes) return actions
 
   forEach(diffedAttributes, (value, key) => {
-    // What does this test tell us?
     if (REGEX_NUMBER.test(key)) {
-      // What does this test tell us?
       if (Array.isArray(value)) {
-        // Whats the difference between _buildNew... and _build... ?
         const setAction = _buildNewSetProductAttributeAction(
           diffpatcher.getDeltaValue(value)
         )
         if (setAction) actions.push(setAction)
-      // What does this test tell us?
       } else if (newProductData.attributes) {
         const setAction = _buildSetProductAttributeAction(
           value.value,
@@ -391,29 +407,24 @@ function _buildProductAttributesActions(
         )
         if (setAction) actions.push(setAction)
       }
-    // What does this test tell us?
     } else if (REGEX_UNDERSCORE_NUMBER.test(key)) {
       if (Array.isArray(value)) {
-        // What does this test tell us?
         // Ignore pure array moves!
         if (value.length === 3 && value[2] === 3) return
 
         let deltaValue = diffpatcher.getDeltaValue(value)
 
-        // What happens here?
         if (!deltaValue)
           if (value[0] && value[0].name)
             // unset attribute if
             deltaValue = { name: value[0].name }
           else deltaValue = undefined
 
-        const setAction = _buildNewSetProductAttributeAction(
-          deltaValue
-        )
+        const setAction = _buildNewSetProductAttributeAction(deltaValue)
 
         if (setAction) actions.push(setAction)
       } else {
-        const index = key.substring(1) // what happens here? Shouldn't this always be underscore?
+        const index = key.substring(1)
         if (newProductData.attributes) {
           const setAction = _buildSetProductAttributeAction(
             value.value,
@@ -761,7 +772,7 @@ export function actionsMapAssets(diff, oldObj, newObj, variantHashMap) {
 export function actionsMapProductAttributes(
   diffedProductData,
   oldProductData,
-  newProductData,
+  newProductData
 ) {
   return _buildProductAttributesActions(
     diffedProductData.attributes,
@@ -770,7 +781,7 @@ export function actionsMapProductAttributes(
   )
 }
 
-export function actionsMapVariantAttributes(
+export function actionsMapAttributes(
   diff,
   oldObj,
   newObj,

--- a/packages/sync-actions/src/product-actions.js
+++ b/packages/sync-actions/src/product-actions.js
@@ -91,42 +91,6 @@ function _buildKeyActions(variantDiff, oldVariant) {
   return null
 }
 
-function _buildNewSetProductAttributeAction(attr) {
-  const attributeName = attr && attr.name
-  if (!attributeName) return undefined
-
-  const action = {
-    action: 'setProductAttribute',
-    name: attributeName,
-    value: attr.value,
-  }
-
-  return action
-}
-
-function _buildNewSetAttributeAction(
-  variantId,
-  attr,
-  sameForAllAttributeNames
-) {
-  const attributeName = attr && attr.name
-  if (!attributeName) return undefined
-
-  let action = {
-    action: 'setAttribute',
-    variantId,
-    name: attributeName,
-    value: attr.value,
-  }
-
-  if (sameForAllAttributeNames.indexOf(attributeName) !== -1) {
-    action = { ...action, action: 'setAttributeInAllVariants' }
-    delete action.variantId
-  }
-
-  return action
-}
-
 function _buildAttributeValue(
   diffedValue,
   oldAttributeValue,
@@ -182,27 +146,25 @@ function _buildAttributeValue(
   return value
 }
 
-function _buildSetProductAttributeAction(
-  diffedValue,
-  oldProductData,
-  newAttribute
+function _buildNewSetAttributeAction(
+  variantId,
+  attr,
+  sameForAllAttributeNames
 ) {
-  if (!newAttribute) return undefined
+  const attributeName = attr && attr.name
+  if (!attributeName) return undefined
 
-  const action = {
-    action: 'setProductAttribute',
-    name: newAttribute.name,
+  let action = {
+    action: 'setAttribute',
+    variantId,
+    name: attributeName,
+    value: attr.value,
   }
 
-  // Used as original object for patching long diff text
-  const oldAttribute =
-    oldProductData.attributes.find((a) => a.name === newAttribute.name) || {}
-
-  action.value = _buildAttributeValue(
-    diffedValue,
-    oldAttribute.value,
-    newAttribute.value
-  )
+  if (sameForAllAttributeNames.indexOf(attributeName) !== -1) {
+    action = { ...action, action: 'setAttributeInAllVariants' }
+    delete action.variantId
+  }
 
   return action
 }
@@ -234,6 +196,44 @@ function _buildSetAttributeAction(
     diffedValue,
     oldAttribute.value,
     attribute.value
+  )
+
+  return action
+}
+
+function _buildNewSetProductAttributeAction(attr) {
+  const attributeName = attr && attr.name
+  if (!attributeName) return undefined
+
+  const action = {
+    action: 'setProductAttribute',
+    name: attributeName,
+    value: attr.value,
+  }
+
+  return action
+}
+
+function _buildSetProductAttributeAction(
+  diffedValue,
+  oldProductData,
+  newAttribute
+) {
+  if (!newAttribute) return undefined
+
+  const action = {
+    action: 'setProductAttribute',
+    name: newAttribute.name,
+  }
+
+  // Used as original object for patching long diff text
+  const oldAttribute =
+    oldProductData.attributes.find((a) => a.name === newAttribute.name) || {}
+
+  action.value = _buildAttributeValue(
+    diffedValue,
+    oldAttribute.value,
+    newAttribute.value
   )
 
   return action

--- a/packages/sync-actions/src/products.js
+++ b/packages/sync-actions/src/products.js
@@ -19,6 +19,7 @@ const actionGroups = [
   'references',
   'prices',
   'pricesCustom',
+  'productAttributes',
   'variantAttributes',
   'images',
   'variants',
@@ -49,6 +50,16 @@ function createProductMapActions(
       diff.variants,
       oldObj.variants,
       newObj.variants
+    )
+
+    allActions.push(
+      mapActionGroup('productAttributes', (): Array<UpdateAction> =>
+        productActions.actionsMapProductAttributes(
+          diff,
+          oldObj,
+          newObj
+        )
+      )
     )
 
     allActions.push(

--- a/packages/sync-actions/src/products.js
+++ b/packages/sync-actions/src/products.js
@@ -19,7 +19,7 @@ const actionGroups = [
   'references',
   'prices',
   'pricesCustom',
-  'attributes',
+  'variantAttributes',
   'images',
   'variants',
   'categories',
@@ -52,7 +52,7 @@ function createProductMapActions(
     )
 
     allActions.push(
-      mapActionGroup('attributes', (): Array<UpdateAction> =>
+      mapActionGroup('variantAttributes', (): Array<UpdateAction> =>
         productActions.actionsMapVariantAttributes(
           diff,
           oldObj,

--- a/packages/sync-actions/src/products.js
+++ b/packages/sync-actions/src/products.js
@@ -20,7 +20,7 @@ const actionGroups = [
   'prices',
   'pricesCustom',
   'productAttributes',
-  'variantAttributes',
+  'attributes',
   'images',
   'variants',
   'categories',
@@ -54,17 +54,13 @@ function createProductMapActions(
 
     allActions.push(
       mapActionGroup('productAttributes', (): Array<UpdateAction> =>
-        productActions.actionsMapProductAttributes(
-          diff,
-          oldObj,
-          newObj
-        )
+        productActions.actionsMapProductAttributes(diff, oldObj, newObj)
       )
     )
 
     allActions.push(
-      mapActionGroup('variantAttributes', (): Array<UpdateAction> =>
-        productActions.actionsMapVariantAttributes(
+      mapActionGroup('attributes', (): Array<UpdateAction> =>
+        productActions.actionsMapAttributes(
           diff,
           oldObj,
           newObj,

--- a/packages/sync-actions/src/products.js
+++ b/packages/sync-actions/src/products.js
@@ -53,7 +53,7 @@ function createProductMapActions(
 
     allActions.push(
       mapActionGroup('attributes', (): Array<UpdateAction> =>
-        productActions.actionsMapAttributes(
+        productActions.actionsMapVariantAttributes(
           diff,
           oldObj,
           newObj,

--- a/packages/sync-actions/test/product-sync-base.spec.js
+++ b/packages/sync-actions/test/product-sync-base.spec.js
@@ -648,4 +648,193 @@ describe('Actions', () => {
       }, // set reference
     ])
   })
+
+  test('should create setProductAttribute action when attribute is removed from product', () => {
+    const before = {
+      id: '123',
+      attributes: [
+        { name: 'testAttr', value: 'oldValue' },
+        { name: 'anotherAttr', value: 'anotherValue' },
+      ],
+    }
+
+    const now = {
+      id: '123',
+      attributes: [
+        { name: 'anotherAttr', value: 'anotherValue' },
+        // testAttr is removed
+      ],
+    }
+
+    const actions = productsSync.buildActions(now, before)
+
+    expect(actions).toEqual(
+      expect.arrayContaining([
+        { action: 'setProductAttribute', name: 'testAttr', value: undefined },
+      ])
+    )
+  })
+
+  test('should build setProductAttribute action', () => {
+    const before = {
+      id: '123',
+      attributes: [
+        { name: 'firstAttr', value: 'firstValue' },
+        { name: 'secondAttr', value: 'secondValue' },
+      ],
+    }
+
+    const now = {
+      id: '123',
+      attributes: [
+        { name: 'firstAttr', value: 'updatedValue' },
+        { name: 'secondAttr', value: 'secondValue' },
+      ],
+    }
+
+    const actions = productsSync.buildActions(now, before)
+
+    expect(actions).toEqual(
+      expect.arrayContaining([
+        {
+          action: 'setProductAttribute',
+          name: 'firstAttr',
+          value: 'updatedValue',
+        },
+      ])
+    )
+  })
+
+  test('should update product attribute value when attribute content changes', () => {
+    const before = {
+      id: '123',
+      attributes: [{ name: 'indexTestAttr', value: 'originalValue' }],
+    }
+
+    const now = {
+      id: '123',
+      attributes: [{ name: 'indexTestAttr', value: 'modifiedValue' }],
+    }
+
+    const actions = productsSync.buildActions(now, before)
+
+    expect(actions).toEqual([
+      {
+        action: 'setProductAttribute',
+        name: 'indexTestAttr',
+        value: 'modifiedValue',
+      },
+    ])
+  })
+
+  test('should update array attribute when items are removed', () => {
+    const before = {
+      id: '123',
+      attributes: [{ name: 'testAttr', value: ['item1', 'item2'] }],
+    }
+
+    const now = {
+      id: '123',
+      attributes: [{ name: 'testAttr', value: ['item1'] }],
+    }
+
+    const actions = productsSync.buildActions(now, before)
+
+    expect(actions).toEqual(
+      expect.arrayContaining([
+        { action: 'setProductAttribute', name: 'testAttr', value: ['item1'] },
+      ])
+    )
+  })
+
+  test('should remove complex attribute with name fallback when attribute is deleted', () => {
+    const before = {
+      id: '123',
+      attributes: [
+        {
+          name: 'complexAttr',
+          value: [{ name: 'fallbackName', someProperty: 'value' }],
+        },
+      ],
+    }
+
+    const now = {
+      id: '123',
+      attributes: [],
+    }
+
+    const actions = productsSync.buildActions(now, before)
+
+    expect(actions).toEqual(
+      expect.arrayContaining([
+        {
+          action: 'setProductAttribute',
+          name: 'complexAttr',
+          value: undefined,
+        },
+      ])
+    )
+  })
+
+  test('should remove simple attribute when no name fallback is available', () => {
+    const before = {
+      id: '123',
+      attributes: [{ name: 'simpleAttr', value: [{ someProperty: 'value' }] }],
+    }
+
+    const now = {
+      id: '123',
+      attributes: [],
+    }
+
+    const actions = productsSync.buildActions(now, before)
+
+    expect(actions).toEqual(
+      expect.arrayContaining([
+        { action: 'setProductAttribute', name: 'simpleAttr', value: undefined },
+      ])
+    )
+  })
+
+  test('should generate setAttribute action for reordered array values', () => {
+    const before = {
+      id: '123',
+      attributes: [{ name: 'listAttr', value: ['a', 'b', 'c'] }],
+    }
+
+    const now = {
+      id: '123',
+      attributes: [{ name: 'listAttr', value: ['a', 'c', 'b'] }],
+    }
+
+    const actions = productsSync.buildActions(now, before)
+
+    expect(actions).toEqual(
+      expect.arrayContaining([
+        {
+          action: 'setProductAttribute',
+          name: 'listAttr',
+          value: ['a', 'c', 'b'],
+        },
+      ])
+    )
+  })
+
+  test('should update simple attribute value when changed', () => {
+    const before = {
+      id: '123',
+      attributes: [{ name: 'indexedAttr', value: 'oldValue' }],
+    }
+
+    const now = {
+      id: '123',
+      attributes: [{ name: 'indexedAttr', value: 'newValue' }],
+    }
+
+    const actions = productsSync.buildActions(now, before)
+
+    expect(actions).toEqual([
+      { action: 'setProductAttribute', name: 'indexedAttr', value: 'newValue' },
+    ])
+  })
 })

--- a/packages/sync-actions/test/product-sync-base.spec.js
+++ b/packages/sync-actions/test/product-sync-base.spec.js
@@ -31,7 +31,6 @@ describe('Exports', () => {
       { action: 'setSearchKeywords', key: 'searchKeywords' },
       { action: 'setKey', key: 'key' },
       { action: 'setPriceMode', key: 'priceMode' },
-      { action: 'setProductAttribute', key: 'attributes' },
     ])
   })
 

--- a/packages/sync-actions/test/product-sync-base.spec.js
+++ b/packages/sync-actions/test/product-sync-base.spec.js
@@ -15,7 +15,7 @@ describe('Exports', () => {
       'prices',
       'pricesCustom',
       'productAttributes',
-      'variantAttributes',
+      'attributes',
       'images',
       'variants',
       'categories',

--- a/packages/sync-actions/test/product-sync-base.spec.js
+++ b/packages/sync-actions/test/product-sync-base.spec.js
@@ -30,6 +30,7 @@ describe('Exports', () => {
       { action: 'setSearchKeywords', key: 'searchKeywords' },
       { action: 'setKey', key: 'key' },
       { action: 'setPriceMode', key: 'priceMode' },
+      { action: 'setProductAttribute', key: 'attributes' },
     ])
   })
 

--- a/packages/sync-actions/test/product-sync-base.spec.js
+++ b/packages/sync-actions/test/product-sync-base.spec.js
@@ -14,6 +14,7 @@ describe('Exports', () => {
       'references',
       'prices',
       'pricesCustom',
+      'productAttributes',
       'variantAttributes',
       'images',
       'variants',

--- a/packages/sync-actions/test/product-sync-base.spec.js
+++ b/packages/sync-actions/test/product-sync-base.spec.js
@@ -504,4 +504,149 @@ describe('Actions', () => {
       },
     ])
   })
+
+  test('should build product attribute actions', () => {
+    const before = {
+      id: '123',
+      attributes: [
+        { name: 'uid', value: '20063672' },
+        { name: 'length', value: 160 },
+        { name: 'wide', value: 85 },
+        { name: 'bulkygoods', value: { label: 'Ja', key: 'YES' } },
+        { name: 'ean', value: '20063672' },
+        { name: 'foo', value: 'bar' }, // removed
+      ],
+    }
+
+    const now = {
+      id: '123',
+      attributes: [
+        { name: 'uid', value: '20063675' }, // changed
+        { name: 'length', value: 160 },
+        { name: 'wide', value: 10 }, // changed
+        { name: 'bulkygoods', value: 'NO' }, // changed
+        { name: 'ean', value: '20063672' },
+        { name: 'baz', value: 'bar' }, // added
+      ],
+    }
+
+    const actions = productsSync.buildActions(now, before)
+
+    expect(actions).toEqual([
+      { action: 'setProductAttribute', name: 'uid', value: '20063675' },
+      { action: 'setProductAttribute', name: 'wide', value: 10 },
+      { action: 'setProductAttribute', name: 'bulkygoods', value: 'NO' },
+      { action: 'setProductAttribute', name: 'baz', value: 'bar' },
+      { action: 'setProductAttribute', name: 'foo', value: undefined },
+    ])
+  })
+
+  test('should build product attribute actions for all types', () => {
+    const before = {
+      id: '123',
+      attributes: [
+        { name: 'foo', value: 'bar' }, // text
+        { name: 'dog', value: { en: 'Dog', de: 'Hund', es: 'perro' } }, // ltext
+        { name: 'num', value: 50 }, // number
+        { name: 'count', value: { label: 'One', key: 'one' } }, // enum
+        { name: 'size', value: { label: { en: 'Medium' }, key: 'medium' } }, // lenum
+        { name: 'color', value: { label: { en: 'Color' }, key: 'red' } }, // lenum
+        { name: 'cost', value: { centAmount: 990, currencyCode: 'EUR' } }, // money
+        { name: 'reference', value: { typeId: 'product', id: '111' } }, // reference
+        { name: 'welcome', value: ['hello', 'world'] }, // set text
+        {
+          name: 'welcome2',
+          value: [
+            { en: 'hello', it: 'ciao' },
+            { en: 'world', it: 'mondo' },
+          ],
+        }, // set ltext
+        { name: 'multicolor', value: ['red'] }, // set enum
+        {
+          name: 'multicolor2',
+          value: [{ key: 'red', label: { en: 'red', it: 'rosso' } }],
+        }, // set lenum
+      ],
+    }
+
+    const now = {
+      id: '123',
+      attributes: [
+        { name: 'foo', value: 'qux' }, // text
+        { name: 'dog', value: { en: 'Doggy', it: 'Cane', es: 'perro' } }, // ltext
+        { name: 'num', value: 100 }, // number
+        { name: 'count', value: { label: 'Two', key: 'two' } }, // enum
+        { name: 'size', value: { label: { en: 'Small' }, key: 'small' } }, // lenum
+        { name: 'color', value: { label: { en: 'Blue' }, key: 'blue' } }, // lenum
+        { name: 'cost', value: { centAmount: 550, currencyCode: 'EUR' } }, // money
+        { name: 'reference', value: { typeId: 'category', id: '222' } }, // reference
+        { name: 'welcome', value: ['hello'] }, // set text
+        { name: 'welcome2', value: [{ en: 'hello', it: 'ciao' }] }, // set ltext
+        { name: 'multicolor', value: ['red', 'yellow'] }, // set enum
+        {
+          name: 'multicolor2',
+          value: [
+            { key: 'red', label: { en: 'red', it: 'rosso' } },
+            { key: 'yellow', label: { en: 'yellow', it: 'giallo' } },
+          ],
+        }, // set lenum
+        {
+          name: 'listWithEmptyValues',
+          value: ['', '', null, { id: '123', typeId: 'products' }],
+        }, // set reference
+      ],
+    }
+
+    const actions = productsSync.buildActions(now, before)
+    expect(actions).toEqual([
+      { action: 'setProductAttribute', name: 'foo', value: 'qux' },
+      {
+        action: 'setProductAttribute',
+        name: 'dog',
+        value: { en: 'Doggy', it: 'Cane', de: undefined, es: 'perro' },
+      },
+      { action: 'setProductAttribute', name: 'num', value: 100 },
+      { action: 'setProductAttribute', name: 'count', value: 'two' },
+      { action: 'setProductAttribute', name: 'size', value: 'small' },
+      { action: 'setProductAttribute', name: 'color', value: 'blue' },
+      {
+        action: 'setProductAttribute',
+        name: 'cost',
+        value: { centAmount: 550, currencyCode: 'EUR' },
+      },
+      {
+        action: 'setProductAttribute',
+        name: 'reference',
+        value: { typeId: 'category', id: '222' },
+      },
+      {
+        action: 'setProductAttribute',
+        name: 'welcome',
+        value: ['hello'],
+      },
+      {
+        action: 'setProductAttribute',
+        name: 'welcome2',
+        value: [{ en: 'hello', it: 'ciao' }],
+      },
+      {
+        action: 'setProductAttribute',
+        name: 'multicolor',
+        value: ['red', 'yellow'],
+      },
+      {
+        action: 'setProductAttribute',
+        name: 'multicolor2',
+        value: [
+          { key: 'red', label: { en: 'red', it: 'rosso' } },
+          { key: 'yellow', label: { en: 'yellow', it: 'giallo' } },
+        ],
+      }, // set lenum
+      {
+        action: 'setProductAttribute',
+        name: 'listWithEmptyValues',
+        value: ['', '', null, { id: '123', typeId: 'products' }],
+      }, // set reference
+    ])
+  })
 })

--- a/packages/sync-actions/test/product-sync-base.spec.js
+++ b/packages/sync-actions/test/product-sync-base.spec.js
@@ -14,7 +14,7 @@ describe('Exports', () => {
       'references',
       'prices',
       'pricesCustom',
-      'attributes',
+      'variantAttributes',
       'images',
       'variants',
       'categories',

--- a/packages/sync-actions/test/product-sync-variants.spec.js
+++ b/packages/sync-actions/test/product-sync-variants.spec.js
@@ -1816,4 +1816,98 @@ describe('Actions', () => {
       })
     })
   })
+
+  describe('attribute edge cases', () => {
+    test('should handle Money attribute with only centAmount change', () => {
+      const before = {
+        id: '123',
+        masterVariant: {
+          id: 1,
+          attributes: [
+            { name: 'price', value: { centAmount: 100, currencyCode: 'USD' } },
+          ],
+        },
+      }
+
+      const now = {
+        id: '123',
+        masterVariant: {
+          id: 1,
+          attributes: [
+            { name: 'price', value: { centAmount: 200, currencyCode: 'USD' } },
+          ],
+        },
+      }
+
+      const actions = productsSync.buildActions(now, before)
+      expect(actions).toEqual([
+        {
+          action: 'setAttribute',
+          variantId: 1,
+          name: 'price',
+          value: { centAmount: 200, currencyCode: 'USD' },
+        },
+      ])
+    })
+
+    test('should handle Money attribute with only currencyCode change', () => {
+      const before = {
+        id: '123',
+        masterVariant: {
+          id: 1,
+          attributes: [
+            { name: 'price', value: { centAmount: 100, currencyCode: 'USD' } },
+          ],
+        },
+      }
+
+      const now = {
+        id: '123',
+        masterVariant: {
+          id: 1,
+          attributes: [
+            { name: 'price', value: { centAmount: 100, currencyCode: 'EUR' } },
+          ],
+        },
+      }
+
+      const actions = productsSync.buildActions(now, before)
+      expect(actions).toEqual([
+        {
+          action: 'setAttribute',
+          variantId: 1,
+          name: 'price',
+          value: { centAmount: 100, currencyCode: 'EUR' },
+        },
+      ])
+    })
+
+    test('should handle simple string attribute change', () => {
+      const before = {
+        id: '123',
+        masterVariant: {
+          id: 1,
+          attributes: [{ name: 'description', value: 'old description' }],
+        },
+      }
+
+      const now = {
+        id: '123',
+        masterVariant: {
+          id: 1,
+          attributes: [{ name: 'description', value: 'new description' }],
+        },
+      }
+
+      const actions = productsSync.buildActions(now, before)
+      expect(actions).toEqual([
+        {
+          action: 'setAttribute',
+          variantId: 1,
+          name: 'description',
+          value: 'new description',
+        },
+      ])
+    })
+  })
 })


### PR DESCRIPTION
https://commercetools.atlassian.net/browse/PDM-236

Add Support for importing products, product drafts with product level attributes

- [X] Add Action Generation for Product Level Attributes on Products
   - [X] Refactor while keeping tests green
   - [X] Add logic for product level attribute actions
   - [X] Add tests for product level attribute actions and get them green
- [x] Add Action Generation for Product Level Attributes on Product-Types
   - [X] The only action affected is addAttributeDefinition which takes a definition. By adding the `level` to the raml (other repo) it will automatically work to import product types with product level attributes
   
   
I suggest t review commit by commit to get a more meaningful diff
 