### PR TITLE
Add sync actions for recurring orders 

### DIFF
--- a/.changeset/bumpy-clouds-poke.md
+++ b/.changeset/bumpy-clouds-poke.md
@@ -1,0 +1,10 @@
+---
+'@commercetools/sync-actions': patch
+---
+
+Added the following recurring orders sync actions
+
+- setOrderSkipConfiguration
+- setStartsAt
+- setExpiresAt
+- setSchedule

--- a/packages/sync-actions/src/recurring-orders-actions.js
+++ b/packages/sync-actions/src/recurring-orders-actions.js
@@ -1,9 +1,19 @@
-import { buildBaseAttributesActions } from './utils/common-actions'
+import {
+  buildBaseAttributesActions,
+  buildReferenceActions,
+} from './utils/common-actions'
 
 export const baseActionsList = [
   { action: 'setKey', key: 'key' },
   { action: 'setRecurringOrderState', key: 'recurringOrderState' },
   { action: 'transitionState', key: 'state' },
+  { action: 'setOrderSkipConfiguration', key: 'skipConfiguration' },
+  { action: 'setStartsAt', key: 'startsAt' },
+  { action: 'setExpiresAt', key: 'expiresAt' },
+]
+
+export const referenceActionsList = [
+  { action: 'setSchedule', key: 'recurrencePolicy' },
 ]
 
 export function actionsMapBase(diff, oldObj, newObj, config = {}) {
@@ -16,5 +26,14 @@ export function actionsMapBase(diff, oldObj, newObj, config = {}) {
     shouldUnsetOmittedProperties: config.shouldUnsetOmittedProperties,
     shouldPreventUnsettingRequiredFields:
       config.shouldPreventUnsettingRequiredFields,
+  })
+}
+
+export function actionsMapReferences(diff, oldObj, newObj) {
+  return buildReferenceActions({
+    actions: referenceActionsList,
+    diff,
+    oldObj,
+    newObj,
   })
 }

--- a/packages/sync-actions/src/recurring-orders.js
+++ b/packages/sync-actions/src/recurring-orders.js
@@ -12,7 +12,7 @@ import actionsMapCustom from './utils/action-map-custom'
 import * as RecurringOrdersActions from './recurring-orders-actions'
 import * as diffpatcher from './utils/diffpatcher'
 
-const actionGroups = ['base', 'custom']
+const actionGroups = ['base', 'references', 'custom']
 
 function createRecurringOrdersMapActions(
   mapActionGroup: Function,
@@ -38,6 +38,12 @@ function createRecurringOrdersMapActions(
           newObj,
           syncActionConfig
         )
+      )
+    )
+
+    allActions.push(
+      mapActionGroup('references', (): Array<UpdateAction> =>
+        RecurringOrdersActions.actionsMapReferences(diff, oldObj, newObj)
       )
     )
 

--- a/packages/sync-actions/test/recurring-orders-sync.spec.js
+++ b/packages/sync-actions/test/recurring-orders-sync.spec.js
@@ -1,14 +1,17 @@
 import createRecurringOrdersSync, {
   actionGroups,
 } from '../src/recurring-orders'
-import { baseActionsList } from '../src/recurring-orders-actions'
+import {
+  baseActionsList,
+  referenceActionsList,
+} from '../src/recurring-orders-actions'
 
 describe('Exports', () => {
   test('action group list', () => {
-    expect(actionGroups).toEqual(['base', 'custom'])
+    expect(actionGroups).toEqual(['base', 'references', 'custom'])
   })
 
-  describe('action list', () => {
+  describe('base action list', () => {
     test('should contain `setRecurringOrderState` action', () => {
       expect(baseActionsList).toEqual(
         expect.arrayContaining([
@@ -28,11 +31,42 @@ describe('Exports', () => {
         expect.arrayContaining([{ action: 'transitionState', key: 'state' }])
       )
     })
+
+    test('should contain `setOrderSkipConfiguration` action', () => {
+      expect(baseActionsList).toEqual(
+        expect.arrayContaining([
+          { action: 'setOrderSkipConfiguration', key: 'skipConfiguration' },
+        ])
+      )
+    })
+
+    test('should contain `setStartsAt` action', () => {
+      expect(baseActionsList).toEqual(
+        expect.arrayContaining([{ action: 'setStartsAt', key: 'startsAt' }])
+      )
+    })
+
+    test('should contain `setExpiresAt` action', () => {
+      expect(baseActionsList).toEqual(
+        expect.arrayContaining([{ action: 'setExpiresAt', key: 'expiresAt' }])
+      )
+    })
+  })
+
+  describe('reference action list', () => {
+    test('should contain `recurrencePolicy` action', () => {
+      expect(referenceActionsList).toEqual(
+        expect.arrayContaining([
+          { action: 'setSchedule', key: 'recurrencePolicy' },
+        ])
+      )
+    })
   })
 })
 
 describe('Actions', () => {
   let recurringOrdersSync
+
   beforeEach(() => {
     recurringOrdersSync = createRecurringOrdersSync()
   })
@@ -80,6 +114,50 @@ describe('Actions', () => {
     const expected = [
       {
         action: 'transitionState',
+        ...now,
+      },
+    ]
+    expect(actual).toEqual(expected)
+  })
+
+  test('should build `setOrderSkipConfiguration` action', () => {
+    const before = {
+      skipConfiguration: { type: 'counter', totalToSkip: 2, skipped: 1 },
+    }
+    const now = {
+      skipConfiguration: { type: 'counter', totalToSkip: 5 },
+    }
+
+    const expected = [
+      {
+        action: 'setOrderSkipConfiguration',
+        ...now,
+      },
+    ]
+    const actual = recurringOrdersSync.buildActions(now, before)
+    expect(actual).toEqual(expected)
+  })
+
+  test('should build `setStartsAt` action', () => {
+    const before = { startsAt: '2025-10-01T00:00:00.000Z' }
+    const now = { startsAt: '2026-01-10T00:00:00.000Z' }
+    const actual = recurringOrdersSync.buildActions(now, before)
+    const expected = [
+      {
+        action: 'setStartsAt',
+        ...now,
+      },
+    ]
+    expect(actual).toEqual(expected)
+  })
+
+  test('should build `setExpiresAt` action', () => {
+    const before = { expiresAt: '2025-10-01T00:00:00.000Z' }
+    const now = { expiresAt: '2026-01-10T00:00:00.000Z' }
+    const actual = recurringOrdersSync.buildActions(now, before)
+    const expected = [
+      {
+        action: 'setExpiresAt',
         ...now,
       },
     ]
@@ -143,6 +221,30 @@ describe('Actions', () => {
         action: 'setCustomField',
         name: 'customField1',
         value: true,
+      },
+    ]
+    expect(actual).toEqual(expected)
+  })
+
+  test('should build `setSchedule` action', () => {
+    const before = {
+      recurrencePolicy: {
+        typeId: 'recurrence-policy',
+        id: '999-9999-9999',
+      },
+    }
+    const now = {
+      recurrencePolicy: {
+        typeId: 'recurrence-policy',
+        id: '1212-1212-1212',
+      },
+    }
+
+    const actual = recurringOrdersSync.buildActions(now, before)
+    const expected = [
+      {
+        action: 'setSchedule',
+        ...now,
       },
     ]
     expect(actual).toEqual(expected)


### PR DESCRIPTION
#### Summary

This PR adds sync actions for recurring orders 

#### Description

The following sync actions are added for Recurring Orders
- setOrderSkipConfiguration
- setStartsAt
- setExpiresAt
- setSchedule

#### Todo

- Tests
  - [x] Unit
  - [ ] Integration
  - [ ] Acceptance
- [ ] Documentation
- [ ] `Type` label for the PR <!-- Used to automatically generate the changelog -->
  <!-- Two persons should review a PR, don't forget to assign them. -->
  <!-- Please remember to squash merge. -->
  <!-- All contribution guidelines can be found here: https://github.com/commercetools/nodejs/blob/master/CONTRIBUTING.md -->
